### PR TITLE
[codex] fix package download sparkline endpoint

### DIFF
--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -20,7 +20,7 @@ import { useDefaultStore } from "@/store";
 import { AdPlacementData } from "@openupm/types";
 import { getPackageMetadata } from "@openupm/common/build/utils.js";
 import { DownloadsRange, PackageInfo, PackageMetadataLocal, Packument, PackageRelease, PackageVersionViewEntry } from "@openupm/types";
-import { getMonthlyDownloadsUrl, getPackageInfoUrl, getPackumentUrl, getPackageRelatedPackagesPath, isPackageDetailPath, getPackageAdPlacementUrl } from '@openupm/common/build/urls.js';
+import { getMonthlyDownloadsRangeUrl, getPackageInfoUrl, getPackumentUrl, getPackageRelatedPackagesPath, isPackageDetailPath, getPackageAdPlacementUrl } from '@openupm/common/build/urls.js';
 import { fillMissingDates, isPackageExist, timeAgoFormat } from '@/utils';
 import UnityAssetAdPlacement from '@/components/UnityAssetAdPlacement.vue';
 import DonationSidebarAd from '@/components/DonationSidebarAd.vue';
@@ -346,7 +346,7 @@ const fetchAllData = async (): Promise<void> => {
 const fetchMonthlyDownloads = async (): Promise<void> => {
   try {
     const resp = await axios.get(
-      getMonthlyDownloadsUrl(packageMetadata.value.name),
+      getMonthlyDownloadsRangeUrl(packageMetadata.value.name),
       { headers: { Accept: "application/json" } }
     );
     const startDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);

--- a/packages/@openupm/common/__tests__/urls.spec.ts
+++ b/packages/@openupm/common/__tests__/urls.spec.ts
@@ -1,4 +1,6 @@
 import {
+  getMonthlyDownloadsRangeUrl,
+  getMonthlyDownloadsUrl,
   isPackageDetailPath,
   isPackageListPath,
   parsePackageNameFromPackageDetailPath,
@@ -87,5 +89,23 @@ describe('parsePackageNameFromPackageDetailPath', () => {
     const path = '/packages/';
     const packageName = parsePackageNameFromPackageDetailPath(path);
     expect(packageName).toBeNull();
+  });
+});
+
+describe('download count urls', () => {
+  it('should build the monthly downloads point url', () => {
+    const result = getMonthlyDownloadsUrl('com.example.package');
+
+    expect(result).toEqual(
+      'https://package.openupm.com/downloads/point/last-month/com.example.package',
+    );
+  });
+
+  it('should build the monthly downloads range url', () => {
+    const result = getMonthlyDownloadsRangeUrl('com.example.package');
+
+    expect(result).toEqual(
+      'https://package.openupm.com/downloads/range/last-month/com.example.package',
+    );
   });
 });

--- a/packages/@openupm/common/src/urls.ts
+++ b/packages/@openupm/common/src/urls.ts
@@ -220,6 +220,20 @@ export const getMonthlyDownloadsUrl = function (name: string): string {
 };
 
 /**
+ * Get monthly downloads range url for package name.
+ * @param name package name
+ */
+export const getMonthlyDownloadsRangeUrl = function (name: string): string {
+  return urlJoin(
+    getRegistryBaseUrl(),
+    'downloads',
+    'range',
+    'last-month',
+    name,
+  );
+};
+
+/**
  * Get openupm-cli repo url.
  * @returns openupm-cli repo url
  */


### PR DESCRIPTION
## Summary

- Add a dedicated monthly downloads range URL helper for the registry range endpoint.
- Update the package detail page to fetch daily download rows from `/downloads/range/last-month/<package>` for the sparkline and displayed monthly total.
- Add URL helper tests that distinguish the point endpoint from the range endpoint.

## Root Cause

The package detail client used the monthly downloads point endpoint, which returns a numeric `downloads` value. The chart code expects `downloads` to be an array of daily rows and passed that value into `fillMissingDates`, causing the chart path to fail and render an empty sparkline / zero-like state.

The package-extra job still correctly uses the point endpoint because it only stores the aggregate `dl30d` value.

## Validation

- `npm run test -- --filter=@openupm/common`
- `npm run build -- --filter=@openupm/common`
- `npm run test -- --filter=@openupm/docs`
- `npm run build -- --filter=@openupm/docs`
- `npm run lint -- --filter=@openupm/common --filter=@openupm/docs`
- `npm run build -- --filter=vuepress-plugin-openupm`
- `npm run docs:build:limit`

Live API spot check for `com.google.external-dependency-manager`: range endpoint returned 30 daily rows totaling `84389`.