### PR TITLE
[codex] add release index backfill command

### DIFF
--- a/apps/queue/__tests__/queueCli.spec.ts
+++ b/apps/queue/__tests__/queueCli.spec.ts
@@ -5,11 +5,17 @@ const {
   getJobsMock,
   getWorkersMock,
   hasQueueMock,
+  fetchAllMock,
+  backfillRecentReleaseIndexesMock,
+  redisScanMock,
 } = vi.hoisted(() => ({
   getJobCountsMock: vi.fn(),
   getJobsMock: vi.fn(),
   getWorkersMock: vi.fn(),
   hasQueueMock: vi.fn((name: string) => name === 'pkg' || name === 'rel'),
+  fetchAllMock: vi.fn(),
+  backfillRecentReleaseIndexesMock: vi.fn(),
+  redisScanMock: vi.fn(),
 }));
 
 vi.mock('../src/queues/core.js', () => ({
@@ -27,9 +33,17 @@ vi.mock('@openupm/server-common/build/redis.js', () => ({
   default: {
     close: vi.fn(),
     client: {
-      scan: vi.fn(),
+      scan: redisScanMock,
     },
   },
+}));
+
+vi.mock('@openupm/server-common/build/models/release.js', () => ({
+  backfillRecentReleaseIndexes: backfillRecentReleaseIndexesMock,
+  fetchAll: fetchAllMock,
+  fetchOne: vi.fn(),
+  remove: vi.fn(),
+  save: vi.fn(),
 }));
 
 describe('parseQueueCliArgs', () => {
@@ -38,6 +52,9 @@ describe('parseQueueCliArgs', () => {
     hasQueueMock.mockImplementation(
       (name: string) => name === 'pkg' || name === 'rel',
     );
+    fetchAllMock.mockReset();
+    backfillRecentReleaseIndexesMock.mockReset();
+    redisScanMock.mockReset();
   });
 
   it('parses json and limit flags', async () => {
@@ -112,6 +129,14 @@ describe('parseQueueCliArgs', () => {
     expect(help).toContain('queue-cli releases-failed [reason|unknown|timeout]');
     expect(help).toContain('BuildTimeout/ConnectionTimeout/GatewayTimeout');
     expect(help).toContain('VersionConflict');
+  });
+
+  it('documents the release index backfill command', async () => {
+    const { getCommandUsage, getUsage } = await import('../src/queueCli.js');
+    expect(getUsage()).toContain('release-index-backfill');
+    const help = getCommandUsage('release-index-backfill');
+    expect(help).toContain('queue-cli release-index-backfill');
+    expect(help).toContain('Rebuild the bounded recent succeeded/failed');
   });
 
   it('documents destructive commands in top-level help', async () => {
@@ -203,5 +228,57 @@ describe('parseQueueCliArgs', () => {
         ],
       },
     ]);
+  });
+
+  it('releases-failed skips derived release index keys while scanning', async () => {
+    const { releasesFailed } = await import('../src/queueCli.js');
+    redisScanMock.mockResolvedValueOnce([
+      '0',
+      ['rel:com.failed.package', 'rel:index:succeeded', 'rel:index:failed'],
+    ]);
+    fetchAllMock.mockResolvedValueOnce([
+      {
+        packageName: 'com.failed.package',
+        version: '1.0.0',
+        state: 3,
+        reason: 700,
+        buildId: '',
+        tag: '',
+        commit: '',
+        updatedAt: 100,
+      },
+    ]);
+
+    const result = await releasesFailed(undefined, 20);
+
+    expect(fetchAllMock).toHaveBeenCalledTimes(1);
+    expect(fetchAllMock).toHaveBeenCalledWith('com.failed.package');
+    expect(result).toMatchObject([
+      { packageName: 'com.failed.package', version: '1.0.0' },
+    ]);
+  });
+
+  it('runs release-index-backfill and prints JSON output', async () => {
+    backfillRecentReleaseIndexesMock.mockResolvedValue({
+      scannedPackages: 10,
+      scannedReleases: 40,
+      succeeded: 30,
+      failed: 2,
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+    await runQueueCli([
+      'node',
+      'index.js',
+      'queue-cli',
+      'release-index-backfill',
+      '--json',
+    ]);
+
+    expect(backfillRecentReleaseIndexesMock).toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"scannedReleases": 40'),
+    );
   });
 });

--- a/apps/queue/__tests__/queueCliActions.spec.ts
+++ b/apps/queue/__tests__/queueCliActions.spec.ts
@@ -11,6 +11,7 @@ const hasQueueMock = vi.fn((name: string) => name === 'pkg' || name === 'rel');
 const addJobMock = vi.fn();
 const closeQueuesMock = vi.fn();
 const fetchAllMock = vi.fn();
+const backfillRecentReleaseIndexesMock = vi.fn();
 const fetchOneMock = vi.fn();
 const removeReleaseRecordMock = vi.fn();
 const saveReleaseMock = vi.fn();
@@ -29,6 +30,7 @@ vi.mock('../src/queues/core.js', () => ({
 }));
 
 vi.mock('@openupm/server-common/build/models/release.js', () => ({
+  backfillRecentReleaseIndexes: backfillRecentReleaseIndexesMock,
   fetchAll: fetchAllMock,
   fetchOne: fetchOneMock,
   remove: removeReleaseRecordMock,

--- a/apps/queue/src/queueCli.ts
+++ b/apps/queue/src/queueCli.ts
@@ -4,6 +4,7 @@ import type { JobType } from 'bullmq';
 import { ReleaseErrorCode, ReleaseState } from '@openupm/types';
 import redis from '@openupm/server-common/build/redis.js';
 import {
+  backfillRecentReleaseIndexes,
   fetchAll,
   fetchOne,
   remove as removeReleaseRecord,
@@ -142,6 +143,9 @@ function getUsage(): string {
     '    and GatewayTimeout. Exact reason names such as VersionConflict are also',
     '    accepted.',
     '',
+    '  release-index-backfill [--json]',
+    '    Rebuild public recent release indexes from existing release records.',
+    '',
     '  release-show <package> <version> [--json]',
     '    Show one release Redis record.',
     '',
@@ -254,6 +258,17 @@ function getCommandUsage(topic: string | undefined): string {
         '',
         'Examples:',
         '  queue-cli release-show com.foo.bar 1.2.3 --json',
+      ].join('\n');
+    case 'release-index-backfill':
+      return [
+        'Usage: queue-cli release-index-backfill [--json]',
+        '',
+        'Rebuild the bounded recent succeeded/failed release indexes from',
+        'existing release Redis records. This scans release hashes once and',
+        'replaces only the derived public status indexes.',
+        '',
+        'Examples:',
+        '  queue-cli release-index-backfill --json',
       ].join('\n');
     case 'release-remove':
       return [
@@ -595,7 +610,9 @@ async function scanReleasePackageNames(): Promise<string[]> {
       200,
     );
     cursor = nextCursor;
-    for (const key of keys) names.push(key.slice('rel:'.length));
+    for (const key of keys) {
+      if (!key.startsWith('rel:index:')) names.push(key.slice('rel:'.length));
+    }
   } while (cursor !== '0');
   names.sort();
   return names;
@@ -747,6 +764,9 @@ export async function runQueueCli(argv: string[] = process.argv): Promise<void> 
         requireArgs(args.rest, 2);
         result = await releaseShow(args.rest[0], args.rest[1]);
         break;
+      case 'release-index-backfill':
+        result = await backfillRecentReleaseIndexes();
+        break;
       case 'release-remove':
         requireArgs(args.rest, 2);
         result = await releaseRemove(args.rest[0], args.rest[1]);
@@ -781,6 +801,7 @@ export {
   queueRemove,
   releasesFailed,
   releaseShow,
+  backfillRecentReleaseIndexes,
   releaseRemove,
   releaseRequeue,
   packageRequeue,

--- a/packages/@openupm/server-common/__tests__/models/release.spec.ts
+++ b/packages/@openupm/server-common/__tests__/models/release.spec.ts
@@ -1,5 +1,6 @@
 import redis from '../../src/redis.js';
 import {
+  backfillRecentReleaseIndexes,
   fetchAll,
   fetchRecentReleases,
   fetchOne,
@@ -172,6 +173,74 @@ describeWithRedis('fetchRecentReleases', function () {
     );
 
     expect(await fetchRecentReleases('failed', 20)).toEqual([]);
+  });
+
+  it('backfills recent release indexes from existing release hashes', async () => {
+    await redis.client!.hset(
+      getRedisKeyForRelease(SAMPLE_PACKAGE_NAME),
+      '1.0.0',
+      JSON.stringify({
+        packageName: SAMPLE_PACKAGE_NAME,
+        version: '1.0.0',
+        commit: '',
+        tag: '',
+        state: ReleaseState.Succeeded,
+        buildId: '',
+        reason: 0,
+        createdAt: 100,
+        updatedAt: 200,
+        source: 'git',
+        signed: false,
+      }),
+      '1.0.1',
+      JSON.stringify({
+        packageName: SAMPLE_PACKAGE_NAME,
+        version: '1.0.1',
+        commit: '',
+        tag: '',
+        state: ReleaseState.Failed,
+        buildId: '',
+        reason: 700,
+        createdAt: 100,
+        updatedAt: 300,
+        source: 'git',
+        signed: false,
+      }),
+      '1.0.2',
+      JSON.stringify({
+        packageName: SAMPLE_PACKAGE_NAME,
+        version: '1.0.2',
+        commit: '',
+        tag: '',
+        state: ReleaseState.Pending,
+        buildId: '',
+        reason: 0,
+        createdAt: 100,
+        updatedAt: 400,
+        source: 'git',
+        signed: false,
+      }),
+    );
+    await redis.client!.zadd(
+      getRedisKeyForRecentReleases('succeeded'),
+      1,
+      JSON.stringify(['stale-package', '0.0.1']),
+    );
+
+    const result = await backfillRecentReleaseIndexes();
+
+    expect(result).toEqual({
+      scannedPackages: 1,
+      scannedReleases: 3,
+      succeeded: 1,
+      failed: 1,
+    });
+    expect(await fetchRecentReleases('succeeded', 20)).toMatchObject([
+      { packageName: SAMPLE_PACKAGE_NAME, version: '1.0.0' },
+    ]);
+    expect(await fetchRecentReleases('failed', 20)).toMatchObject([
+      { packageName: SAMPLE_PACKAGE_NAME, version: '1.0.1' },
+    ]);
   });
 });
 

--- a/packages/@openupm/server-common/src/models/release.ts
+++ b/packages/@openupm/server-common/src/models/release.ts
@@ -18,6 +18,13 @@ const REDIS_KEY_RECENT_FAILED_RELEASES = 'rel:index:failed';
 
 type ReleaseHistoryState = 'succeeded' | 'failed';
 
+interface ReleaseHistoryBackfillResult {
+  scannedPackages: number;
+  scannedReleases: number;
+  succeeded: number;
+  failed: number;
+}
+
 /**
  * Get the redis key for a release hashset.
  * @param {string} packageName - The name of the package.
@@ -84,6 +91,15 @@ async function updateRecentReleaseIndexes(record: ReleaseModel): Promise<void> {
     .zrem(succeededKey, member)
     .zrem(failedKey, member)
     .exec();
+}
+
+function isReleaseHashKey(key: string): boolean {
+  return (
+    key.startsWith(REDIS_KEY_RELEASE_PREFIX) &&
+    key !== REDIS_KEY_RECENT_SUCCEEDED_RELEASES &&
+    key !== REDIS_KEY_RECENT_FAILED_RELEASES &&
+    !key.startsWith(`${REDIS_KEY_RELEASE_PREFIX}index:`)
+  );
 }
 
 /**
@@ -234,4 +250,63 @@ export async function fetchRecentReleases(
 
   releases.sort((a, b) => b.updatedAt - a.updatedAt);
   return releases.slice(0, limit);
+}
+
+export async function backfillRecentReleaseIndexes(): Promise<ReleaseHistoryBackfillResult> {
+  const client = redis.client!;
+  let cursor = '0';
+  const releaseKeys: string[] = [];
+
+  do {
+    const [nextCursor, keys] = await client.scan(
+      cursor,
+      'MATCH',
+      `${REDIS_KEY_RELEASE_PREFIX}*`,
+      'COUNT',
+      200,
+    );
+    cursor = nextCursor;
+    for (const key of keys) {
+      if (isReleaseHashKey(key)) releaseKeys.push(key);
+    }
+  } while (cursor !== '0');
+
+  releaseKeys.sort();
+
+  const succeeded: Array<[number, string]> = [];
+  const failed: Array<[number, string]> = [];
+  let scannedReleases = 0;
+
+  for (const key of releaseKeys) {
+    const objs = await client.hgetall(key);
+    for (const value of Object.values(objs)) {
+      const release = normalizeReleaseModel(JSON.parse(value) as ReleaseModel);
+      scannedReleases += 1;
+      const member = getReleaseIndexMember(
+        release.packageName,
+        release.version,
+      );
+      const score = release.updatedAt || release.createdAt || 0;
+      if (release.state === ReleaseState.Succeeded) {
+        succeeded.push([score, member]);
+      } else if (release.state === ReleaseState.Failed) {
+        failed.push([score, member]);
+      }
+    }
+  }
+
+  const succeededKey = getRedisKeyForRecentReleases('succeeded');
+  const failedKey = getRedisKeyForRecentReleases('failed');
+  const pipeline = client.multi().del(succeededKey, failedKey);
+  for (const [score, member] of succeeded)
+    pipeline.zadd(succeededKey, score, member);
+  for (const [score, member] of failed) pipeline.zadd(failedKey, score, member);
+  await pipeline.exec();
+
+  return {
+    scannedPackages: releaseKeys.length,
+    scannedReleases,
+    succeeded: succeeded.length,
+    failed: failed.length,
+  };
 }


### PR DESCRIPTION
## Summary

Adds a one-time `queue-cli release-index-backfill` operator command to rebuild the public queue status recent release indexes from existing release Redis records.

## Details

- Adds `backfillRecentReleaseIndexes()` in the release model.
- Rebuilds only the derived `rel:index:succeeded` and `rel:index:failed` sorted sets.
- Scans existing `rel:*` release hashes once and preserves release `updatedAt` timestamps as scores.
- Skips `rel:index:*` keys during release scans so existing `releases-failed` does not try to read sorted-set indexes as release hashes.

## Validation

- `npm test --workspace @openupm/queue -- queueCli.spec.ts queueCliActions.spec.ts`
- `npm test --workspace @openupm/server-common -- release.spec.ts`
- `npm run lint --workspace @openupm/queue`
- `npm run lint --workspace @openupm/server-common`
- `npm run build --workspace @openupm/queue`
- `npm run build --workspace @openupm/server-common`

## Production Note

This PR only adds the command. It does not run the production backfill.