### PR TITLE
[codex] Require package tracking mode

### DIFF
--- a/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
@@ -33,6 +33,8 @@ const PackageFormSchema = Joi.object({
   gitTagPrefix: Joi.string().allow("").default(""),
   gitTagIgnore: Joi.string().allow("").default(""),
   minVersion: Joi.string().allow("").default(""),
+  trackingMode: Joi.string().valid("git", "githubRelease").required().default("git"),
+  githubReleaseAssetName: Joi.string().allow("").default(""),
   topics: Joi.array().min(1).required().default([]),
   image: Joi.string().allow("").default(""),
 });
@@ -47,6 +49,7 @@ interface PackageAddFormState {
     branch: FormFieldOption[];
     packageJson: FormFieldOption[];
     readme: FormFieldOption[];
+    trackingMode: FormFieldOption[];
   };
 }
 
@@ -77,6 +80,10 @@ const initState = function (): PackageAddState {
         branch: [],
         packageJson: [],
         readme: [],
+        trackingMode: [
+          { key: "git", text: "build from Git tag checkout" },
+          { key: "githubRelease", text: "publish GitHub Release asset" },
+        ],
       },
     },
     isSubmitting: false,
@@ -515,11 +522,12 @@ const genYaml = (): string => {
   const form = state.form;
   const repoInfo = state.repoInfo;
   const packageJsonObj = state.packageJsonObj;
-  const content = {
+  const content: Record<string, unknown> = {
     name: packageJsonObj.name,
     displayName: packageJsonObj.displayName,
     description: packageJsonObj.description || repoInfo.description || "",
     repoUrl: repoInfo.html_url,
+    trackingMode: form.values.trackingMode,
     parentRepoUrl: repoInfo.parent ? repoInfo.parent.html_url : null,
     licenseSpdxId: form.values.licenseId,
     licenseName: form.values.licenseName,
@@ -534,6 +542,12 @@ const genYaml = (): string => {
       : "main:README.md",
     createdAt: new Date().getTime(),
   };
+  if (
+    form.values.trackingMode === "githubRelease" &&
+    form.values.githubReleaseAssetName.trim()
+  ) {
+    content["githubReleaseAssetName"] = form.values.githubReleaseAssetName.trim();
+  }
   return yaml.dump(content);
 };
 
@@ -634,6 +648,11 @@ onMounted(() => {
               </FormField>
               <FormField :form="state.form" field="minVersion" :label='t("min-version")' type="text"
                 :hint="t('min-version-desc')" :placeholder="$t('min-version-placeholder')" />
+              <FormField :form="state.form" field="trackingMode" :label='t("tracking-mode")' type="select"
+                :hint="t('tracking-mode-desc')" />
+              <FormField v-if="state.form.values.trackingMode === 'githubRelease'" :form="state.form"
+                field="githubReleaseAssetName" :label='t("github-release-asset-name")' type="text"
+                :hint="t('github-release-asset-name-desc')" :placeholder="$t('github-release-asset-name-placeholder')" />
             </div>
           </div>
           <div class="column col-6 col-sm-12" :class="{ hide: state.hideMetaFields }">
@@ -755,6 +774,9 @@ onMounted(() => {
   git-tag-prefix: Git tag prefix
   git-tag-prefix-desc: "Filter Git tags for monorepo by using a prefix that separates the semver with a slash, hyphen, or underscore. Example: 'com.example.pkg/'."
   git-tag-prefix-placeholder: leave empty to include all tags
+  github-release-asset-name: GitHub Release asset name
+  github-release-asset-name-desc: Leave empty when each release provides one clearly named publishable .tgz or .tar.gz asset. If a release has multiple publishable assets, use an exact filename or stable prefix. OpenUPM tries exact match first, then one publishable asset starting with the value. Do not include paths.
+  github-release-asset-name-placeholder: ""
   license-name-desc: Only open source licenses are permitted.
   min-version: Minimal version to build
   min-version-desc: "The minimum version to build from. For example: '1.0.2'"
@@ -770,4 +792,6 @@ onMounted(() => {
   private-repository-error: "Refuse to publish a private repository (\"private\": true in the package.json)."
   repository-placeholder: owner/project-name
   submit-metadata: submit metadata
+  tracking-mode: Tracking mode
+  tracking-mode-desc: Choose whether OpenUPM builds from Git tags or publishes a GitHub Release asset.
 </i18n>

--- a/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
+++ b/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
@@ -17,7 +17,7 @@ type PackageFixture = {
   hunter: string;
   createdAt: number;
   image?: string | null;
-  trackingMode?: 'git' | 'githubRelease';
+  trackingMode: 'git' | 'githubRelease';
   githubReleaseAssetName?: string;
 };
 
@@ -40,6 +40,7 @@ const validPackage: PackageFixture = {
   hunter: 'hunter',
   createdAt: 1_700_000_000_000,
   image: 'https://example.com/image.png',
+  trackingMode: 'git',
 };
 
 async function createDataDir(): Promise<string> {
@@ -149,7 +150,7 @@ describe('validateDataDirectory', () => {
   });
 
   it('covers required package field checks from openupm data tests', async () => {
-    expect.assertions(7);
+    expect.assertions(8);
     await expectIssue(
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {
@@ -180,6 +181,14 @@ describe('validateDataDirectory', () => {
         writePackage(dataDir, validPackage.name, {
           ...validPackage,
           topics: 'utilities',
+        }),
+      'package-metadata-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          trackingMode: undefined,
         }),
       'package-metadata-invalid',
     );

--- a/packages/@openupm/local-data/src/utils/parse-pkg.ts
+++ b/packages/@openupm/local-data/src/utils/parse-pkg.ts
@@ -82,7 +82,6 @@ export const parsePackageMetadata = function (raw: any): PackageMetadataLocal {
   if (base.image === undefined) base.image = null;
   // Set imageFit
   if (base.imageFit === undefined) base.imageFit = 'cover';
-  if (base.trackingMode === undefined) base.trackingMode = 'git';
   return {
     ...base,
     repo,

--- a/packages/@openupm/test/src/arbitraries.ts
+++ b/packages/@openupm/test/src/arbitraries.ts
@@ -112,5 +112,6 @@ export const packageMetadataLocalBaseArb = fc.record<PackageMetadataLocalBase>({
   gitTagPrefix: fc.oneof(fc.constant(undefined), fc.string()),
   gitTagIgnore: fc.oneof(fc.constant(undefined), fc.string()),
   minVersion: fc.oneof(fc.constant(undefined), semanticVersion),
+  trackingMode: fc.constant('git'),
   excludedFromList: fc.oneof(fc.constant(undefined), fc.boolean()),
 });

--- a/packages/@openupm/types/src/schema.ts
+++ b/packages/@openupm/types/src/schema.ts
@@ -17,7 +17,7 @@ export const PackageMetadataLocalBaseSchema = z.object({
   gitTagPrefix: z.string().optional(),
   gitTagIgnore: z.string().optional(),
   minVersion: z.string().optional(),
-  trackingMode: z.enum(['git', 'githubRelease']).optional(),
+  trackingMode: z.enum(['git', 'githubRelease']),
   githubReleaseAssetName: z.string().optional(),
   excludedFromList: z.boolean().optional(),
 });

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -19,7 +19,7 @@ export interface PackageMetadataLocalBase {
   gitTagPrefix?: string;
   gitTagIgnore?: string;
   minVersion?: string;
-  trackingMode?: 'git' | 'githubRelease';
+  trackingMode: 'git' | 'githubRelease';
   githubReleaseAssetName?: string;
   // Misc
   excludedFromList?: boolean;


### PR DESCRIPTION
## Summary

- Make package metadata `trackingMode` required in the shared type and Zod schema.
- Remove the local-data parser fallback that silently defaulted missing `trackingMode` to `git`.
- Update validator fixtures/arbitraries/tests so valid metadata includes `trackingMode`, and missing `trackingMode` fails validation.
- Add package add form controls for `trackingMode` and optional `githubReleaseAssetName`, with YAML generation that always emits `trackingMode` and only emits asset name for GitHub Release mode when set.

## Rollout note

This PR should merge after openupm/openupm#6437, which migrates the package data to include `trackingMode: git`.

## Validation

- `npm run build -w @openupm/types`
- `npm run build -w @openupm/test`
- `npm run build -w @openupm/local-data`
- `npm run test -w @openupm/local-data -- --run __tests__/validation/data-validator.spec.ts __tests__/utils/parse-pkg.spec.ts`
- `npm run docs:build:limit -w @openupm/docs`
- `npm run lint`
- `git diff --check`