### PR TITLE
[codex] Fallback to package name for empty display name

### DIFF
--- a/packages/@openupm/common/__tests__/utils.spec.ts
+++ b/packages/@openupm/common/__tests__/utils.spec.ts
@@ -6,8 +6,10 @@ import {
   parsePackageMetadataRemote,
   filterMetadatabyTopicSlug,
   getPackageNamespace,
+  getLocalePackageDisplayName,
   isPackageRequiresManualVerification,
 } from '../src/utils.js';
+import { PackageMetadataLocal } from '@openupm/types';
 
 describe('isValidPackageName()', function () {
   it('should fail with com.company.UPPERCASE', async function () {
@@ -234,6 +236,26 @@ describe('getPackageNamespace()', function () {
       'com.littlebigfun.addressable-importer.sub',
     );
     expect(namespace).toEqual('com.littlebigfun');
+  });
+});
+
+describe('getLocalePackageDisplayName()', () => {
+  it('should return displayName when defined', () => {
+    const metadata = {
+      name: 'com.example.package',
+      displayName: 'Example Package',
+    } as PackageMetadataLocal;
+    expect(getLocalePackageDisplayName(metadata)).toEqual('Example Package');
+  });
+
+  it('should return package name when displayName is empty', () => {
+    const metadata = {
+      name: 'com.example.package',
+      displayName: '',
+    } as PackageMetadataLocal;
+    expect(getLocalePackageDisplayName(metadata)).toEqual(
+      'com.example.package',
+    );
   });
 });
 

--- a/packages/@openupm/common/src/utils.ts
+++ b/packages/@openupm/common/src/utils.ts
@@ -151,7 +151,7 @@ export const getPackageMetadata = function (
 export const getLocalePackageDisplayName = function (
   metadata: PackageMetadataLocal,
 ): string {
-  return metadata.displayName || '';
+  return metadata.displayName || metadata.name;
 };
 
 /**

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -133,7 +133,7 @@ const createDetailPages = async function (app: App): Promise<Page[]> {
   const { metadataLocalList, topicsWithAll } = PLUGIN_DATA;
   for (const metadataLocal of metadataLocalList) {
     const displayName = getLocalePackageDisplayName(metadataLocal);
-    const title = displayName
+    const title = metadataLocal.displayName
       ? `${displayName} | ${metadataLocal.name} | Unity Package Manager (UPM)`
       : `${metadataLocal.name} | Unity Package Manager (UPM)`;
     const description = getLocalePackageDescription(metadataLocal);


### PR DESCRIPTION
## Summary

- Fall back to the package name when package metadata has an empty `displayName`.
- Keep package detail page titles from duplicating the package name when `displayName` is empty.
- Add focused common utility tests for display-name fallback behavior.

## Validation

- `npm test` in `packages/@openupm/common`
- `npm run lint` in `packages/@openupm/common`
- `npm run lint` in `packages/vuepress-plugin-openupm`
- `npm test` in `apps/docs`