### PR TITLE
[codex] add public queue status page

### DIFF
--- a/apps/docs/__tests__/vue/queueStatusView.spec.ts
+++ b/apps/docs/__tests__/vue/queueStatusView.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "vitest";
+import chai from "chai";
+chai.should();
+
+import {
+  PublicQueueStatus,
+  formatDuration,
+  formatRelativeTime,
+  isQueueStatusEmpty,
+  packageUrl,
+} from "@/queueStatusView";
+
+function createStatus(
+  overrides: Partial<PublicQueueStatus> = {},
+): PublicQueueStatus {
+  return {
+    generatedAt: "2026-05-14T10:00:00.000Z",
+    cache: { state: "fresh", ttlSeconds: 10 },
+    summary: { state: "healthy", message: "ok" },
+    packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
+    releaseQueue: {
+      waiting: 0,
+      active: 0,
+      delayed: 0,
+      failed: 0,
+      workers: 0,
+      oldestWaitingMs: null,
+      activeJobs: [],
+      waitingJobs: [],
+    },
+    recentSuccessfulReleases: [],
+    recentFailedReleases: [],
+    retainedFailedReleaseJobs: [],
+    ...overrides,
+  };
+}
+
+describe("@/queueStatusView", () => {
+  it("identifies empty and populated queue states", () => {
+    isQueueStatusEmpty(createStatus()).should.equal(true);
+    isQueueStatusEmpty(
+      createStatus({
+        releaseQueue: {
+          waiting: 1,
+          active: 0,
+          delayed: 0,
+          failed: 0,
+          workers: 0,
+          oldestWaitingMs: 60_000,
+          activeJobs: [],
+          waitingJobs: [],
+        },
+      }),
+    ).should.equal(false);
+  });
+
+  it("formats loading table times and durations compactly", () => {
+    const now = new Date("2026-05-14T10:00:00.000Z").getTime();
+    formatRelativeTime("2026-05-14T09:55:00.000Z", now).should.equal("5m ago");
+    formatRelativeTime("2026-05-14T07:45:00.000Z", now).should.equal(
+      "2h 15m ago",
+    );
+    formatDuration(2 * 60 * 60 * 1000 + 14 * 60 * 1000).should.equal("2h 14m");
+  });
+
+  it("builds package links with encoded names", () => {
+    packageUrl("com.example.package").should.equal(
+      "/packages/com.example.package/",
+    );
+    packageUrl("com.example/package").should.equal(
+      "/packages/com.example%2Fpackage/",
+    );
+  });
+
+  it("represents api error state as a non-empty absence of data", () => {
+    const status = createStatus({
+      summary: {
+        state: "degraded",
+        message: "Queue status is temporarily unavailable.",
+      },
+    });
+    status.summary.state.should.equal("degraded");
+    isQueueStatusEmpty(status).should.equal(true);
+  });
+});

--- a/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
@@ -1,0 +1,385 @@
+<template>
+  <main class="queue-status">
+    <header class="queue-status__header">
+      <div>
+        <h1>Queue Status</h1>
+        <p v-if="status">{{ status.summary.message }}</p>
+        <p v-else-if="loading">Loading public queue status...</p>
+        <p v-else-if="error">{{ error }}</p>
+      </div>
+      <div v-if="status" class="queue-status__meta">
+        <span :class="['queue-status__state', `is-${status.summary.state}`]">
+          {{ status.summary.state }}
+        </span>
+        <span>Updated {{ formatRelativeTime(status.generatedAt, nowMs) }}</span>
+        <span
+          >Cache {{ status.cache.state }}, {{ status.cache.ttlSeconds }}s</span
+        >
+      </div>
+    </header>
+
+    <div v-if="loading" class="queue-status__notice">Loading...</div>
+    <div v-else-if="error" class="queue-status__notice is-error">
+      {{ error }}
+    </div>
+    <div
+      v-else-if="status && isQueueStatusEmpty(status)"
+      class="queue-status__notice"
+    >
+      No active, waiting, delayed, failed, or recent release records are
+      visible.
+    </div>
+
+    <template v-if="status">
+      <section class="queue-status__section">
+        <div class="queue-status__section-title">
+          <h2>Package Scan Queue</h2>
+        </div>
+        <div class="queue-status__metrics">
+          <div>
+            <span>Active</span><strong>{{ status.packageQueue.active }}</strong>
+          </div>
+          <div>
+            <span>Failed Jobs</span
+            ><strong>{{ status.packageQueue.failed }}</strong>
+          </div>
+          <div>
+            <span>Workers</span
+            ><strong>{{ status.packageQueue.workers }}</strong>
+          </div>
+        </div>
+      </section>
+
+      <QueueStatusTable
+        title="Failed Package Scan Jobs"
+        :columns="['Package', 'Failed', 'Attempts', 'Last Error']"
+        :empty="status.packageQueue.failedJobs.length === 0"
+      >
+        <tr
+          v-for="job in status.packageQueue.failedJobs"
+          :key="`pkg-${job.package}`"
+        >
+          <td>
+            <a :href="packageUrl(job.package)">{{ job.package }}</a>
+          </td>
+          <td>
+            {{ formatRelativeTime(job.finishedAt || job.timestamp, nowMs) }}
+          </td>
+          <td>{{ job.attempts }}/{{ job.maxAttempts }}</td>
+          <td class="queue-status__error">{{ job.error || "" }}</td>
+        </tr>
+      </QueueStatusTable>
+
+      <section class="queue-status__section">
+        <div class="queue-status__section-title">
+          <h2>Release Build Queue</h2>
+        </div>
+        <div class="queue-status__metrics">
+          <div>
+            <span>Waiting</span
+            ><strong>{{ status.releaseQueue.waiting }}</strong>
+          </div>
+          <div>
+            <span>Active</span><strong>{{ status.releaseQueue.active }}</strong>
+          </div>
+          <div>
+            <span>Delayed</span
+            ><strong>{{ status.releaseQueue.delayed }}</strong>
+          </div>
+          <div>
+            <span>Failed Jobs</span
+            ><strong>{{ status.releaseQueue.failed }}</strong>
+          </div>
+          <div>
+            <span>Workers</span
+            ><strong>{{ status.releaseQueue.workers }}</strong>
+          </div>
+          <div>
+            <span>Oldest Waiting</span>
+            <strong>{{
+              formatDuration(status.releaseQueue.oldestWaitingMs) || "-"
+            }}</strong>
+          </div>
+        </div>
+      </section>
+
+      <QueueStatusTable
+        title="Active Release Builds"
+        :columns="['Package', 'Version', 'Age', 'Attempts']"
+        :empty="status.releaseQueue.activeJobs.length === 0"
+      >
+        <tr
+          v-for="job in status.releaseQueue.activeJobs"
+          :key="`active-${job.package}-${job.version}`"
+        >
+          <td>
+            <a :href="packageUrl(job.package)">{{ job.package }}</a>
+          </td>
+          <td>{{ job.version }}</td>
+          <td>
+            {{ formatRelativeTime(job.processedAt || job.timestamp, nowMs) }}
+          </td>
+          <td>{{ job.attempts }}/{{ job.maxAttempts }}</td>
+        </tr>
+      </QueueStatusTable>
+
+      <QueueStatusTable
+        title="Waiting Release Builds"
+        :columns="['Package', 'Version', 'Queued']"
+        :empty="status.releaseQueue.waitingJobs.length === 0"
+      >
+        <tr
+          v-for="job in status.releaseQueue.waitingJobs"
+          :key="`waiting-${job.package}-${job.version}`"
+        >
+          <td>
+            <a :href="packageUrl(job.package)">{{ job.package }}</a>
+          </td>
+          <td>{{ job.version }}</td>
+          <td>{{ formatRelativeTime(job.timestamp, nowMs) }}</td>
+        </tr>
+      </QueueStatusTable>
+
+      <QueueStatusTable
+        title="Recent Successful Releases"
+        :columns="['Time', 'Package', 'Version', 'Source', 'Signed']"
+        :empty="status.recentSuccessfulReleases.length === 0"
+      >
+        <tr
+          v-for="release in status.recentSuccessfulReleases"
+          :key="`success-${release.package}-${release.version}`"
+        >
+          <td>{{ formatRelativeTime(release.updatedAt, nowMs) }}</td>
+          <td>
+            <a :href="packageUrl(release.package)">{{ release.package }}</a>
+          </td>
+          <td>{{ release.version }}</td>
+          <td>{{ release.source }}</td>
+          <td>{{ release.signed ? "yes" : "no" }}</td>
+        </tr>
+      </QueueStatusTable>
+
+      <QueueStatusTable
+        title="Recent Failed Releases"
+        :columns="['Time', 'Package', 'Version', 'Reason', 'Retryable']"
+        :empty="status.recentFailedReleases.length === 0"
+      >
+        <tr
+          v-for="release in status.recentFailedReleases"
+          :key="`failed-release-${release.package}-${release.version}`"
+        >
+          <td>{{ formatRelativeTime(release.updatedAt, nowMs) }}</td>
+          <td>
+            <a :href="packageUrl(release.package)">{{ release.package }}</a>
+          </td>
+          <td>{{ release.version }}</td>
+          <td>{{ release.reason }}</td>
+          <td>{{ release.retryable ? "yes" : "no" }}</td>
+        </tr>
+      </QueueStatusTable>
+
+      <QueueStatusTable
+        title="Retained Failed Release Queue Jobs"
+        :columns="['Package', 'Version', 'Failed', 'Attempts', 'Last Error']"
+        :empty="status.retainedFailedReleaseJobs.length === 0"
+      >
+        <tr
+          v-for="job in status.retainedFailedReleaseJobs"
+          :key="`failed-job-${job.package}-${job.version}`"
+        >
+          <td>
+            <a :href="packageUrl(job.package)">{{ job.package }}</a>
+          </td>
+          <td>{{ job.version }}</td>
+          <td>
+            {{ formatRelativeTime(job.finishedAt || job.timestamp, nowMs) }}
+          </td>
+          <td>{{ job.attempts }}/{{ job.maxAttempts }}</td>
+          <td class="queue-status__error">{{ job.error || "" }}</td>
+        </tr>
+      </QueueStatusTable>
+    </template>
+  </main>
+</template>
+
+<script setup lang="ts">
+import axios from "axios";
+import urlJoin from "url-join";
+import { onMounted, ref } from "vue";
+import { getAPIBaseUrl } from "@openupm/common/build/urls.js";
+import {
+  PublicQueueStatus,
+  formatDuration,
+  formatRelativeTime,
+  isQueueStatusEmpty,
+  packageUrl,
+} from "../queueStatusView";
+import QueueStatusTable from "./QueueStatusTable.vue";
+
+const loading = ref(true);
+const error = ref("");
+const status = ref<PublicQueueStatus | null>(null);
+const nowMs = ref(Date.now());
+
+async function fetchQueueStatus(): Promise<void> {
+  loading.value = true;
+  error.value = "";
+  try {
+    const response = await axios.get(
+      urlJoin(getAPIBaseUrl(), "/queue/status"),
+      {
+        headers: { Accept: "application/json" },
+      },
+    );
+    status.value = response.data as PublicQueueStatus;
+    nowMs.value = Date.now();
+  } catch {
+    status.value = null;
+    error.value = "Queue status is temporarily unavailable.";
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(fetchQueueStatus);
+</script>
+
+<style lang="scss">
+.queue-status {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+  color: #1f2933;
+}
+
+.queue-status__header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  border-bottom: 1px solid #d9e2ec;
+  padding-bottom: 1rem;
+
+  h1 {
+    margin: 0 0 0.35rem;
+    font-size: 2rem;
+    line-height: 1.15;
+  }
+
+  p {
+    margin: 0;
+    color: #52606d;
+  }
+}
+
+.queue-status__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  color: #52606d;
+  font-size: 0.9rem;
+}
+
+.queue-status__state {
+  color: #102a43;
+  font-weight: 700;
+  text-transform: uppercase;
+
+  &.is-healthy {
+    color: #0b7285;
+  }
+
+  &.is-backlog {
+    color: #8d6b00;
+  }
+
+  &.is-degraded {
+    color: #b42318;
+  }
+}
+
+.queue-status__notice {
+  margin: 1rem 0;
+  border: 1px solid #bcccdc;
+  padding: 0.75rem 1rem;
+  background: #f8fafc;
+  color: #334e68;
+
+  &.is-error {
+    border-color: #f1aeb5;
+    background: #fff5f5;
+    color: #b42318;
+  }
+}
+
+.queue-status__section {
+  margin-top: 1.5rem;
+  border-top: 1px solid #d9e2ec;
+  padding-top: 1rem;
+}
+
+.queue-status__section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+    line-height: 1.2;
+  }
+}
+
+.queue-status__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  border: 1px solid #d9e2ec;
+
+  div {
+    display: grid;
+    gap: 0.2rem;
+    border-right: 1px solid #d9e2ec;
+    padding: 0.75rem;
+
+    &:last-child {
+      border-right: 0;
+    }
+  }
+
+  span {
+    color: #627d98;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+  }
+
+  strong {
+    font-size: 1.35rem;
+    line-height: 1.1;
+  }
+}
+
+.queue-status__error {
+  max-width: 34rem;
+  white-space: normal;
+}
+
+@media (max-width: 720px) {
+  .queue-status__header {
+    display: block;
+  }
+
+  .queue-status__meta {
+    justify-content: flex-start;
+    margin-top: 0.75rem;
+  }
+
+  .queue-status__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+
+    div {
+      border-bottom: 1px solid #d9e2ec;
+    }
+  }
+}
+</style>

--- a/apps/docs/docs/.vuepress/components/QueueStatusTable.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusTable.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="queue-status-table">
+    <h2>{{ title }}</h2>
+    <div class="queue-status-table__wrap">
+      <table>
+        <thead>
+          <tr>
+            <th v-for="column in columns" :key="column">{{ column }}</th>
+          </tr>
+        </thead>
+        <tbody v-if="!empty">
+          <slot />
+        </tbody>
+        <tbody v-else>
+          <tr>
+            <td :colspan="columns.length" class="queue-status-table__empty">
+              No rows
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title: string;
+  columns: string[];
+  empty: boolean;
+}>();
+</script>
+
+<style lang="scss">
+.queue-status-table {
+  margin-top: 1.5rem;
+  border-top: 1px solid #d9e2ec;
+  padding-top: 1rem;
+
+  h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+    line-height: 1.2;
+  }
+}
+
+.queue-status-table__wrap {
+  overflow-x: auto;
+  border: 1px solid #d9e2ec;
+}
+
+.queue-status-table table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.queue-status-table th,
+.queue-status-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.55rem 0.65rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.queue-status-table th {
+  background: #f0f4f8;
+  color: #52606d;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+
+.queue-status-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.queue-status-table a {
+  overflow-wrap: anywhere;
+  font-weight: 600;
+}
+
+.queue-status-table__empty {
+  color: #627d98;
+}
+</style>

--- a/apps/docs/docs/.vuepress/queueStatusView.ts
+++ b/apps/docs/docs/.vuepress/queueStatusView.ts
@@ -1,0 +1,110 @@
+export interface PublicQueueJobSummary {
+  package: string;
+  version?: string;
+  state: string;
+  timestamp?: string;
+  processedAt?: string;
+  finishedAt?: string;
+  attempts: number;
+  maxAttempts: number;
+  error?: string;
+}
+
+export interface PublicReleaseSummary {
+  package: string;
+  version: string;
+  state: string;
+  reason: string;
+  updatedAt: string;
+  source: "git" | "githubRelease";
+  signed: boolean;
+  retryable?: boolean;
+}
+
+export interface PublicQueueStatus {
+  generatedAt: string;
+  cache: {
+    state: "fresh" | "stale";
+    ttlSeconds: number;
+  };
+  summary: {
+    state: "healthy" | "backlog" | "degraded";
+    message: string;
+  };
+  packageQueue: {
+    active: number;
+    failed: number;
+    workers: number;
+    failedJobs: PublicQueueJobSummary[];
+  };
+  releaseQueue: {
+    waiting: number;
+    active: number;
+    delayed: number;
+    failed: number;
+    workers: number;
+    oldestWaitingMs: number | null;
+    activeJobs: PublicQueueJobSummary[];
+    waitingJobs: PublicQueueJobSummary[];
+  };
+  recentSuccessfulReleases: PublicReleaseSummary[];
+  recentFailedReleases: PublicReleaseSummary[];
+  retainedFailedReleaseJobs: PublicQueueJobSummary[];
+}
+
+export function isQueueStatusEmpty(status: PublicQueueStatus): boolean {
+  return (
+    status.packageQueue.active === 0 &&
+    status.packageQueue.failed === 0 &&
+    status.releaseQueue.waiting === 0 &&
+    status.releaseQueue.active === 0 &&
+    status.releaseQueue.delayed === 0 &&
+    status.releaseQueue.failed === 0 &&
+    status.packageQueue.failedJobs.length === 0 &&
+    status.releaseQueue.activeJobs.length === 0 &&
+    status.releaseQueue.waitingJobs.length === 0 &&
+    status.recentSuccessfulReleases.length === 0 &&
+    status.recentFailedReleases.length === 0 &&
+    status.retainedFailedReleaseJobs.length === 0
+  );
+}
+
+export function formatRelativeTime(
+  value: string | undefined,
+  nowMs = Date.now(),
+): string {
+  if (!value) return "";
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return "";
+  const elapsed = Math.max(0, nowMs - timestamp);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (elapsed < minute) return "just now";
+  if (elapsed < hour) return `${Math.floor(elapsed / minute)}m ago`;
+  if (elapsed < day) {
+    const hours = Math.floor(elapsed / hour);
+    const minutes = Math.floor((elapsed % hour) / minute);
+    return minutes > 0 ? `${hours}h ${minutes}m ago` : `${hours}h ago`;
+  }
+  return `${Math.floor(elapsed / day)}d ago`;
+}
+
+export function formatDuration(value: number | null): string {
+  if (value === null) return "";
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (value < minute) return "<1m";
+  if (value < hour) return `${Math.floor(value / minute)}m`;
+  if (value < day) {
+    const hours = Math.floor(value / hour);
+    const minutes = Math.floor((value % hour) / minute);
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${Math.floor(value / day)}d`;
+}
+
+export function packageUrl(packageName: string): string {
+  return `/packages/${encodeURIComponent(packageName)}/`;
+}

--- a/apps/docs/docs/queue/index.md
+++ b/apps/docs/docs/queue/index.md
@@ -1,0 +1,7 @@
+---
+layout: Layout
+title: Queue Status
+description: Public OpenUPM package scan and release build queue status.
+---
+
+<QueueStatusPage />

--- a/apps/web/__tests__/routers/queueStatus.spec.ts
+++ b/apps/web/__tests__/routers/queueStatus.spec.ts
@@ -1,0 +1,96 @@
+import request from 'supertest';
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  clear: vi.fn(),
+}));
+
+vi.mock('../../src/status/queueStatus.js', () => ({
+  buildPublicQueueStatus: vi.fn(),
+  getQueue: vi.fn(),
+  createQueueStatusCache: vi.fn(() => ({
+    get: mocks.get,
+    clear: mocks.clear,
+  })),
+}));
+
+const { app } = await import('../../src/apiServer.js');
+
+describe('queue status router', () => {
+  beforeEach(async () => {
+    await app.ready();
+  });
+
+  afterEach(() => {
+    mocks.get.mockReset();
+    mocks.clear.mockReset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns the public queue status shape', async () => {
+    mocks.get.mockResolvedValue({
+      generatedAt: '2026-05-14T10:42:00.000Z',
+      cache: { state: 'fresh', ttlSeconds: 10 },
+      summary: { state: 'healthy', message: 'ok' },
+      packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
+      releaseQueue: {
+        waiting: 0,
+        active: 0,
+        delayed: 0,
+        failed: 0,
+        workers: 0,
+        oldestWaitingMs: null,
+        activeJobs: [],
+        waitingJobs: [],
+      },
+      recentSuccessfulReleases: [],
+      recentFailedReleases: [],
+      retainedFailedReleaseJobs: [],
+    });
+
+    const response = await request(app.server)
+      .get('/queue/status')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect('Content-Type', /json/);
+
+    expect(response.body).toMatchObject({
+      generatedAt: '2026-05-14T10:42:00.000Z',
+      cache: { state: 'fresh', ttlSeconds: 10 },
+      packageQueue: { failedJobs: [] },
+      releaseQueue: { activeJobs: [], waitingJobs: [] },
+      recentSuccessfulReleases: [],
+      recentFailedReleases: [],
+      retainedFailedReleaseJobs: [],
+    });
+  });
+
+  it('returns a sanitized 503 response when status generation fails', async () => {
+    mocks.get.mockRejectedValue(
+      new Error('redis connection failed /srv/private'),
+    );
+
+    const response = await request(app.server)
+      .get('/queue/status')
+      .set('Accept', 'application/json')
+      .expect(503)
+      .expect('Content-Type', /json/);
+
+    expect(response.body).toEqual({
+      error: 'QueueStatusUnavailable',
+      message: 'Queue status is temporarily unavailable.',
+    });
+  });
+});

--- a/apps/web/__tests__/status/queueStatus.spec.ts
+++ b/apps/web/__tests__/status/queueStatus.spec.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ReleaseErrorCode, ReleaseState } from '@openupm/types';
+
+import {
+  buildPublicQueueStatus,
+  createQueueStatusCache,
+  parseReleaseJobIdentity,
+} from '../../src/status/queueStatus.js';
+
+function createJob(params: {
+  id?: string;
+  data?: unknown;
+  state?: string;
+  timestamp?: number;
+  processedOn?: number;
+  finishedOn?: number;
+  attemptsMade?: number;
+  attempts?: number;
+  failedReason?: string;
+}) {
+  return {
+    id: params.id,
+    name: 'job',
+    data: params.data ?? {},
+    attemptsMade: params.attemptsMade ?? 0,
+    opts: { attempts: params.attempts ?? 3 },
+    timestamp: params.timestamp ?? 1_700_000_000_000,
+    processedOn: params.processedOn,
+    finishedOn: params.finishedOn,
+    failedReason: params.failedReason,
+    getState: vi.fn(async () => params.state ?? 'waiting'),
+  };
+}
+
+function createQueue(params: {
+  counts: Record<string, number>;
+  workers?: unknown[];
+  jobs?: Record<string, ReturnType<typeof createJob>[]>;
+}) {
+  return {
+    getJobCounts: vi.fn(async (...types: string[]) => {
+      return Object.fromEntries(
+        types.map((type) => [type, params.counts[type] ?? 0]),
+      );
+    }),
+    getWorkers: vi.fn(async () => params.workers ?? []),
+    getJobs: vi.fn(async (types: string | string[], _start, end, asc) => {
+      const names = Array.isArray(types) ? types : [types];
+      const jobs = names.flatMap((name) => params.jobs?.[name] ?? []);
+      const sorted = asc
+        ? [...jobs].sort((a, b) => a.timestamp - b.timestamp)
+        : [...jobs].sort((a, b) => b.timestamp - a.timestamp);
+      return sorted.slice(0, (end ?? sorted.length - 1) + 1);
+    }),
+  };
+}
+
+describe('parseReleaseJobIdentity', () => {
+  it('parses package and version from job data first', () => {
+    expect(
+      parseReleaseJobIdentity({
+        id: 'build-rel|wrong|0.0.1',
+        data: { packageName: 'com.example.runtime', version: '1.2.3' },
+      }),
+    ).toEqual({ packageName: 'com.example.runtime', version: '1.2.3' });
+  });
+
+  it('parses deterministic encoded release job ids', () => {
+    expect(
+      parseReleaseJobIdentity({
+        id: 'build-rel|com.example.camera|1.0.0-preview%2Bbuild',
+        data: {},
+      }),
+    ).toEqual({
+      packageName: 'com.example.camera',
+      version: '1.0.0-preview+build',
+    });
+  });
+});
+
+describe('buildPublicQueueStatus', () => {
+  it('shapes and sanitizes the public queue response', async () => {
+    const now = 1_700_000_120_000;
+    const packageQueue = createQueue({
+      counts: { active: 4, failed: 1, waiting: 5000, delayed: 1000 },
+      workers: [{ private: 'worker-host' }],
+      jobs: {
+        failed: [
+          createJob({
+            id: 'build-pkg|com.bad.repo',
+            state: 'failed',
+            attemptsMade: 3,
+            failedReason:
+              'git ls-remote failed\nstack trace with /srv/private/path',
+          }),
+        ],
+      },
+    });
+    const releaseQueue = createQueue({
+      counts: { waiting: 2, active: 1, delayed: 3, failed: 1 },
+      workers: [{ name: 'worker' }, { name: 'worker2' }],
+      jobs: {
+        active: [
+          createJob({
+            id: 'build-rel|com.active.pkg|2.0.0',
+            state: 'active',
+            timestamp: now - 10_000,
+            attemptsMade: 1,
+          }),
+        ],
+        waiting: [
+          createJob({
+            id: 'build-rel|com.waiting.old|1.0.0',
+            state: 'waiting',
+            timestamp: now - 60_000,
+          }),
+          createJob({
+            id: 'build-rel|com.waiting.new|1.0.1',
+            state: 'waiting',
+            timestamp: now - 10_000,
+          }),
+        ],
+        failed: [
+          createJob({
+            id: 'build-rel|com.failed.pkg|3.0.0',
+            state: 'failed',
+            finishedOn: now - 5_000,
+            attemptsMade: 3,
+            failedReason: 'build failed because package.json was invalid',
+          }),
+        ],
+      },
+    });
+
+    const status = await buildPublicQueueStatus(
+      {
+        packageQueue,
+        releaseQueue,
+        getRecentSuccessfulReleases: async () => [
+          {
+            packageName: 'com.success.pkg',
+            version: '1.0.0',
+            state: ReleaseState.Succeeded,
+            reason: ReleaseErrorCode.None,
+            commit: '',
+            tag: '',
+            buildId: '',
+            createdAt: now,
+            updatedAt: now,
+            source: 'githubRelease',
+            signed: true,
+          },
+        ],
+        getRecentFailedReleases: async () => [
+          {
+            packageName: 'com.retry.pkg',
+            version: '1.0.0',
+            state: ReleaseState.Failed,
+            reason: ReleaseErrorCode.BuildTimeout,
+            commit: '',
+            tag: '',
+            buildId: '',
+            createdAt: now,
+            updatedAt: now - 1,
+            source: 'git',
+            signed: false,
+          },
+          {
+            packageName: 'com.final.pkg',
+            version: '1.0.0',
+            state: ReleaseState.Failed,
+            reason: ReleaseErrorCode.VersionConflict,
+            commit: '',
+            tag: '',
+            buildId: '',
+            createdAt: now,
+            updatedAt: now - 2,
+            source: 'git',
+            signed: false,
+          },
+        ],
+        now: () => now,
+      },
+      { jobLimit: 20, releaseLimit: 20, ttlSeconds: 10 },
+    );
+
+    expect(status.generatedAt).toEqual(new Date(now).toISOString());
+    expect(status.packageQueue).toMatchObject({
+      active: 4,
+      failed: 1,
+      workers: 1,
+    });
+    expect(status.packageQueue).not.toHaveProperty('waiting');
+    expect(status.packageQueue.failedJobs[0]).toMatchObject({
+      package: 'com.bad.repo',
+      attempts: 3,
+      maxAttempts: 3,
+      error: 'git ls-remote failed',
+    });
+    expect(status.releaseQueue.waitingJobs.map((job) => job.package)).toEqual([
+      'com.waiting.old',
+      'com.waiting.new',
+    ]);
+    expect(status.releaseQueue.oldestWaitingMs).toEqual(60_000);
+    expect(status.recentSuccessfulReleases[0]).toMatchObject({
+      package: 'com.success.pkg',
+      source: 'githubRelease',
+      signed: true,
+    });
+    expect(
+      status.recentFailedReleases.map((release) => release.retryable),
+    ).toEqual([true, false]);
+    expect(JSON.stringify(status)).not.toContain('/srv/private/path');
+  });
+
+  it('limits job and release rows', async () => {
+    const packageQueue = createQueue({
+      counts: { active: 0, failed: 3 },
+      jobs: {
+        failed: [
+          createJob({ id: 'build-pkg|com.one' }),
+          createJob({ id: 'build-pkg|com.two' }),
+          createJob({ id: 'build-pkg|com.three' }),
+        ],
+      },
+    });
+    const releaseQueue = createQueue({
+      counts: { waiting: 0, active: 0, delayed: 0, failed: 0 },
+    });
+
+    const status = await buildPublicQueueStatus(
+      {
+        packageQueue,
+        releaseQueue,
+        getRecentSuccessfulReleases: async (limit) =>
+          Array.from({ length: limit + 1 }, (_, index) => ({
+            packageName: `com.pkg.${index}`,
+            version: '1.0.0',
+            state: ReleaseState.Succeeded,
+            reason: ReleaseErrorCode.None,
+            commit: '',
+            tag: '',
+            buildId: '',
+            createdAt: index,
+            updatedAt: index,
+          })),
+        getRecentFailedReleases: async () => [],
+      },
+      { jobLimit: 2, releaseLimit: 2 },
+    );
+
+    expect(status.packageQueue.failedJobs).toHaveLength(2);
+    expect(status.recentSuccessfulReleases).toHaveLength(2);
+    expect(packageQueue.getJobs).toHaveBeenCalledWith(['failed'], 0, 1, false);
+  });
+});
+
+describe('createQueueStatusCache', () => {
+  it('single-flights the first refresh and returns stale data while refreshing', async () => {
+    let now = 0;
+    let resolveRefresh: (value: unknown) => void = () => undefined;
+    const refresh = vi.fn(async () => {
+      await new Promise((resolve) => {
+        resolveRefresh = resolve;
+      });
+      return {
+        generatedAt: new Date(now).toISOString(),
+        cache: { state: 'fresh' as const, ttlSeconds: 10 },
+        summary: { state: 'healthy' as const, message: 'ok' },
+        packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
+        releaseQueue: {
+          waiting: 0,
+          active: 0,
+          delayed: 0,
+          failed: 0,
+          workers: 0,
+          oldestWaitingMs: null,
+          activeJobs: [],
+          waitingJobs: [],
+        },
+        recentSuccessfulReleases: [],
+        recentFailedReleases: [],
+        retainedFailedReleaseJobs: [],
+      };
+    });
+    const cache = createQueueStatusCache(refresh, 10, () => now);
+
+    const first = cache.get();
+    const second = cache.get();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    resolveRefresh(undefined);
+    await expect(first).resolves.toMatchObject({ cache: { state: 'fresh' } });
+    await expect(second).resolves.toMatchObject({ cache: { state: 'fresh' } });
+
+    now = 11_000;
+    const stale = await cache.get();
+    expect(stale.cache.state).toEqual('stale');
+    expect(refresh).toHaveBeenCalledTimes(2);
+    resolveRefresh(undefined);
+  });
+
+  it('serves stale data when a background refresh fails', async () => {
+    let now = 0;
+    const refresh = vi
+      .fn()
+      .mockResolvedValueOnce({
+        generatedAt: new Date(now).toISOString(),
+        cache: { state: 'fresh' as const, ttlSeconds: 10 },
+        summary: { state: 'healthy' as const, message: 'ok' },
+        packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
+        releaseQueue: {
+          waiting: 0,
+          active: 0,
+          delayed: 0,
+          failed: 0,
+          workers: 0,
+          oldestWaitingMs: null,
+          activeJobs: [],
+          waitingJobs: [],
+        },
+        recentSuccessfulReleases: [],
+        recentFailedReleases: [],
+        retainedFailedReleaseJobs: [],
+      })
+      .mockRejectedValueOnce(new Error('redis unavailable'));
+    const cache = createQueueStatusCache(refresh, 10, () => now);
+
+    await expect(cache.get()).resolves.toMatchObject({
+      cache: { state: 'fresh' },
+    });
+    now = 11_000;
+    await expect(cache.get()).resolves.toMatchObject({
+      cache: { state: 'stale' },
+    });
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@fastify/cors": "^8.5.0",
     "@openupm/ads": "*",
     "@openupm/server-common": "*",
+    "bullmq": "^5.58.5",
     "config": "^4.4.1",
     "dotenv-flow": "^4.0.1",
     "fastify": "^4.25.2",

--- a/apps/web/src/apiServer.ts
+++ b/apps/web/src/apiServer.ts
@@ -6,6 +6,7 @@ import adsRouter from './routers/ads.js';
 import feedsRouter from './routers/feeds.js';
 import siteInfoRouter from './routers/siteInfo.js';
 import packagesRouter from './routers/packages.js';
+import queueStatusRouter from './routers/queueStatus.js';
 
 // Touch the redis.client property to prepare the connection as soon as possible
 redis.client;
@@ -36,3 +37,4 @@ adsRouter(app);
 feedsRouter(app);
 siteInfoRouter(app);
 packagesRouter(app);
+queueStatusRouter(app);

--- a/apps/web/src/routers/queueStatus.ts
+++ b/apps/web/src/routers/queueStatus.ts
@@ -1,0 +1,37 @@
+import { FastifyInstance } from 'fastify';
+
+import {
+  buildPublicQueueStatus,
+  createQueueStatusCache,
+  getQueue,
+} from '../status/queueStatus.js';
+
+const CACHE_TTL_SECONDS = 10;
+
+const queueStatusCache = createQueueStatusCache(async (cacheState) => {
+  return await buildPublicQueueStatus(
+    {
+      packageQueue: getQueue('pkg'),
+      releaseQueue: getQueue('rel'),
+    },
+    { cacheState, ttlSeconds: CACHE_TTL_SECONDS },
+  );
+}, CACHE_TTL_SECONDS);
+
+export function clearQueueStatusCache(): void {
+  queueStatusCache.clear();
+}
+
+export default function router(server: FastifyInstance): void {
+  server.get('/queue/status', async function (_request, reply) {
+    try {
+      return await queueStatusCache.get();
+    } catch {
+      reply.code(503);
+      return {
+        error: 'QueueStatusUnavailable',
+        message: 'Queue status is temporarily unavailable.',
+      };
+    }
+  });
+}

--- a/apps/web/src/status/queueStatus.ts
+++ b/apps/web/src/status/queueStatus.ts
@@ -1,0 +1,443 @@
+import configRaw from 'config';
+import { Job, JobType, Queue } from 'bullmq';
+import {
+  ReleaseErrorCode,
+  ReleaseModel,
+  ReleaseState,
+  RetryableReleaseErrorCodes,
+} from '@openupm/types';
+import { fetchRecentReleases } from '@openupm/server-common/build/models/release.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config = configRaw as any;
+
+export interface PublicQueueJobSummary {
+  package: string;
+  version?: string;
+  state: string;
+  timestamp?: string;
+  processedAt?: string;
+  finishedAt?: string;
+  attempts: number;
+  maxAttempts: number;
+  error?: string;
+}
+
+export interface PublicReleaseSummary {
+  package: string;
+  version: string;
+  state: string;
+  reason: string;
+  updatedAt: string;
+  source: 'git' | 'githubRelease';
+  signed: boolean;
+  retryable?: boolean;
+}
+
+export interface PublicQueueStatus {
+  generatedAt: string;
+  cache: {
+    state: 'fresh' | 'stale';
+    ttlSeconds: number;
+  };
+  summary: {
+    state: 'healthy' | 'backlog' | 'degraded';
+    message: string;
+  };
+  packageQueue: {
+    active: number;
+    failed: number;
+    workers: number;
+    failedJobs: PublicQueueJobSummary[];
+  };
+  releaseQueue: {
+    waiting: number;
+    active: number;
+    delayed: number;
+    failed: number;
+    workers: number;
+    oldestWaitingMs: number | null;
+    activeJobs: PublicQueueJobSummary[];
+    waitingJobs: PublicQueueJobSummary[];
+  };
+  recentSuccessfulReleases: PublicReleaseSummary[];
+  recentFailedReleases: PublicReleaseSummary[];
+  retainedFailedReleaseJobs: PublicQueueJobSummary[];
+}
+
+interface QueueLike {
+  getJobCounts: (...types: JobType[]) => Promise<Record<string, number>>;
+  getWorkers: () => Promise<unknown[]>;
+  getJobs: (
+    types: JobType[] | JobType,
+    start?: number,
+    end?: number,
+    asc?: boolean,
+  ) => Promise<Array<Job | QueueJobLike>>;
+}
+
+interface QueueJobLike {
+  id?: string | number;
+  name: string;
+  data: unknown;
+  attemptsMade: number;
+  opts?: { attempts?: number };
+  timestamp: number;
+  processedOn?: number;
+  finishedOn?: number;
+  failedReason?: string;
+  getState: () => Promise<string>;
+}
+
+export interface QueueStatusSources {
+  packageQueue: QueueLike;
+  releaseQueue: QueueLike;
+  getRecentSuccessfulReleases?: (limit: number) => Promise<ReleaseModel[]>;
+  getRecentFailedReleases?: (limit: number) => Promise<ReleaseModel[]>;
+  now?: () => number;
+}
+
+export interface QueueStatusOptions {
+  cacheState?: 'fresh' | 'stale';
+  ttlSeconds?: number;
+  jobLimit?: number;
+  releaseLimit?: number;
+}
+
+interface CachedStatus {
+  generatedAtMs: number;
+  value: PublicQueueStatus;
+}
+
+const DEFAULT_TTL_SECONDS = 10;
+const DEFAULT_JOB_LIMIT = 20;
+const DEFAULT_RELEASE_LIMIT = 20;
+
+const queues: Record<string, Queue> = {};
+
+function enumName<T extends Record<string, string | number>>(
+  obj: T,
+  value: number,
+): string {
+  return (obj[value as keyof T] as string | undefined) ?? `${value}`;
+}
+
+function toIso(value?: number): string | undefined {
+  if (!value) return undefined;
+  return new Date(value).toISOString();
+}
+
+function truncateError(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  const firstLine = value.split(/\r?\n/, 1)[0].trim();
+  if (firstLine.length <= 160) return firstLine;
+  return `${firstLine.slice(0, 157)}...`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getStringField(value: unknown, keys: string[]): string | undefined {
+  if (!isRecord(value)) return undefined;
+  for (const key of keys) {
+    const field = value[key];
+    if (typeof field === 'string' && field.length > 0) return field;
+  }
+  return undefined;
+}
+
+export function parseReleaseJobIdentity(
+  job: Pick<QueueJobLike, 'id' | 'data'>,
+): {
+  packageName: string;
+  version: string;
+} {
+  const dataPackage = getStringField(job.data, ['packageName', 'package']);
+  const dataVersion = getStringField(job.data, ['version', 'packageVersion']);
+  if (dataPackage && dataVersion) {
+    return { packageName: dataPackage, version: dataVersion };
+  }
+
+  const parts = `${job.id ?? ''}`.split('|').map((part) => {
+    try {
+      return decodeURIComponent(part);
+    } catch {
+      return part;
+    }
+  });
+  return {
+    packageName: parts[1] || '',
+    version: parts[2] || '',
+  };
+}
+
+function parsePackageJobName(job: Pick<QueueJobLike, 'id' | 'data'>): string {
+  const dataPackage = getStringField(job.data, ['packageName', 'package']);
+  if (dataPackage) return dataPackage;
+  const parts = `${job.id ?? ''}`.split('|').map((part) => {
+    try {
+      return decodeURIComponent(part);
+    } catch {
+      return part;
+    }
+  });
+  return parts[1] || `${job.id ?? ''}`;
+}
+
+async function summarizeJob(
+  job: Job | QueueJobLike,
+  type: 'package' | 'release',
+): Promise<PublicQueueJobSummary> {
+  const state = await job.getState();
+  const release = type === 'release' ? parseReleaseJobIdentity(job) : null;
+  return {
+    package: release?.packageName || parsePackageJobName(job),
+    version: release?.version,
+    state,
+    timestamp: toIso(job.timestamp),
+    processedAt: toIso(job.processedOn),
+    finishedAt: toIso(job.finishedOn),
+    attempts: job.attemptsMade,
+    maxAttempts: job.opts?.attempts ?? 1,
+    error: truncateError(job.failedReason),
+  };
+}
+
+function countValue(counts: Record<string, number>, key: string): number {
+  return Number(counts[key] || 0);
+}
+
+async function getLimitedJobs(
+  queue: QueueLike,
+  types: JobType[],
+  limit: number,
+  sortByOldest = false,
+): Promise<Array<Job | QueueJobLike>> {
+  if (limit < 1) return [];
+  const jobs = await queue.getJobs(types, 0, limit - 1, sortByOldest);
+  return jobs;
+}
+
+function summarizeRelease(
+  release: ReleaseModel,
+  includeRetryable: boolean,
+): PublicReleaseSummary {
+  const summary: PublicReleaseSummary = {
+    package: release.packageName,
+    version: release.version,
+    state: enumName(ReleaseState, release.state),
+    reason: enumName(ReleaseErrorCode, release.reason),
+    updatedAt: new Date(release.updatedAt).toISOString(),
+    source: release.source || 'git',
+    signed: release.signed === true,
+  };
+  if (includeRetryable) {
+    summary.retryable = RetryableReleaseErrorCodes.includes(release.reason);
+  }
+  return summary;
+}
+
+function getSummary(params: {
+  packageFailed: number;
+  releaseWaiting: number;
+  releaseFailed: number;
+  oldestWaitingMs: number | null;
+}): PublicQueueStatus['summary'] {
+  const oneHourMs = 60 * 60 * 1000;
+  if (params.packageFailed > 0 || params.releaseFailed > 0) {
+    return {
+      state: 'degraded',
+      message: 'Some queue jobs are retained as failed and need attention.',
+    };
+  }
+  if (
+    params.releaseWaiting > 100 ||
+    (params.oldestWaitingMs !== null && params.oldestWaitingMs > oneHourMs)
+  ) {
+    return {
+      state: 'backlog',
+      message: 'Release builds are queued and waiting for available workers.',
+    };
+  }
+  return {
+    state: 'healthy',
+    message: 'Package scans and release builds are processing normally.',
+  };
+}
+
+export async function buildPublicQueueStatus(
+  sources: QueueStatusSources,
+  options: QueueStatusOptions = {},
+): Promise<PublicQueueStatus> {
+  const now = sources.now?.() ?? Date.now();
+  const ttlSeconds = options.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const jobLimit = options.jobLimit ?? DEFAULT_JOB_LIMIT;
+  const releaseLimit = options.releaseLimit ?? DEFAULT_RELEASE_LIMIT;
+  const [packageCounts, packageWorkers, releaseCounts, releaseWorkers] =
+    await Promise.all([
+      sources.packageQueue.getJobCounts('active', 'failed'),
+      sources.packageQueue.getWorkers(),
+      sources.releaseQueue.getJobCounts(
+        'waiting',
+        'active',
+        'delayed',
+        'failed',
+      ),
+      sources.releaseQueue.getWorkers(),
+    ]);
+
+  const [
+    failedPackageJobs,
+    activeReleaseJobs,
+    waitingReleaseJobs,
+    failedReleaseJobs,
+    recentSuccessfulReleases,
+    recentFailedReleases,
+  ] = await Promise.all([
+    getLimitedJobs(sources.packageQueue, ['failed'], jobLimit),
+    getLimitedJobs(sources.releaseQueue, ['active'], jobLimit),
+    getLimitedJobs(sources.releaseQueue, ['waiting'], jobLimit, true),
+    getLimitedJobs(sources.releaseQueue, ['failed'], jobLimit),
+    (
+      sources.getRecentSuccessfulReleases ??
+      ((limit: number): Promise<ReleaseModel[]> =>
+        fetchRecentReleases('succeeded', limit))
+    )(releaseLimit),
+    (
+      sources.getRecentFailedReleases ??
+      ((limit: number): Promise<ReleaseModel[]> =>
+        fetchRecentReleases('failed', limit))
+    )(releaseLimit),
+  ]);
+
+  const waitingSummaries = await Promise.all(
+    waitingReleaseJobs.map(async (job) => await summarizeJob(job, 'release')),
+  );
+  const oldestWaitingMs = waitingReleaseJobs.length
+    ? Math.max(
+        0,
+        now - Math.min(...waitingReleaseJobs.map((job) => job.timestamp)),
+      )
+    : null;
+  const packageFailed = countValue(packageCounts, 'failed');
+  const releaseFailed = countValue(releaseCounts, 'failed');
+  const releaseWaiting = countValue(releaseCounts, 'waiting');
+
+  return {
+    generatedAt: new Date(now).toISOString(),
+    cache: {
+      state: options.cacheState ?? 'fresh',
+      ttlSeconds,
+    },
+    summary: getSummary({
+      packageFailed,
+      releaseWaiting,
+      releaseFailed,
+      oldestWaitingMs,
+    }),
+    packageQueue: {
+      active: countValue(packageCounts, 'active'),
+      failed: packageFailed,
+      workers: packageWorkers.length,
+      failedJobs: await Promise.all(
+        failedPackageJobs.map(
+          async (job) => await summarizeJob(job, 'package'),
+        ),
+      ),
+    },
+    releaseQueue: {
+      waiting: releaseWaiting,
+      active: countValue(releaseCounts, 'active'),
+      delayed: countValue(releaseCounts, 'delayed'),
+      failed: releaseFailed,
+      workers: releaseWorkers.length,
+      oldestWaitingMs,
+      activeJobs: await Promise.all(
+        activeReleaseJobs.map(
+          async (job) => await summarizeJob(job, 'release'),
+        ),
+      ),
+      waitingJobs: waitingSummaries,
+    },
+    recentSuccessfulReleases: recentSuccessfulReleases
+      .slice(0, releaseLimit)
+      .map((release) => summarizeRelease(release, false)),
+    recentFailedReleases: recentFailedReleases
+      .slice(0, releaseLimit)
+      .map((release) => summarizeRelease(release, true)),
+    retainedFailedReleaseJobs: await Promise.all(
+      failedReleaseJobs.map(async (job) => await summarizeJob(job, 'release')),
+    ),
+  };
+}
+
+export function getQueue(name: string): Queue {
+  if (!queues[name]) {
+    queues[name] = new Queue(name, {
+      ...config.queueSettings[name],
+      connection: config.redis,
+    });
+  }
+  return queues[name];
+}
+
+export async function closeQueueStatusQueues(): Promise<void> {
+  await Promise.all(
+    Object.values(queues).map(async (queue) => await queue.close()),
+  );
+  for (const name of Object.keys(queues)) delete queues[name];
+}
+
+export function createQueueStatusCache(
+  refresh: (cacheState: 'fresh') => Promise<PublicQueueStatus>,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+  now: () => number = (): number => Date.now(),
+): { get: () => Promise<PublicQueueStatus>; clear: () => void } {
+  let cached: CachedStatus | null = null;
+  let refreshPromise: Promise<CachedStatus> | null = null;
+
+  async function runRefresh(): Promise<CachedStatus> {
+    const value = await refresh('fresh');
+    const next = { generatedAtMs: now(), value };
+    cached = next;
+    return next;
+  }
+
+  return {
+    async get(): Promise<PublicQueueStatus> {
+      if (cached && now() - cached.generatedAtMs < ttlSeconds * 1000) {
+        return {
+          ...cached.value,
+          cache: { ...cached.value.cache, state: 'fresh', ttlSeconds },
+        };
+      }
+
+      if (!refreshPromise) {
+        const nextRefresh = runRefresh();
+        refreshPromise = (
+          cached ? nextRefresh.catch(() => cached as CachedStatus) : nextRefresh
+        ).finally(() => {
+          refreshPromise = null;
+        });
+      }
+
+      if (cached) {
+        return {
+          ...cached.value,
+          cache: { ...cached.value.cache, state: 'stale', ttlSeconds },
+        };
+      }
+
+      const next = await refreshPromise;
+      return {
+        ...next.value,
+        cache: { ...next.value.cache, state: 'fresh', ttlSeconds },
+      };
+    },
+    clear(): void {
+      cached = null;
+      refreshPromise = null;
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,6 +172,7 @@
         "@fastify/cors": "^8.5.0",
         "@openupm/ads": "*",
         "@openupm/server-common": "*",
+        "bullmq": "^5.58.5",
         "config": "^4.4.1",
         "dotenv-flow": "^4.0.1",
         "fastify": "^4.25.2",

--- a/packages/@openupm/server-common/__tests__/models/release.spec.ts
+++ b/packages/@openupm/server-common/__tests__/models/release.spec.ts
@@ -1,12 +1,15 @@
 import redis from '../../src/redis.js';
 import {
   fetchAll,
+  fetchRecentReleases,
   fetchOne,
   fetchOneOrThrow,
+  getRedisKeyForRecentReleases,
   getRedisKeyForRelease,
   remove,
   save,
 } from '../../src/models/release.js';
+import { ReleaseState } from '@openupm/types';
 
 const SAMPLE_PACKAGE_NAME = 'sample-package';
 
@@ -14,7 +17,12 @@ function describeWithRedis(name: string, fn: () => void): void {
   // eslint-disable-next-line jest/valid-title
   describe(name, function () {
     afterEach(async () => {
-      await redis.client!.del(getRedisKeyForRelease(SAMPLE_PACKAGE_NAME));
+      await redis.client!.del(
+        getRedisKeyForRelease(SAMPLE_PACKAGE_NAME),
+        getRedisKeyForRelease('sample-package-two'),
+        getRedisKeyForRecentReleases('succeeded'),
+        getRedisKeyForRecentReleases('failed'),
+      );
     });
 
     afterAll(async () => {
@@ -86,6 +94,84 @@ describeWithRedis('save', function () {
     await remove(obj2!.packageName, obj2!.version);
     const obj3 = await fetchOne(obj.packageName, obj.version);
     expect(obj3).toBeNull();
+  });
+});
+
+describeWithRedis('fetchRecentReleases', function () {
+  it('indexes succeeded releases and removes them from the failed index', async () => {
+    await save({
+      packageName: SAMPLE_PACKAGE_NAME,
+      version: '1.0.0',
+      state: ReleaseState.Failed,
+    });
+    const saved = await save({
+      packageName: SAMPLE_PACKAGE_NAME,
+      version: '1.0.0',
+      state: ReleaseState.Succeeded,
+      source: 'githubRelease',
+      signed: true,
+    });
+
+    expect(await fetchRecentReleases('failed', 20)).toEqual([]);
+    expect(await fetchRecentReleases('succeeded', 20)).toMatchObject([
+      {
+        packageName: SAMPLE_PACKAGE_NAME,
+        version: saved.version,
+        state: ReleaseState.Succeeded,
+        source: 'githubRelease',
+        signed: true,
+      },
+    ]);
+  });
+
+  it('indexes failed releases and removes them from the succeeded index', async () => {
+    await save({
+      packageName: SAMPLE_PACKAGE_NAME,
+      version: '1.0.0',
+      state: ReleaseState.Succeeded,
+    });
+    await save({
+      packageName: SAMPLE_PACKAGE_NAME,
+      version: '1.0.0',
+      state: ReleaseState.Failed,
+    });
+
+    expect(await fetchRecentReleases('succeeded', 20)).toEqual([]);
+    expect(await fetchRecentReleases('failed', 20)).toMatchObject([
+      {
+        packageName: SAMPLE_PACKAGE_NAME,
+        version: '1.0.0',
+        state: ReleaseState.Failed,
+      },
+    ]);
+  });
+
+  it('sorts by newest update time and respects the limit', async () => {
+    await save({
+      packageName: SAMPLE_PACKAGE_NAME,
+      version: '1.0.0',
+      state: ReleaseState.Succeeded,
+    });
+    await save({
+      packageName: 'sample-package-two',
+      version: '2.0.0',
+      state: ReleaseState.Succeeded,
+    });
+
+    const releases = await fetchRecentReleases('succeeded', 1);
+    expect(releases).toHaveLength(1);
+    expect(releases[0].packageName).toEqual('sample-package-two');
+  });
+
+  it('skips stale indexed release keys', async () => {
+    const member = JSON.stringify(['sample-package-two', '2.0.0']);
+    await redis.client!.zadd(
+      getRedisKeyForRecentReleases('failed'),
+      Date.now(),
+      member,
+    );
+
+    expect(await fetchRecentReleases('failed', 20)).toEqual([]);
   });
 });
 

--- a/packages/@openupm/server-common/src/models/release.ts
+++ b/packages/@openupm/server-common/src/models/release.ts
@@ -8,11 +8,15 @@
  */
 
 import { pick } from 'lodash-es';
-import { ReleaseModel, releaseModelFields } from '@openupm/types';
+import { ReleaseModel, releaseModelFields, ReleaseState } from '@openupm/types';
 
 import redis from '../redis.js';
 
 const REDIS_KEY_RELEASE_PREFIX = 'rel:';
+const REDIS_KEY_RECENT_SUCCEEDED_RELEASES = 'rel:index:succeeded';
+const REDIS_KEY_RECENT_FAILED_RELEASES = 'rel:index:failed';
+
+type ReleaseHistoryState = 'succeeded' | 'failed';
 
 /**
  * Get the redis key for a release hashset.
@@ -22,6 +26,65 @@ const REDIS_KEY_RELEASE_PREFIX = 'rel:';
 export const getRedisKeyForRelease = function (packageName: string): string {
   return REDIS_KEY_RELEASE_PREFIX + packageName;
 };
+
+export function getRedisKeyForRecentReleases(
+  state: ReleaseHistoryState,
+): string {
+  return state === 'succeeded'
+    ? REDIS_KEY_RECENT_SUCCEEDED_RELEASES
+    : REDIS_KEY_RECENT_FAILED_RELEASES;
+}
+
+function getReleaseIndexMember(packageName: string, version: string): string {
+  return JSON.stringify([packageName, version]);
+}
+
+function parseReleaseIndexMember(
+  value: string,
+): { packageName: string; version: string } | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed) || parsed.length !== 2) return null;
+    const [packageName, version] = parsed;
+    if (typeof packageName !== 'string' || typeof version !== 'string') {
+      return null;
+    }
+    return { packageName, version };
+  } catch {
+    return null;
+  }
+}
+
+async function updateRecentReleaseIndexes(record: ReleaseModel): Promise<void> {
+  const member = getReleaseIndexMember(record.packageName, record.version);
+  const succeededKey = getRedisKeyForRecentReleases('succeeded');
+  const failedKey = getRedisKeyForRecentReleases('failed');
+  const score = record.updatedAt || Date.now();
+
+  if (record.state === ReleaseState.Succeeded) {
+    await redis
+      .client!.multi()
+      .zadd(succeededKey, score, member)
+      .zrem(failedKey, member)
+      .exec();
+    return;
+  }
+
+  if (record.state === ReleaseState.Failed) {
+    await redis
+      .client!.multi()
+      .zadd(failedKey, score, member)
+      .zrem(succeededKey, member)
+      .exec();
+    return;
+  }
+
+  await redis
+    .client!.multi()
+    .zrem(succeededKey, member)
+    .zrem(failedKey, member)
+    .exec();
+}
 
 /**
  * Saves a release object to Redis.
@@ -60,6 +123,7 @@ export async function save(
   const jsonText = JSON.stringify(record, null, 0);
   const key = getRedisKeyForRelease(record.packageName);
   await redis.client!.hset(key, record.version, jsonText);
+  await updateRecentReleaseIndexes(record);
   Object.assign(obj, record);
   return obj as ReleaseModel;
 }
@@ -88,7 +152,13 @@ export async function remove(
       `Can not remove release with packageName=${packageName} version=${version}`,
     );
   const key = getRedisKeyForRelease(packageName);
-  await redis.client!.hdel(key, version);
+  const member = getReleaseIndexMember(packageName, version);
+  await redis
+    .client!.multi()
+    .hdel(key, version)
+    .zrem(getRedisKeyForRecentReleases('succeeded'), member)
+    .zrem(getRedisKeyForRecentReleases('failed'), member)
+    .exec();
 }
 
 /**
@@ -141,4 +211,27 @@ export async function fetchAll(packageName: string): Promise<ReleaseModel[]> {
   return Object.values(objs).map((x) =>
     normalizeReleaseModel(JSON.parse(x) as ReleaseModel),
   );
+}
+
+export async function fetchRecentReleases(
+  state: ReleaseHistoryState,
+  limit: number,
+): Promise<ReleaseModel[]> {
+  if (!Number.isInteger(limit) || limit < 1) return [];
+  const key = getRedisKeyForRecentReleases(state);
+  const members = await redis.client!.zrevrange(key, 0, limit - 1);
+  const releases: ReleaseModel[] = [];
+  const expectedState =
+    state === 'succeeded' ? ReleaseState.Succeeded : ReleaseState.Failed;
+
+  for (const member of members) {
+    const parsed = parseReleaseIndexMember(member);
+    if (!parsed) continue;
+    const release = await fetchOne(parsed.packageName, parsed.version);
+    if (!release || release.state !== expectedState) continue;
+    releases.push(release);
+  }
+
+  releases.sort((a, b) => b.updatedAt - a.updatedAt);
+  return releases.slice(0, limit);
 }


### PR DESCRIPTION
## Summary

Adds a public `/queue` status page in the docs app backed by a read-only `GET /queue/status` API in the web app.

The API returns sanitized queue health data with a 10-second server-side cache, single-flight refresh, and stale-while-refresh behavior. It exposes package scan failures, release queue counts, active/waiting release jobs, recent successful and failed releases, and retained failed release queue jobs.

## Implementation Notes

- Adds bounded Redis sorted-set indexes for recent succeeded and failed release records, maintained when release records are saved or removed.
- Avoids unbounded release scans from the public status refresh path.
- Keeps `/queue` discoverable by URL without adding docs navigation in this first version.
- Historical release records will not appear in the recent release indexes until they are saved again unless a separate operator backfill is run.

## Validation

- `npm test --workspace @openupm/web -- queueStatus`
- `npm test --workspace @openupm/docs -- queueStatusView`
- `npm test --workspace @openupm/server-common -- release.spec.ts`
- `npm run lint --workspace @openupm/web`
- `npm run lint --workspace @openupm/docs`
- `npm run lint --workspace @openupm/server-common`
- `npm run build --workspace @openupm/web`
- `npm run docs:build:limit --workspace @openupm/docs`