### PR TITLE
Support GitHub Release asset publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@
 - Root `npm test` runs `turbo run test`, and Turbo runs each package `build` before `test`.
 - If you need a clean rebuild, use `npm run build:release -- --force` or `npm test -- --force`.
 - Prefer changing shared config in `tooling/` rather than duplicating per-package config.
+- When working from a plan, after finishing any item, always state the next
+  concrete step. Continue doing this until the plan is genuinely complete so
+  the user does not need to ask "what's next?".
 
 ## Queue CLI Notes
 

--- a/apps/docs/docs/docs/adding-upm-package.md
+++ b/apps/docs/docs/docs/adding-upm-package.md
@@ -84,6 +84,10 @@ gitTagPrefix: ''
 gitTagIgnore: '-master$'
 # The minimal version to build. Leave it blank to build all versions.
 minVersion: '1.0.5'
+# Package source mode: git (default) or githubRelease.
+trackingMode: git
+# Optional exact GitHub Release asset filename or stable filename prefix when trackingMode is githubRelease.
+githubReleaseAssetName: 'com.example.package-'
 # The featured image URL. It should point to a valid image URL instead of a web page that presents the image.
 # Leave it blank to use the generated default image.
 image: 'https://github.com/author/reponame/raw/master/path-of-img.png'
@@ -118,6 +122,23 @@ The repository you submitted must have at least one versioned Git tag to trigger
 ### Handling Prefixed Git Tags
 
 Some repositories use different content for different tags, for example, `1.0.0` for the main branch and `upm/1.0.0` for the UPM branch. In such cases, you need to specify the `gitTagPrefix` field in the package YAML file. For instance, set `gitTagPrefix: "upm/"` to prevent confusion in the build pipelines due to duplicated version tags. Without specifying a prefix, the build pipelines will treat `1.0.0` and `upm/1.0.0` as the same version tag and only build one of them. By default, a tag name with the prefix `upm/` takes higher priority. For example, `1.0.0` and `upm/1.1.0` will result in building only `upm/1.1.0`.
+
+### Publishing from a GitHub Release Asset
+
+By default, OpenUPM clones the repository at each discovered Git tag and runs
+`npm pack`. If your package needs to publish a tarball that you build yourself,
+set `trackingMode: githubRelease`. OpenUPM will still discover versions from
+Git tags, then find the GitHub Release whose tag name exactly matches the
+discovered Git tag and publish the attached `.tgz` or `.tar.gz` asset unchanged.
+
+Set `githubReleaseAssetName` when the release has multiple assets or when you
+want to require a specific filename pattern. OpenUPM first looks for an exact
+asset filename match, then falls back to the only publishable asset whose name
+starts with that value. Use a stable prefix such as `com.example.package-`
+instead of a versioned filename so the package metadata does not need to change
+for every release. GitHub Release asset names are filenames only, so do not
+include a directory path such as `dist/`. If it is omitted, the release must
+contain exactly one publishable `.tgz` or `.tar.gz` asset.
 
 ### Handling Monorepo
 

--- a/apps/queue/__tests__/utils/githubReleaseAsset.spec.ts
+++ b/apps/queue/__tests__/utils/githubReleaseAsset.spec.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ReleaseErrorCode } from '@openupm/types';
+import {
+  GitHubReleaseAssetError,
+  parseGitHubRepoUrl,
+  resolveGitHubReleaseAsset,
+  selectGitHubReleaseAsset,
+} from '../../src/utils/githubReleaseAsset.js';
+
+describe('githubReleaseAsset utils', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parses GitHub repo URLs', () => {
+    expect(parseGitHubRepoUrl('https://github.com/openupm/openupm.git')).toEqual({
+      owner: 'openupm',
+      repo: 'openupm',
+    });
+    expect(parseGitHubRepoUrl('git@github.com:openupm/openupm.git')).toEqual({
+      owner: 'openupm',
+      repo: 'openupm',
+    });
+    expect(parseGitHubRepoUrl('https://example.com/openupm/openupm')).toBeNull();
+  });
+
+  it('selects configured publishable asset by exact name', () => {
+    const asset = selectGitHubReleaseAsset(
+      [
+        { name: 'package.tgz', browser_download_url: 'https://example.com/a' },
+        {
+          name: 'package.tar.gz',
+          browser_download_url: 'https://example.com/b',
+        },
+      ],
+      'package.tar.gz',
+    );
+
+    expect(asset.browser_download_url).toEqual('https://example.com/b');
+  });
+
+  it('selects configured asset by stable prefix when exact name is absent', () => {
+    const asset = selectGitHubReleaseAsset(
+      [
+        {
+          name: 'com.example.package-1.0.0.tgz',
+          browser_download_url: 'https://example.com/a',
+        },
+        {
+          name: 'com.example.other-1.0.0.tgz',
+          browser_download_url: 'https://example.com/b',
+        },
+      ],
+      'com.example.package-',
+    );
+
+    expect(asset.name).toEqual('com.example.package-1.0.0.tgz');
+  });
+
+  it('prefers exact configured asset name over prefix matches', () => {
+    const asset = selectGitHubReleaseAsset(
+      [
+        {
+          name: 'com.example.package.tgz',
+          browser_download_url: 'https://example.com/a',
+        },
+        {
+          name: 'com.example.package-extra.tgz',
+          browser_download_url: 'https://example.com/b',
+        },
+      ],
+      'com.example.package.tgz',
+    );
+
+    expect(asset.browser_download_url).toEqual('https://example.com/a');
+  });
+
+  it('rejects ambiguous configured asset prefixes', () => {
+    expect(() =>
+      selectGitHubReleaseAsset(
+        [
+          {
+            name: 'com.example.package-1.0.0.tgz',
+            browser_download_url: 'https://example.com/a',
+          },
+          {
+            name: 'com.example.package-1.0.0-symbols.tgz',
+            browser_download_url: 'https://example.com/b',
+          },
+        ],
+        'com.example.package-',
+      ),
+    ).toThrowError(GitHubReleaseAssetError);
+  });
+
+  it('selects the only publishable asset when name is omitted', () => {
+    const asset = selectGitHubReleaseAsset([
+      { name: 'notes.txt', browser_download_url: 'https://example.com/a' },
+      { name: 'package.tar.gz', browser_download_url: 'https://example.com/b' },
+    ]);
+
+    expect(asset.name).toEqual('package.tar.gz');
+  });
+
+  it('ignores GitHub generated source archive links when selecting release assets', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            tag_name: 'v1.0.0',
+            zipball_url: 'https://api.github.com/repos/openupm/openupm/zipball/v1.0.0',
+            tarball_url: 'https://api.github.com/repos/openupm/openupm/tarball/v1.0.0',
+            assets: [
+              {
+                name: 'package.tgz',
+                browser_download_url: 'https://example.com/package.tgz',
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await expect(
+      resolveGitHubReleaseAsset({
+        config: {},
+        repoUrl: 'https://github.com/openupm/openupm',
+        releaseTag: 'v1.0.0',
+      }),
+    ).resolves.toEqual({
+      packageAssetName: 'package.tgz',
+      packageAssetUrl: 'https://example.com/package.tgz',
+    });
+  });
+
+  it('rejects ambiguous publishable assets', () => {
+    expect(() =>
+      selectGitHubReleaseAsset([
+        { name: 'one.tgz', browser_download_url: 'https://example.com/a' },
+        { name: 'two.tar.gz', browser_download_url: 'https://example.com/b' },
+      ]),
+    ).toThrowError(GitHubReleaseAssetError);
+  });
+
+  it('resolves release asset with GitHub token headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          tag_name: 'v1.0.0',
+          assets: [
+            {
+              name: 'package.tgz',
+              browser_download_url: 'https://example.com/package.tgz',
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resolved = await resolveGitHubReleaseAsset({
+      config: { github: { tokens: ['token-a'] } },
+      repoUrl: 'https://github.com/openupm/openupm',
+      releaseTag: 'v1.0.0',
+    });
+
+    expect(resolved).toEqual({
+      packageAssetName: 'package.tgz',
+      packageAssetUrl: 'https://example.com/package.tgz',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/openupm/openupm/releases/tags/v1.0.0',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer token-a' }),
+      }),
+    );
+  });
+
+  it('maps missing release to retryable reason', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{}', { status: 404 })),
+    );
+
+    await expect(
+      resolveGitHubReleaseAsset({
+        config: {},
+        repoUrl: 'https://github.com/openupm/openupm',
+        releaseTag: 'v1.0.0',
+      }),
+    ).rejects.toMatchObject({
+      reason: ReleaseErrorCode.GitHubReleaseNotFound,
+    });
+  });
+
+  it('maps invalid GitHub API JSON to retryable API error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('not-json', { status: 200 })),
+    );
+
+    await expect(
+      resolveGitHubReleaseAsset({
+        config: {},
+        repoUrl: 'https://github.com/openupm/openupm',
+        releaseTag: 'v1.0.0',
+      }),
+    ).rejects.toMatchObject({
+      reason: ReleaseErrorCode.GitHubReleaseApiError,
+    });
+  });
+});

--- a/apps/queue/__tests__/utils/githubReleaseAsset.spec.ts
+++ b/apps/queue/__tests__/utils/githubReleaseAsset.spec.ts
@@ -23,6 +23,10 @@ describe('githubReleaseAsset utils', () => {
       repo: 'openupm',
     });
     expect(parseGitHubRepoUrl('https://example.com/openupm/openupm')).toBeNull();
+    expect(parseGitHubRepoUrl('https://notgithub.com/openupm/openupm')).toBeNull();
+    expect(parseGitHubRepoUrl('https://github.com/')).toBeNull();
+    expect(parseGitHubRepoUrl('git@github.com:')).toBeNull();
+    expect(parseGitHubRepoUrl('git@github.com:openupm/openupm/path')).toBeNull();
   });
 
   it('selects configured publishable asset by exact name', () => {

--- a/apps/queue/__tests__/workers/buildRelease.spec.ts
+++ b/apps/queue/__tests__/workers/buildRelease.spec.ts
@@ -78,4 +78,49 @@ npm error command failed
       ReleaseErrorCode.InvalidVersion,
     );
   });
+
+  it('GitHub Release asset download errors are retryable', () => {
+    expect(
+      getReasonFromBuildLogText('GITHUB_RELEASE_ASSET_DOWNLOAD_NOT_FOUND'),
+    ).toEqual(ReleaseErrorCode.GitHubReleaseAssetNotFound);
+    expect(
+      getReasonFromBuildLogText('GITHUB_RELEASE_ASSET_DOWNLOAD_FAILED'),
+    ).toEqual(ReleaseErrorCode.GitHubReleaseAssetDownloadFailed);
+    expect(
+      RetryableReleaseErrorCodes.includes(
+        ReleaseErrorCode.GitHubReleaseAssetNotFound,
+      ),
+    ).toBe(true);
+    expect(
+      RetryableReleaseErrorCodes.includes(
+        ReleaseErrorCode.GitHubReleaseAssetDownloadFailed,
+      ),
+    ).toBe(true);
+  });
+
+  it('GitHub Release asset validation errors are non-retryable', () => {
+    expect(
+      getReasonFromBuildLogText('Unsupported package asset extension'),
+    ).toEqual(ReleaseErrorCode.PackageJsonParsingError);
+    expect(
+      getReasonFromBuildLogText(
+        'Downloaded package asset has no package/package.json',
+      ),
+    ).toEqual(ReleaseErrorCode.PackageNotFound);
+    expect(
+      getReasonFromBuildLogText(
+        'Downloaded package asset name mismatch: actual=package-a, expected=package-b',
+      ),
+    ).toEqual(ReleaseErrorCode.PackageNameInvalid);
+    expect(
+      getReasonFromBuildLogText(
+        'Downloaded package asset version mismatch: actual=1.0.0, expected=2.0.0',
+      ),
+    ).toEqual(ReleaseErrorCode.InvalidVersion);
+    expect(
+      RetryableReleaseErrorCodes.includes(
+        ReleaseErrorCode.PackageJsonParsingError,
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/queue/src/utils/githubReleaseAsset.ts
+++ b/apps/queue/src/utils/githubReleaseAsset.ts
@@ -1,0 +1,176 @@
+import { ReleaseErrorCode } from '@openupm/types';
+import { withGitHubAuthorizationHeader } from '@openupm/server-common/build/utils/githubToken.js';
+
+export type GitHubReleaseAsset = {
+  name: string;
+  browser_download_url: string;
+};
+
+type GitHubReleaseResponse = {
+  tag_name?: string;
+  assets?: GitHubReleaseAsset[];
+};
+
+export type ResolvedGitHubReleaseAsset = {
+  packageAssetName: string;
+  packageAssetUrl: string;
+};
+
+export class GitHubReleaseAssetError extends Error {
+  constructor(
+    message: string,
+    public readonly reason: ReleaseErrorCode,
+  ) {
+    super(message);
+    this.name = 'GitHubReleaseAssetError';
+  }
+}
+
+export function parseGitHubRepoUrl(
+  repoUrl: string,
+): { owner: string; repo: string } | null {
+  if (repoUrl.startsWith('git@github.com:')) {
+    const match = /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/i.exec(repoUrl);
+    if (!match) return null;
+    return { owner: match[1], repo: match[2] };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(repoUrl);
+  } catch {
+    return null;
+  }
+  if (!/github\.com$/i.test(parsed.host)) return null;
+  const [owner, repoWithSuffix] = parsed.pathname.split('/').filter(Boolean);
+  if (!owner || !repoWithSuffix) return null;
+  return { owner, repo: repoWithSuffix.replace(/\.git$/i, '') };
+}
+
+export function isPublishableReleaseAsset(name: string): boolean {
+  return name.endsWith('.tgz') || name.endsWith('.tar.gz');
+}
+
+export function selectGitHubReleaseAsset(
+  assets: GitHubReleaseAsset[],
+  githubReleaseAssetName?: string,
+): GitHubReleaseAsset {
+  const publishableAssets = assets.filter((asset) =>
+    isPublishableReleaseAsset(asset.name),
+  );
+  if (githubReleaseAssetName) {
+    const exactMatch = publishableAssets.find(
+      (asset) => asset.name === githubReleaseAssetName,
+    );
+    if (exactMatch) return exactMatch;
+
+    const prefixMatches = publishableAssets.filter((asset) =>
+      asset.name.startsWith(githubReleaseAssetName),
+    );
+    if (prefixMatches.length === 0) {
+      throw new GitHubReleaseAssetError(
+        `GitHub Release asset not found: ${githubReleaseAssetName}`,
+        ReleaseErrorCode.GitHubReleaseAssetNotFound,
+      );
+    }
+    if (prefixMatches.length > 1) {
+      throw new GitHubReleaseAssetError(
+        'GitHub Release has multiple assets matching githubReleaseAssetName; set a more specific prefix or exact filename',
+        ReleaseErrorCode.GitHubReleaseAssetAmbiguous,
+      );
+    }
+    return prefixMatches[0];
+  }
+
+  if (publishableAssets.length === 0) {
+    throw new GitHubReleaseAssetError(
+      'GitHub Release has no publishable .tgz or .tar.gz asset',
+      ReleaseErrorCode.GitHubReleaseAssetNotFound,
+    );
+  }
+  if (publishableAssets.length > 1) {
+    throw new GitHubReleaseAssetError(
+      'GitHub Release has multiple publishable assets; set githubReleaseAssetName',
+      ReleaseErrorCode.GitHubReleaseAssetAmbiguous,
+    );
+  }
+  return publishableAssets[0];
+}
+
+export async function resolveGitHubReleaseAsset(options: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: any;
+  repoUrl: string;
+  releaseTag: string;
+  githubReleaseAssetName?: string;
+}): Promise<ResolvedGitHubReleaseAsset> {
+  const repo = parseGitHubRepoUrl(options.repoUrl);
+  if (!repo) {
+    throw new GitHubReleaseAssetError(
+      `GitHub Release tracking requires a GitHub repoUrl: ${options.repoUrl}`,
+      ReleaseErrorCode.RemoteRepositoryUnavailable,
+    );
+  }
+
+  const releaseUrl = `https://api.github.com/repos/${repo.owner}/${repo.repo}/releases/tags/${encodeURIComponent(
+    options.releaseTag,
+  )}`;
+  const headers = withGitHubAuthorizationHeader(options.config, {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(releaseUrl, { headers });
+  } catch (error) {
+    throw new GitHubReleaseAssetError(
+      `GitHub Release API request failed: ${error instanceof Error ? error.message : String(error)}`,
+      ReleaseErrorCode.GitHubReleaseApiError,
+    );
+  }
+
+  if (response.status === 404) {
+    throw new GitHubReleaseAssetError(
+      `GitHub Release not found for tag ${options.releaseTag}`,
+      ReleaseErrorCode.GitHubReleaseNotFound,
+    );
+  }
+  if (response.status === 403 || response.status === 429 || response.status >= 500) {
+    throw new GitHubReleaseAssetError(
+      `GitHub Release API failed with status ${response.status}`,
+      ReleaseErrorCode.GitHubReleaseApiError,
+    );
+  }
+  if (!response.ok) {
+    throw new GitHubReleaseAssetError(
+      `GitHub Release API failed with status ${response.status}`,
+      ReleaseErrorCode.GitHubReleaseAssetNotFound,
+    );
+  }
+
+  let release: GitHubReleaseResponse;
+  try {
+    release = (await response.json()) as GitHubReleaseResponse;
+  } catch (error) {
+    throw new GitHubReleaseAssetError(
+      `GitHub Release API response was not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      ReleaseErrorCode.GitHubReleaseApiError,
+    );
+  }
+  if (release.tag_name !== options.releaseTag) {
+    throw new GitHubReleaseAssetError(
+      `GitHub Release tag mismatch: actual=${release.tag_name || ''}, expected=${options.releaseTag}`,
+      ReleaseErrorCode.GitHubReleaseNotFound,
+    );
+  }
+
+  const asset = selectGitHubReleaseAsset(
+    release.assets || [],
+    options.githubReleaseAssetName,
+  );
+  return {
+    packageAssetName: asset.name,
+    packageAssetUrl: asset.browser_download_url,
+  };
+}

--- a/apps/queue/src/utils/githubReleaseAsset.ts
+++ b/apps/queue/src/utils/githubReleaseAsset.ts
@@ -30,7 +30,9 @@ export function parseGitHubRepoUrl(
   repoUrl: string,
 ): { owner: string; repo: string } | null {
   if (repoUrl.startsWith('git@github.com:')) {
-    const match = /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/i.exec(repoUrl);
+    const match = /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i.exec(
+      repoUrl,
+    );
     if (!match) return null;
     return { owner: match[1], repo: match[2] };
   }
@@ -41,8 +43,10 @@ export function parseGitHubRepoUrl(
   } catch {
     return null;
   }
-  if (!/github\.com$/i.test(parsed.host)) return null;
-  const [owner, repoWithSuffix] = parsed.pathname.split('/').filter(Boolean);
+  if (parsed.host.toLowerCase() !== 'github.com') return null;
+  const pathParts = parsed.pathname.split('/').filter(Boolean);
+  if (pathParts.length !== 2) return null;
+  const [owner, repoWithSuffix] = pathParts;
   if (!owner || !repoWithSuffix) return null;
   return { owner, repo: repoWithSuffix.replace(/\.git$/i, '') };
 }

--- a/apps/queue/src/workers/buildRelease.ts
+++ b/apps/queue/src/workers/buildRelease.ts
@@ -7,6 +7,7 @@ import {
   ReleaseModel,
   ReleaseState,
   RetryableReleaseErrorCodes,
+  type PackageMetadataLocal,
 } from '@openupm/types';
 import { loadPackageMetadataLocal } from '@openupm/local-data';
 import {
@@ -24,6 +25,10 @@ import {
   queueBuild,
   waitBuild,
 } from '../utils/azure.js';
+import {
+  GitHubReleaseAssetError,
+  resolveGitHubReleaseAsset,
+} from '../utils/githubReleaseAsset.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
@@ -43,13 +48,18 @@ export async function buildRelease(
 
   try {
     const buildApi = await getBuildApi();
-    release = await updateReleaseBuild(buildApi, pkg.repoUrl, release);
+    release = await updateReleaseBuild(buildApi, pkg, release);
     const build = await waitReleaseBuild(buildApi, release);
     await handleReleaseBuild(build, release);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ETIMEDOUT') {
       release.state = ReleaseState.Failed;
       release.reason = ReleaseErrorCode.ConnectionTimeout;
+      await save(release);
+      logReleaseError(release);
+    } else if (err instanceof GitHubReleaseAssetError) {
+      release.state = ReleaseState.Failed;
+      release.reason = err.reason;
       await save(release);
       logReleaseError(release);
     }
@@ -92,22 +102,54 @@ async function updateReleaseState(release: ReleaseModel): Promise<boolean> {
 async function updateReleaseBuild(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   buildApi: any,
-  repoUrl: string,
+  pkg: PackageMetadataLocal,
   release: ReleaseModel,
 ): Promise<ReleaseModel> {
   if (!release.buildId) {
     logger.info({ rel: `${release.packageName}@${release.version}` }, 'queue build');
+    if (!pkg) throw new Error(`package not found: ${release.packageName}`);
+    const parameters = await getQueueBuildParameters(pkg, release);
     const build = await queueBuild(buildApi, config.azureDevops.definitionId, {
-      repoUrl,
-      repoBranch: release.tag,
-      packageName: release.packageName,
-      packageVersion: release.version,
+      ...parameters,
     });
     release.buildId = `${build.id}`;
     release = await save(release);
     await sleep(config.azureDevops.check.duration);
   }
   return release;
+}
+
+export async function getQueueBuildParameters(
+  pkg: PackageMetadataLocal,
+  release: ReleaseModel,
+): Promise<Record<string, string>> {
+  const baseParameters = {
+    repoUrl: pkg.repoUrl,
+    repoBranch: release.tag,
+    packageName: release.packageName,
+    packageVersion: release.version,
+  };
+
+  if ((pkg.trackingMode || 'git') === 'git') {
+    return {
+      ...baseParameters,
+      packageSource: 'git',
+    };
+  }
+
+  const resolvedAsset = await resolveGitHubReleaseAsset({
+    config,
+    repoUrl: pkg.repoUrl,
+    releaseTag: release.tag,
+    githubReleaseAssetName: pkg.githubReleaseAssetName,
+  });
+
+  return {
+    ...baseParameters,
+    packageSource: 'githubRelease',
+    packageAssetUrl: resolvedAsset.packageAssetUrl,
+    packageAssetName: resolvedAsset.packageAssetName,
+  };
 }
 
 async function waitReleaseBuild(
@@ -201,7 +243,10 @@ export function getReasonFromBuildLogText(text: string): ReleaseErrorCode {
   if (/fatal: Remote branch .* not found/.test(text))
     return ReleaseErrorCode.RemoteBranchNotFound;
   else if (text.includes('code E409')) return ReleaseErrorCode.VersionConflict;
-  else if (text.includes('ENOENT') && text.includes('error path package.json'))
+  else if (
+    (text.includes('ENOENT') && text.includes('error path package.json')) ||
+    text.includes('Downloaded package asset has no package/package.json')
+  )
     return ReleaseErrorCode.PackageNotFound;
   else if (text.includes('code E400')) {
     if (/400 Bad Request - PUT https:\/\/.*\.com\/@/.test(text)) {
@@ -217,7 +262,12 @@ export function getReasonFromBuildLogText(text: string): ReleaseErrorCode {
     return ReleaseErrorCode.ServiceUnavailable;
   else if (text.includes('code E504')) return ReleaseErrorCode.GatewayTimeout;
   else if (text.includes('code EPRIVATE')) return ReleaseErrorCode.Private;
-  else if (text.includes('code EJSONPARSE'))
+  else if (
+    text.includes('code EJSONPARSE') ||
+    text.includes('Unsupported package asset extension') ||
+    text.includes('Downloaded package asset is not a valid tar archive') ||
+    text.includes('Downloaded package asset package.json is not valid JSON')
+  )
     return ReleaseErrorCode.PackageJsonParsingError;
   else if (
     text.includes('code ERR_STRING_TOO_LONG') ||
@@ -228,6 +278,14 @@ export function getReasonFromBuildLogText(text: string): ReleaseErrorCode {
     return ReleaseErrorCode.LfsBudgetExceeded;
   else if (text.includes('Object does not exist on the server'))
     return ReleaseErrorCode.LfsObjectNotFound;
+  else if (text.includes('GITHUB_RELEASE_ASSET_DOWNLOAD_NOT_FOUND'))
+    return ReleaseErrorCode.GitHubReleaseAssetNotFound;
+  else if (text.includes('GITHUB_RELEASE_ASSET_DOWNLOAD_FAILED'))
+    return ReleaseErrorCode.GitHubReleaseAssetDownloadFailed;
+  else if (text.includes('Downloaded package asset name mismatch'))
+    return ReleaseErrorCode.PackageNameInvalid;
+  else if (text.includes('Downloaded package asset version mismatch'))
+    return ReleaseErrorCode.InvalidVersion;
   else if (text.includes('Invalid version') || text.includes('code EBADSEMVER'))
     return ReleaseErrorCode.InvalidVersion;
   else if (text.includes('Could not read from remote repository'))

--- a/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
+++ b/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
@@ -17,6 +17,8 @@ type PackageFixture = {
   hunter: string;
   createdAt: number;
   image?: string | null;
+  trackingMode?: 'git' | 'githubRelease';
+  githubReleaseAssetName?: string;
 };
 
 const topLevelFiles = [
@@ -95,8 +97,37 @@ describe('validateDataDirectory', () => {
     }
   });
 
+  it('accepts GitHub Release tracking metadata with optional asset name', async () => {
+    const dataDir = await createDataDir();
+    try {
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        trackingMode: 'githubRelease',
+        githubReleaseAssetName: 'com.example.package-1.0.0.tgz',
+      });
+      const result = await validateDataDirectory(dataDir);
+      expect(result).toEqual({ valid: true, issues: [] });
+    } finally {
+      await afs.rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts GitHub Release tracking metadata without asset name', async () => {
+    const dataDir = await createDataDir();
+    try {
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        trackingMode: 'githubRelease',
+      });
+      const result = await validateDataDirectory(dataDir);
+      expect(result).toEqual({ valid: true, issues: [] });
+    } finally {
+      await afs.rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('covers required package field checks from openupm data tests', async () => {
-    expect.assertions(6);
+    expect.assertions(7);
     await expectIssue(
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {
@@ -134,6 +165,14 @@ describe('validateDataDirectory', () => {
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {
           ...validPackage,
+          trackingMode: 'release',
+        }),
+      'package-metadata-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
           hunter: ' ',
         }),
       'package-hunter-empty',
@@ -149,7 +188,7 @@ describe('validateDataDirectory', () => {
   });
 
   it('covers package semantic checks from openupm data tests', async () => {
-    expect.assertions(6);
+    expect.assertions(9);
     await expectIssue(
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {
@@ -194,6 +233,33 @@ describe('validateDataDirectory', () => {
           image: 'not-a-url',
         }),
       'package-image-url-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          trackingMode: 'githubRelease',
+          githubReleaseAssetName: ' ',
+        }),
+      'package-github-release-asset-name-empty',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          trackingMode: 'githubRelease',
+          repoUrl: 'https://example.com/example/package',
+        }),
+      'package-github-release-repo-url-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          trackingMode: 'githubRelease',
+          githubReleaseAssetName: 'dist/package.tgz',
+        }),
+      'package-github-release-asset-name-path-invalid',
     );
   });
 

--- a/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
+++ b/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
@@ -126,6 +126,28 @@ describe('validateDataDirectory', () => {
     }
   });
 
+  it('rejects malformed GitHub Release repo URLs', async () => {
+    expect.assertions(2);
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          trackingMode: 'githubRelease',
+          repoUrl: 'https://notgithub.com/example/package',
+        }),
+      'package-github-release-repo-url-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          trackingMode: 'githubRelease',
+          repoUrl: 'https://github.com/',
+        }),
+      'package-github-release-repo-url-invalid',
+    );
+  });
+
   it('covers required package field checks from openupm data tests', async () => {
     expect.assertions(7);
     await expectIssue(

--- a/packages/@openupm/local-data/src/utils/parse-pkg.ts
+++ b/packages/@openupm/local-data/src/utils/parse-pkg.ts
@@ -82,6 +82,7 @@ export const parsePackageMetadata = function (raw: any): PackageMetadataLocal {
   if (base.image === undefined) base.image = null;
   // Set imageFit
   if (base.imageFit === undefined) base.imageFit = 'cover';
+  if (base.trackingMode === undefined) base.trackingMode = 'git';
   return {
     ...base,
     repo,

--- a/packages/@openupm/local-data/src/validation/data-validator.ts
+++ b/packages/@openupm/local-data/src/validation/data-validator.ts
@@ -49,6 +49,16 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function isGitHubRepoUrl(value: string): boolean {
+  if (value.startsWith('git@github.com:')) return true;
+  try {
+    const parsed = new URL(value);
+    return /github\.com$/i.test(parsed.host);
+  } catch {
+    return false;
+  }
+}
+
 function messageFromError(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
@@ -238,6 +248,36 @@ export async function validateDataDirectory(
         addIssue(issues, {
           code: 'package-image-url-invalid',
           message: 'image field should be a valid URL',
+          path: relPath,
+          packageName,
+        });
+      }
+      if (
+        pkg.githubReleaseAssetName !== undefined &&
+        !isNonEmptyString(pkg.githubReleaseAssetName)
+      ) {
+        addIssue(issues, {
+          code: 'package-github-release-asset-name-empty',
+          message: 'githubReleaseAssetName must not be empty when set',
+          path: relPath,
+          packageName,
+        });
+      }
+      if (
+        isNonEmptyString(pkg.githubReleaseAssetName) &&
+        /[\\/]/.test(pkg.githubReleaseAssetName)
+      ) {
+        addIssue(issues, {
+          code: 'package-github-release-asset-name-path-invalid',
+          message: 'GitHub Release asset names are filenames only; githubReleaseAssetName must not include a directory path',
+          path: relPath,
+          packageName,
+        });
+      }
+      if (pkg.trackingMode === 'githubRelease' && !isGitHubRepoUrl(pkg.repoUrl)) {
+        addIssue(issues, {
+          code: 'package-github-release-repo-url-invalid',
+          message: 'trackingMode githubRelease requires a GitHub repoUrl',
           path: relPath,
           packageName,
         });

--- a/packages/@openupm/local-data/src/validation/data-validator.ts
+++ b/packages/@openupm/local-data/src/validation/data-validator.ts
@@ -50,10 +50,13 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 function isGitHubRepoUrl(value: string): boolean {
-  if (value.startsWith('git@github.com:')) return true;
+  if (value.startsWith('git@github.com:')) {
+    return /^git@github\.com:[^/]+\/[^/]+?(?:\.git)?$/i.test(value);
+  }
   try {
     const parsed = new URL(value);
-    return /github\.com$/i.test(parsed.host);
+    if (parsed.host.toLowerCase() !== 'github.com') return false;
+    return parsed.pathname.split('/').filter(Boolean).length === 2;
   } catch {
     return false;
   }

--- a/packages/@openupm/types/src/constant.ts
+++ b/packages/@openupm/types/src/constant.ts
@@ -65,6 +65,16 @@ export enum ReleaseErrorCode {
   LfsBudgetExceeded = 902,
   // Git LFS object is missing from the remote server
   LfsObjectNotFound = 903,
+  // GitHub Release was not found for the discovered tag
+  GitHubReleaseNotFound = 904,
+  // GitHub Release had no matching publishable asset
+  GitHubReleaseAssetNotFound = 905,
+  // GitHub Release asset selection was ambiguous
+  GitHubReleaseAssetAmbiguous = 906,
+  // GitHub Release API failed transiently
+  GitHubReleaseApiError = 907,
+  // GitHub Release asset download failed in Azure
+  GitHubReleaseAssetDownloadFailed = 908,
 }
 
 // A list of error codes that should be retried.
@@ -82,6 +92,11 @@ export const RetryableReleaseErrorCodes = [
   ReleaseErrorCode.BuildTimeout,
   ReleaseErrorCode.BuildCancellation,
   ReleaseErrorCode.ConnectionTimeout,
+  ReleaseErrorCode.GitHubReleaseNotFound,
+  ReleaseErrorCode.GitHubReleaseAssetNotFound,
+  ReleaseErrorCode.GitHubReleaseAssetAmbiguous,
+  ReleaseErrorCode.GitHubReleaseApiError,
+  ReleaseErrorCode.GitHubReleaseAssetDownloadFailed,
 ];
 
 // TODO: move to @openupm/local-data package

--- a/packages/@openupm/types/src/schema.ts
+++ b/packages/@openupm/types/src/schema.ts
@@ -17,5 +17,7 @@ export const PackageMetadataLocalBaseSchema = z.object({
   gitTagPrefix: z.string().optional(),
   gitTagIgnore: z.string().optional(),
   minVersion: z.string().optional(),
+  trackingMode: z.enum(['git', 'githubRelease']).optional(),
+  githubReleaseAssetName: z.string().optional(),
   excludedFromList: z.boolean().optional(),
 });

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -19,6 +19,8 @@ export interface PackageMetadataLocalBase {
   gitTagPrefix?: string;
   gitTagIgnore?: string;
   minVersion?: string;
+  trackingMode?: 'git' | 'githubRelease';
+  githubReleaseAssetName?: string;
   // Misc
   excludedFromList?: boolean;
 }


### PR DESCRIPTION
## Summary
- add `trackingMode: githubRelease` and optional `githubReleaseAssetName` metadata support
- resolve GitHub Release assets in the queue using configured GitHub tokens before queueing Azure
- pass exact asset URL/name to Azure and map release/download/validation failures to release reasons
- document stable asset filename prefixes and add AGENTS follow-through guidance

## Verification
- `npm --workspace apps/queue test -- --run __tests__/utils/githubReleaseAsset.spec.ts __tests__/workers/buildRelease.spec.ts`
- `npm --workspace packages/@openupm/local-data test -- --run __tests__/validation/data-validator.spec.ts`
- `npm --workspace apps/queue run lint`
- `npm --workspace apps/queue run build`
- `npm --workspace packages/@openupm/local-data run build`
- `npm --workspace packages/@openupm/types run build`
- `npm --workspace apps/docs run docs:build:limit`
- GitHub Actions CI `25455057332` passed