### PR TITLE
[codex] Add missing package queue cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,8 @@
 - `queue-jobs` returns all matching jobs when `--limit` is omitted. Preserve
   explicit `--limit` for large or scripted inspections.
 - Destructive commands are `remove-job`, `release-remove`, `release-requeue`,
-  and `package-requeue`; validate them with focused tests before deploy.
+  `package-requeue`, and `cleanup-missing-packages`; validate them with focused
+  tests before deploy.
 - Do not put private production hostnames, paths, or sudo wrapper details in
   this public application repo. Production invocation belongs in
   `openupm-devops`.

--- a/apps/queue/README.md
+++ b/apps/queue/README.md
@@ -48,6 +48,9 @@ Common commands:
   a fresh release build job.
 - `package-requeue <package> [--json]`: remove the deterministic package queue
   job and enqueue a fresh package scan.
+- `cleanup-missing-packages [--json]`: clean failed package jobs for packages
+  removed from local data, deleting failed release records and related release
+  jobs while preserving successful releases.
 
 ## Production Entry Points
 

--- a/apps/queue/__tests__/jobs/cleanupMissingPackage.spec.ts
+++ b/apps/queue/__tests__/jobs/cleanupMissingPackage.spec.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReleaseErrorCode, ReleaseState } from '@openupm/types';
+
+const packageMetadataLocalExistsMock = vi.fn();
+const fetchAllMock = vi.fn();
+const removeReleaseRecordMock = vi.fn();
+const pkgRemoveMock = vi.fn();
+const relRemoveMock = vi.fn();
+const getJobCountsMock = vi.fn();
+const getJobsMock = vi.fn();
+const getQueueMock = vi.fn();
+
+vi.mock('@openupm/local-data', () => ({
+  packageMetadataLocalExists: packageMetadataLocalExistsMock,
+}));
+
+vi.mock('@openupm/server-common/build/models/release.js', () => ({
+  fetchAll: fetchAllMock,
+  remove: removeReleaseRecordMock,
+}));
+
+vi.mock('../../src/queues/core.js', () => ({
+  getQueue: getQueueMock,
+}));
+
+describe('cleanupMissingPackage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getQueueMock.mockImplementation((name: string) => {
+      if (name === 'pkg') {
+        return {
+          remove: pkgRemoveMock,
+          getJobCounts: getJobCountsMock,
+          getJobs: getJobsMock,
+        };
+      }
+      if (name === 'rel') return { remove: relRemoveMock };
+      throw new Error(`unexpected queue: ${name}`);
+    });
+    pkgRemoveMock.mockResolvedValue(1);
+    relRemoveMock.mockResolvedValue(1);
+    removeReleaseRecordMock.mockResolvedValue(undefined);
+  });
+
+  it('removes the package job and failed releases for missing package metadata', async () => {
+    packageMetadataLocalExistsMock.mockReturnValue(false);
+    fetchAllMock.mockResolvedValue([
+      {
+        packageName: 'com.foo.bar',
+        version: '1.0.0',
+        state: ReleaseState.Failed,
+        reason: ReleaseErrorCode.BuildTimeout,
+        buildId: '',
+        tag: '1.0.0',
+        commit: 'abc',
+        updatedAt: 100,
+      },
+      {
+        packageName: 'com.foo.bar',
+        version: '2.0.0',
+        state: ReleaseState.Succeeded,
+        reason: ReleaseErrorCode.None,
+        buildId: '123',
+        tag: '2.0.0',
+        commit: 'def',
+        updatedAt: 200,
+      },
+    ]);
+
+    const { cleanupMissingPackage } = await import(
+      '../../src/jobs/cleanupMissingPackage.js'
+    );
+
+    const result = await cleanupMissingPackage('com.foo.bar');
+
+    expect(pkgRemoveMock).toHaveBeenCalledWith('build-pkg|com.foo.bar', {
+      removeChildren: true,
+    });
+    expect(relRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.foo.bar|1.0.0',
+      {
+        removeChildren: true,
+      },
+    );
+    expect(removeReleaseRecordMock).toHaveBeenCalledWith('com.foo.bar', '1.0.0');
+    expect(removeReleaseRecordMock).not.toHaveBeenCalledWith(
+      'com.foo.bar',
+      '2.0.0',
+    );
+    expect(result).toMatchObject({
+      packageName: 'com.foo.bar',
+      metadataMissing: true,
+      preservedReleaseCount: 1,
+      failedReleasesRemoved: [
+        {
+          packageName: 'com.foo.bar',
+          version: '1.0.0',
+          jobId: 'build-rel|com.foo.bar|1.0.0',
+          jobRemoved: true,
+        },
+      ],
+    });
+  });
+
+  it('does not remove queue or release state when package metadata still exists', async () => {
+    packageMetadataLocalExistsMock.mockReturnValue(true);
+
+    const { cleanupMissingPackage } = await import(
+      '../../src/jobs/cleanupMissingPackage.js'
+    );
+
+    const result = await cleanupMissingPackage('com.foo.bar');
+
+    expect(pkgRemoveMock).not.toHaveBeenCalled();
+    expect(fetchAllMock).not.toHaveBeenCalled();
+    expect(removeReleaseRecordMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      packageName: 'com.foo.bar',
+      metadataMissing: false,
+      failedReleasesRemoved: [],
+      preservedReleaseCount: 0,
+    });
+  });
+
+  it('scans failed package jobs and cleans only packages missing from local data', async () => {
+    packageMetadataLocalExistsMock.mockImplementation(
+      (name: string) => name === 'com.kept.package',
+    );
+    getJobCountsMock.mockResolvedValue({ failed: 2 });
+    getJobsMock.mockResolvedValue([
+      {
+        id: 'build-pkg|com.removed.package',
+        data: { name: 'com.removed.package' },
+      },
+      {
+        id: 'build-pkg|com.kept.package',
+        data: { name: 'com.kept.package' },
+      },
+    ]);
+    fetchAllMock.mockResolvedValue([]);
+
+    const { cleanupMissingPackageJobs } = await import(
+      '../../src/jobs/cleanupMissingPackage.js'
+    );
+
+    const result = await cleanupMissingPackageJobs();
+
+    expect(getJobsMock).toHaveBeenCalledWith(['failed'], 0, 1, false);
+    expect(pkgRemoveMock).toHaveBeenCalledTimes(1);
+    expect(pkgRemoveMock).toHaveBeenCalledWith(
+      'build-pkg|com.removed.package',
+      {
+        removeChildren: true,
+      },
+    );
+    expect(result.cleaned).toHaveLength(1);
+    expect(result.skipped).toEqual(['com.kept.package']);
+  });
+});

--- a/apps/queue/__tests__/queueCli.spec.ts
+++ b/apps/queue/__tests__/queueCli.spec.ts
@@ -120,6 +120,14 @@ describe('parseQueueCliArgs', () => {
     expect(help).toContain('remove-job <queue> <jobId>');
     expect(help).toContain('This is destructive');
     expect(help).toContain('release-remove <package> <version>');
+    expect(help).toContain('cleanup-missing-packages');
+  });
+
+  it('documents cleanup-missing-packages behavior', async () => {
+    const { getCommandUsage } = await import('../src/queueCli.js');
+    const help = getCommandUsage('cleanup-missing-packages');
+    expect(help).toContain('queue-cli cleanup-missing-packages');
+    expect(help).toContain('Successful and non-failed release records are preserved.');
   });
 
   it('queue-jobs includes total and limit metadata', async () => {

--- a/apps/queue/__tests__/queueCliActions.spec.ts
+++ b/apps/queue/__tests__/queueCliActions.spec.ts
@@ -10,10 +10,16 @@ const getQueueMock = vi.fn(() => ({
 const hasQueueMock = vi.fn((name: string) => name === 'pkg' || name === 'rel');
 const addJobMock = vi.fn();
 const closeQueuesMock = vi.fn();
+const fetchAllMock = vi.fn();
 const fetchOneMock = vi.fn();
 const removeReleaseRecordMock = vi.fn();
 const saveReleaseMock = vi.fn();
 const redisCloseMock = vi.fn();
+const packageMetadataLocalExistsMock = vi.fn();
+
+vi.mock('@openupm/local-data', () => ({
+  packageMetadataLocalExists: packageMetadataLocalExistsMock,
+}));
 
 vi.mock('../src/queues/core.js', () => ({
   addJob: addJobMock,
@@ -23,7 +29,7 @@ vi.mock('../src/queues/core.js', () => ({
 }));
 
 vi.mock('@openupm/server-common/build/models/release.js', () => ({
-  fetchAll: vi.fn(),
+  fetchAll: fetchAllMock,
   fetchOne: fetchOneMock,
   remove: removeReleaseRecordMock,
   save: saveReleaseMock,
@@ -45,9 +51,12 @@ describe('queue-cli destructive actions', () => {
     getQueueMock.mockReturnValue({
       remove: queueRemoveMock,
       add: queueAddMock,
+      getJobCounts: vi.fn().mockResolvedValue({ failed: 0 }),
+      getJobs: vi.fn().mockResolvedValue([]),
     });
     hasQueueMock.mockImplementation((name: string) => name === 'pkg' || name === 'rel');
     queueRemoveMock.mockResolvedValue(1);
+    packageMetadataLocalExistsMock.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -181,6 +190,93 @@ describe('queue-cli destructive actions', () => {
     );
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining('"signed": true'),
+    );
+  });
+
+  it('cleanup-missing-packages removes failed state for missing packages only', async () => {
+    const getJobCountsMock = vi.fn().mockResolvedValue({ failed: 2 });
+    const getJobsMock = vi.fn().mockResolvedValue([
+      {
+        id: 'build-pkg|com.removed.package',
+        data: { name: 'com.removed.package' },
+      },
+      {
+        id: 'build-pkg|com.kept.package',
+        data: { name: 'com.kept.package' },
+      },
+    ]);
+    getQueueMock.mockImplementation((name: string) => {
+      if (name === 'pkg') {
+        return {
+          remove: queueRemoveMock,
+          add: queueAddMock,
+          getJobCounts: getJobCountsMock,
+          getJobs: getJobsMock,
+        };
+      }
+      return {
+        remove: queueRemoveMock,
+        add: queueAddMock,
+      };
+    });
+    packageMetadataLocalExistsMock.mockImplementation(
+      (name: string) => name === 'com.kept.package',
+    );
+    fetchAllMock.mockResolvedValue([
+      {
+        packageName: 'com.removed.package',
+        version: '1.0.0',
+        state: ReleaseState.Failed,
+        reason: ReleaseErrorCode.BuildTimeout,
+        buildId: '',
+        tag: '1.0.0',
+        commit: 'abc',
+        updatedAt: 100,
+      },
+      {
+        packageName: 'com.removed.package',
+        version: '2.0.0',
+        state: ReleaseState.Succeeded,
+        reason: ReleaseErrorCode.None,
+        buildId: '123',
+        tag: '2.0.0',
+        commit: 'def',
+        updatedAt: 200,
+      },
+    ]);
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await runQueueCli([
+      'node',
+      'index.js',
+      'queue-cli',
+      'cleanup-missing-packages',
+      '--json',
+    ]);
+
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-pkg|com.removed.package',
+      {
+        removeChildren: true,
+      },
+    );
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.removed.package|1.0.0',
+      {
+        removeChildren: true,
+      },
+    );
+    expect(removeReleaseRecordMock).toHaveBeenCalledWith(
+      'com.removed.package',
+      '1.0.0',
+    );
+    expect(removeReleaseRecordMock).not.toHaveBeenCalledWith(
+      'com.removed.package',
+      '2.0.0',
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"packageName": "com.removed.package"'),
     );
   });
 });

--- a/apps/queue/__tests__/workers/buildPackageCleanup.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackageCleanup.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadPackageMetadataLocalMock = vi.fn();
+const packageMetadataLocalExistsMock = vi.fn();
+const cleanupMissingPackageMock = vi.fn();
+
+vi.mock('@openupm/local-data', () => ({
+  loadPackageMetadataLocal: loadPackageMetadataLocalMock,
+  packageMetadataLocalExists: packageMetadataLocalExistsMock,
+}));
+
+vi.mock('../../src/jobs/cleanupMissingPackage.js', () => ({
+  cleanupMissingPackage: cleanupMissingPackageMock,
+}));
+
+vi.mock('@openupm/server-common/build/models/release.js', () => ({
+  fetchAll: vi.fn(),
+  fetchOne: vi.fn(),
+  remove: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock('@openupm/server-common/build/models/packageExtra.js', () => ({
+  setInvalidTags: vi.fn(),
+  setRepoUnavailable: vi.fn(),
+}));
+
+vi.mock('../../src/queues/core.js', () => ({
+  addJob: vi.fn(),
+  getQueue: vi.fn(),
+}));
+
+vi.mock('../../src/utils/git.js', () => ({
+  gitListRemoteTags: vi.fn(),
+}));
+
+describe('buildPackage missing metadata cleanup', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    loadPackageMetadataLocalMock.mockResolvedValue(null);
+    packageMetadataLocalExistsMock.mockReturnValue(false);
+    cleanupMissingPackageMock.mockResolvedValue(undefined);
+  });
+
+  it('cleans missing package state and resolves without throwing', async () => {
+    const { buildPackage } = await import('../../src/workers/buildPackage.js');
+
+    await expect(buildPackage('com.removed.package')).resolves.toBeUndefined();
+
+    expect(cleanupMissingPackageMock).toHaveBeenCalledWith(
+      'com.removed.package',
+    );
+  });
+
+  it('throws when metadata fails to load but still exists', async () => {
+    packageMetadataLocalExistsMock.mockReturnValue(true);
+    const { buildPackage } = await import('../../src/workers/buildPackage.js');
+
+    await expect(buildPackage('com.invalid.package')).rejects.toThrow(
+      'package not found: com.invalid.package',
+    );
+
+    expect(cleanupMissingPackageMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/queue/src/jobs/cleanupMissingPackage.ts
+++ b/apps/queue/src/jobs/cleanupMissingPackage.ts
@@ -1,0 +1,199 @@
+import configRaw from 'config';
+import type { Job, JobType } from 'bullmq';
+
+import { ReleaseState } from '@openupm/types';
+import { packageMetadataLocalExists } from '@openupm/local-data';
+import {
+  fetchAll,
+  remove as removeReleaseRecord,
+} from '@openupm/server-common/build/models/release.js';
+import { createLogger } from '@openupm/server-common/build/log.js';
+
+import { getQueue } from '../queues/core.js';
+import { createJobId } from '../queues/jobId.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config = configRaw as any;
+const logger = createLogger('@openupm/queue/cleanupMissingPackage');
+
+export interface CleanupMissingPackageResult {
+  packageName: string;
+  metadataMissing: boolean;
+  packageJob: {
+    queue: string;
+    jobId: string;
+    removed: boolean;
+    removeError?: string;
+  };
+  failedReleasesRemoved: Array<{
+    packageName: string;
+    version: string;
+    jobId: string;
+    jobRemoved: boolean;
+  }>;
+  preservedReleaseCount: number;
+}
+
+export interface CleanupMissingPackageJobsResult {
+  queue: string;
+  states: JobType[];
+  scanned: number;
+  cleaned: CleanupMissingPackageResult[];
+  skipped: string[];
+}
+
+export function getBuildPackageJobId(packageName: string): string {
+  const jobConfig = config.jobs.buildPackage;
+  return createJobId(jobConfig.name, packageName);
+}
+
+export function getBuildReleaseJobId(
+  packageName: string,
+  version: string,
+): string {
+  const jobConfig = config.jobs.buildRelease;
+  return createJobId(jobConfig.name, packageName, version);
+}
+
+export function getPackageNameFromBuildPackageJob(
+  job: Pick<Job, 'id' | 'data'>,
+): string | null {
+  const data = job.data;
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    !Array.isArray(data) &&
+    typeof (data as Record<string, unknown>).name === 'string'
+  ) {
+    return (data as Record<string, string>).name;
+  }
+
+  if (typeof job.id !== 'string') return null;
+  const parts = job.id.split('|');
+  const expectedName = encodeURIComponent(config.jobs.buildPackage.name);
+  if (parts.length !== 2 || parts[0] !== expectedName) return null;
+
+  try {
+    return decodeURIComponent(parts[1]);
+  } catch {
+    return null;
+  }
+}
+
+async function removeQueueJob(
+  queueName: string,
+  jobId: string,
+): Promise<{ removed: boolean; removeError?: string }> {
+  try {
+    const removed = await getQueue(queueName).remove(jobId, {
+      removeChildren: true,
+    });
+    return { removed: removed === 1 };
+  } catch (error) {
+    const removeError = (error as Error).message || String(error);
+    logger.warn({ queueName, jobId, err: error }, 'queue job remove failed');
+    return { removed: false, removeError };
+  }
+}
+
+export async function cleanupMissingPackage(
+  packageName: string,
+): Promise<CleanupMissingPackageResult> {
+  const packageJobConfig = config.jobs.buildPackage;
+  const releaseJobConfig = config.jobs.buildRelease;
+  const packageJobId = getBuildPackageJobId(packageName);
+  const metadataMissing = !packageMetadataLocalExists(packageName);
+  const packageJob = {
+    queue: packageJobConfig.queue,
+    jobId: packageJobId,
+    removed: false,
+  };
+
+  if (!metadataMissing) {
+    return {
+      packageName,
+      metadataMissing: false,
+      packageJob,
+      failedReleasesRemoved: [],
+      preservedReleaseCount: 0,
+    };
+  }
+
+  Object.assign(
+    packageJob,
+    await removeQueueJob(packageJobConfig.queue, packageJobId),
+  );
+
+  const releases = await fetchAll(packageName);
+  const failedReleasesRemoved: CleanupMissingPackageResult['failedReleasesRemoved'] =
+    [];
+  let preservedReleaseCount = 0;
+
+  for (const release of releases) {
+    if (release.state !== ReleaseState.Failed) {
+      preservedReleaseCount++;
+      continue;
+    }
+
+    const jobId = getBuildReleaseJobId(packageName, release.version);
+    const job = await removeQueueJob(releaseJobConfig.queue, jobId);
+    await removeReleaseRecord(packageName, release.version);
+    failedReleasesRemoved.push({
+      packageName,
+      version: release.version,
+      jobId,
+      jobRemoved: job.removed,
+    });
+  }
+
+  logger.info(
+    {
+      packageName,
+      packageJob,
+      failedReleaseCount: failedReleasesRemoved.length,
+      preservedReleaseCount,
+    },
+    'cleaned missing package queue state',
+  );
+
+  return {
+    packageName,
+    metadataMissing: true,
+    packageJob,
+    failedReleasesRemoved,
+    preservedReleaseCount,
+  };
+}
+
+export async function cleanupMissingPackageJobs(): Promise<CleanupMissingPackageJobsResult> {
+  const jobConfig = config.jobs.buildPackage;
+  const queue = getQueue(jobConfig.queue);
+  const states: JobType[] = ['failed'];
+  const counts = await queue.getJobCounts(...states);
+  const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
+  const jobs =
+    total === 0 ? [] : await queue.getJobs(states, 0, total - 1, false);
+  const cleaned: CleanupMissingPackageResult[] = [];
+  const skipped: string[] = [];
+
+  for (const job of jobs) {
+    const packageName = getPackageNameFromBuildPackageJob(job as Job);
+    if (!packageName) {
+      skipped.push(`${job.id ?? ''}`);
+      continue;
+    }
+    if (packageMetadataLocalExists(packageName)) {
+      skipped.push(packageName);
+      continue;
+    }
+    cleaned.push(await cleanupMissingPackage(packageName));
+  }
+
+  return {
+    queue: jobConfig.queue,
+    states,
+    scanned: jobs.length,
+    cleaned,
+    skipped,
+  };
+}

--- a/apps/queue/src/queueCli.ts
+++ b/apps/queue/src/queueCli.ts
@@ -12,6 +12,7 @@ import {
 
 import { addJob, closeQueues, getQueue, hasQueue } from './queues/core.js';
 import { createJobId } from './queues/jobId.js';
+import { cleanupMissingPackageJobs } from './jobs/cleanupMissingPackage.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
@@ -154,6 +155,10 @@ function getUsage(): string {
     '',
     '  package-requeue <package> [--json]',
     '    Remove the deterministic pkg queue job and enqueue a fresh package scan.',
+    '',
+    '  cleanup-missing-packages [--json]',
+    '    Clean failed pkg jobs for packages removed from local data, plus failed',
+    '    release records and deterministic rel jobs. Successful releases stay.',
   ].join('\n');
 }
 
@@ -282,6 +287,19 @@ function getCommandUsage(topic: string | undefined): string {
         '',
         'Examples:',
         '  queue-cli package-requeue com.foo.bar --json',
+      ].join('\n');
+    case 'cleanup-missing-packages':
+      return [
+        'Usage: queue-cli cleanup-missing-packages [--json]',
+        '',
+        'Scan failed pkg queue jobs and clean jobs for packages missing from local',
+        'data. This removes the deterministic pkg job, failed release Redis',
+        'records, and deterministic rel jobs for failed releases only.',
+        '',
+        'Successful and non-failed release records are preserved.',
+        '',
+        'Examples:',
+        '  queue-cli cleanup-missing-packages --json',
       ].join('\n');
     default:
       return getUsage();
@@ -741,6 +759,9 @@ export async function runQueueCli(argv: string[] = process.argv): Promise<void> 
         requireArgs(args.rest, 1);
         result = await packageRequeue(args.rest[0]);
         break;
+      case 'cleanup-missing-packages':
+        result = await cleanupMissingPackageJobs();
+        break;
       default:
         throw new Error(getUsage());
     }
@@ -763,4 +784,5 @@ export {
   releaseRemove,
   releaseRequeue,
   packageRequeue,
+  cleanupMissingPackageJobs,
 };

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -9,7 +9,10 @@ import {
   RetryableReleaseErrorCodes,
 } from '@openupm/types';
 import { getVersionFromTag } from '@openupm/common/build/semver.js';
-import { loadPackageMetadataLocal } from '@openupm/local-data';
+import {
+  loadPackageMetadataLocal,
+  packageMetadataLocalExists,
+} from '@openupm/local-data';
 import {
   fetchAll,
   fetchOne,
@@ -24,6 +27,7 @@ import { createLogger } from '@openupm/server-common/build/log.js';
 
 import { addJob, getQueue } from '../queues/core.js';
 import { createJobId } from '../queues/jobId.js';
+import { cleanupMissingPackage } from '../jobs/cleanupMissingPackage.js';
 import { gitListRemoteTags, RemoteTag } from '../utils/git.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -66,7 +70,13 @@ export function toGitRepoUrl(url: string): string {
 
 export async function buildPackage(name: string): Promise<void> {
   const pkg = await loadPackageMetadataLocal(name);
-  if (!pkg) throw new Error(`package not found: ${name}`);
+  if (!pkg) {
+    if (!packageMetadataLocalExists(name)) {
+      await cleanupMissingPackage(name);
+      return;
+    }
+    throw new Error(`package not found: ${name}`);
+  }
 
   let remoteTags: RemoteTag[] = [];
   try {


### PR DESCRIPTION
## Summary

- Treat missing package metadata in `queue-pkg` as a cleanup condition instead of a worker failure.
- Add shared cleanup logic that removes deterministic failed package jobs, failed release records, and related release jobs while preserving successful/non-failed releases.
- Add `queue-cli cleanup-missing-packages --json` for scrubbing already-failed package jobs whose metadata was removed from local data.

## Validation

- `npx npm@10.9.3 -w @openupm/queue test`
- `npx npm@10.9.3 -w @openupm/queue run lint`
- `npx npm@10.9.3 -w @openupm/queue run build`
- `git diff --check`