### PR TITLE
[codex] Validate SPDX license names

### DIFF
--- a/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
+++ b/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
@@ -219,7 +219,7 @@ describe('validateDataDirectory', () => {
   });
 
   it('covers package semantic checks from openupm data tests', async () => {
-    expect.assertions(9);
+    expect.assertions(10);
     await expectIssue(
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {
@@ -261,6 +261,15 @@ describe('validateDataDirectory', () => {
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {
           ...validPackage,
+          licenseSpdxId: 'MIT',
+          licenseName: 'MIT',
+        }),
+      'package-license-name-spdx-mismatch',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
           image: 'not-a-url',
         }),
       'package-image-url-invalid',
@@ -292,6 +301,21 @@ describe('validateDataDirectory', () => {
         }),
       'package-github-release-asset-name-path-invalid',
     );
+  });
+
+  it('allows custom license names when licenseSpdxId is null', async () => {
+    const dataDir = await createDataDir();
+    try {
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        licenseSpdxId: null,
+        licenseName: 'Custom License',
+      });
+      const result = await validateDataDirectory(dataDir);
+      expect(result).toEqual({ valid: true, issues: [] });
+    } finally {
+      await afs.rm(dataDir, { recursive: true, force: true });
+    }
   });
 
   it('covers package extension and top-level YAML checks from openupm data tests', async () => {

--- a/packages/@openupm/local-data/src/validation/data-validator.ts
+++ b/packages/@openupm/local-data/src/validation/data-validator.ts
@@ -75,6 +75,13 @@ function normalizePackageForLegacyData(raw: unknown): unknown {
   return raw;
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
 /**
  * Validate an OpenUPM data directory.
  *
@@ -158,7 +165,9 @@ export async function validateDataDirectory(
     }
 
     try {
-      const pkg = parsePackageMetadata(normalizePackageForLegacyData(raw));
+      const normalizedRaw = normalizePackageForLegacyData(raw);
+      const rawPackage = asRecord(normalizedRaw);
+      const pkg = parsePackageMetadata(normalizedRaw);
       if (!isNonEmptyString(pkg.repoUrl)) {
         addIssue(issues, {
           code: 'package-repo-url-empty',
@@ -239,13 +248,23 @@ export async function validateDataDirectory(
           });
         }
       }
-      if (pkg.licenseSpdxId && !spdx[pkg.licenseSpdxId]) {
-        addIssue(issues, {
-          code: 'package-license-spdx-id-invalid',
-          message: `licenseSpdxId ${pkg.licenseSpdxId} should be valid`,
-          path: relPath,
-          packageName,
-        });
+      if (pkg.licenseSpdxId) {
+        const spdxLicense = spdx[pkg.licenseSpdxId];
+        if (!spdxLicense) {
+          addIssue(issues, {
+            code: 'package-license-spdx-id-invalid',
+            message: `licenseSpdxId ${pkg.licenseSpdxId} should be valid`,
+            path: relPath,
+            packageName,
+          });
+        } else if (rawPackage.licenseName !== spdxLicense.name) {
+          addIssue(issues, {
+            code: 'package-license-name-spdx-mismatch',
+            message: `licenseName should be ${spdxLicense.name} for licenseSpdxId ${pkg.licenseSpdxId}`,
+            path: relPath,
+            packageName,
+          });
+        }
       }
       if (pkg.image && !/https?:\/\//i.test(pkg.image)) {
         addIssue(issues, {


### PR DESCRIPTION
## Summary

- require OpenUPM data validation to compare raw `licenseName` values against the exact SPDX full name when `licenseSpdxId` is valid
- add `package-license-name-spdx-mismatch` for canonical SPDX name mismatches
- cover mismatch, invalid SPDX id, and null SPDX id behavior in local-data validator tests

## Validation

- `OPENUPM_DATA_PATH=<openupm-data-worktree>/data npm run test --workspace packages/@openupm/local-data`
- `npm run lint`
- `npm run build --workspace packages/@openupm/local-data`
- downstream data validation passed from the matching `openupm` data branch via `OPENUPM_NEXT_PATH=<openupm-next-validator-worktree> npm test`