### PR TITLE
[codex] add UnityNuGet signing cache blog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,22 @@
 
 - Docs commands run from `apps/docs`.
 - `npm run docs:build:limit` is the fastest full SSR build smoke test for the docs app.
+- New blog posts live at `apps/docs/docs/blog/<slug>/index.md`.
+- Add each new blog post to `BLOG_POSTS` in
+  `apps/docs/docs/.vuepress/blog.ts`; this drives the blog index, adjacent
+  post navigation, and RSS metadata.
+- Keep blog frontmatter aligned with the `BlogPost` metadata entry: `title`,
+  `author`, `date`, `readingTime`, and `description`/`excerpt` should describe
+  the same post.
+- Blog ordering tests should verify general ordering behavior, such as dates
+  sorted newest first, rather than hard-coding the current first or last post
+  unless the test is intentionally covering a specific legacy post.
+- For blog-only changes, run `npm run test -- blog.spec.ts` and
+  `npm run lint` from `apps/docs`, then run `npm run docs:build:limit`.
+- If `docs:build:limit` fails because
+  `node_modules/vuepress-plugin-openupm/build/index.js` is missing, first build
+  the local plugin dependency from the repo root with
+  `npm run build -- --filter=vuepress-plugin-openupm`.
 - The docs VuePress config contains Node 22 compatibility aliases for:
   - `date-fns/locale`
   - `@intlify/shared`

--- a/apps/docs/__tests__/blog.spec.ts
+++ b/apps/docs/__tests__/blog.spec.ts
@@ -28,12 +28,13 @@ describe("blog metadata", () => {
   });
 
   it("orders posts newest first", () => {
-    getBlogPostsNewestFirst()[0].slug.should.equal(
-      "signing-upm-packages-with-openupm",
-    );
-    getBlogPostsNewestFirst().at(-1)?.slug.should.equal(
-      "openupm-beta-is-now-available-a6665ff60c71",
-    );
+    const posts = getBlogPostsNewestFirst();
+
+    for (let i = 1; i < posts.length; i += 1) {
+      new Date(posts[i - 1].date).getTime().should.be.gte(
+        new Date(posts[i].date).getTime(),
+      );
+    }
   });
 
   it("returns previous and next posts in chronological order", () => {

--- a/apps/docs/docs/.vuepress/blog.ts
+++ b/apps/docs/docs/.vuepress/blog.ts
@@ -14,6 +14,15 @@ export const BLOG_RSS_PATH = "/blog/rss.xml";
 
 export const BLOG_POSTS: BlogPost[] = [
   {
+    title: "UnityNuGet Packages Are Now Code Signed",
+    slug: "unitynuget-packages-are-now-code-signed",
+    author: "Favo Yang",
+    date: "2026-05-13",
+    readingTime: "1 min read",
+    excerpt:
+      "UnityNuGet packages served through OpenUPM are now code signed, with daily cache verification to keep mirrored package versions current.",
+  },
+  {
     title: "Signing UPM Packages with OpenUPM",
     slug: "signing-upm-packages-with-openupm",
     featuredImage: "/images/blog-signing-upm-packages-code-sign.png",

--- a/apps/docs/docs/blog/unitynuget-packages-are-now-code-signed/index.md
+++ b/apps/docs/docs/blog/unitynuget-packages-are-now-code-signed/index.md
@@ -1,0 +1,45 @@
+---
+title: "UnityNuGet Packages Are Now Code Signed"
+author: "Favo Yang"
+date: "2026-05-13"
+readingTime: "1 min read"
+description: "UnityNuGet packages served through OpenUPM are now code signed, with daily cache verification to keep mirrored package versions current."
+editLink: false
+---
+# UnityNuGet Packages Are Now Code Signed
+
+<BlogPostMeta />
+
+UnityNuGet packages are now code signed. OpenUPM has synced the UnityNuGet
+cache, so packages resolved through OpenUPM can receive the newly signed
+versions.
+
+We have also deployed a daily job that compares the OpenUPM cache with the
+UnityNuGet registry versions. When a cached UnityNuGet package is out of date,
+the job updates the cached package so the OpenUPM mirror stays aligned on a
+daily basis.
+
+If your Unity project already downloaded an older `org.nuget` package, Unity
+may continue using the local cached copy. To force Unity to fetch the signed
+package again, close Unity, clean the Unity Package Manager cache, then reopen
+the project and run a force resolve.
+
+Unity documents the local cache locations here:
+
+```text
+https://docs.unity3d.com/Manual/upm-cache.html
+```
+
+In particular, check the global `npm` and `packages` cache folders, and remove
+cached entries for `package.openupm.com` or `unitynuget-registry.openupm.com`
+that contain `org.nuget` packages.
+
+If Unity still shows a signature mismatch after the local cache has been
+purged and the project has been resolved again, please create a new
+[OpenUPM issue](https://github.com/openupm/openupm/issues/new) and include the
+Unity version, package name, package version, registry URL, and the full
+mismatch message.
+
+Reference: [UnityNuGet issue #636](https://github.com/bdovaz/UnityNuGet/issues/636).
+
+<BlogPostNav />


### PR DESCRIPTION
## Summary

- Add a short blog post announcing that UnityNuGet packages served through OpenUPM are now code signed.
- Document the daily OpenUPM cache comparison/update job and local Unity cache cleanup guidance.
- Register the post in the docs blog metadata and improve the blog ordering test to assert general date ordering.
- Add repo-local agent notes for future blog post additions.

## Validation

- `npm run test -- blog.spec.ts`
- `npm run lint`
- `npm run docs:build:limit`