### PR TITLE
Tune public queue status page

### DIFF
--- a/apps/docs/__tests__/vue/queueStatusView.spec.ts
+++ b/apps/docs/__tests__/vue/queueStatusView.spec.ts
@@ -15,7 +15,7 @@ function createStatus(
 ): PublicQueueStatus {
   return {
     generatedAt: "2026-05-14T10:00:00.000Z",
-    cache: { state: "fresh", ttlSeconds: 10 },
+    cache: { state: "fresh", ttlSeconds: 15 },
     summary: { state: "healthy", message: "ok" },
     packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
     releaseQueue: {

--- a/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
@@ -1,20 +1,22 @@
 <template>
   <main class="queue-status">
     <header class="queue-status__header">
-      <div>
-        <h1>Queue Status</h1>
+      <div class="queue-status__intro">
+        <div class="queue-status__title-row">
+          <h1>Queue Status</h1>
+          <span
+            v-if="status"
+            :class="['queue-status__state', `is-${status.summary.state}`]"
+          >
+            {{ status.summary.state }}
+          </span>
+          <span v-if="status" class="queue-status__updated">
+            Updated {{ formatRelativeTime(status.generatedAt, nowMs) }}
+          </span>
+        </div>
         <p v-if="status">{{ status.summary.message }}</p>
         <p v-else-if="loading">Loading public queue status...</p>
         <p v-else-if="error">{{ error }}</p>
-      </div>
-      <div v-if="status" class="queue-status__meta">
-        <span :class="['queue-status__state', `is-${status.summary.state}`]">
-          {{ status.summary.state }}
-        </span>
-        <span>Updated {{ formatRelativeTime(status.generatedAt, nowMs) }}</span>
-        <span
-          >Cache {{ status.cache.state }}, {{ status.cache.ttlSeconds }}s</span
-        >
       </div>
     </header>
 
@@ -51,6 +53,7 @@
       </section>
 
       <QueueStatusTable
+        v-if="status.packageQueue.failedJobs.length > 0"
         title="Failed Package Scan Jobs"
         :columns="['Package', 'Failed', 'Attempts', 'Last Error']"
         :empty="status.packageQueue.failedJobs.length === 0"
@@ -104,6 +107,7 @@
       </section>
 
       <QueueStatusTable
+        v-if="status.releaseQueue.activeJobs.length > 0"
         title="Active Release Builds"
         :columns="['Package', 'Version', 'Age', 'Attempts']"
         :empty="status.releaseQueue.activeJobs.length === 0"
@@ -124,6 +128,7 @@
       </QueueStatusTable>
 
       <QueueStatusTable
+        v-if="status.releaseQueue.waitingJobs.length > 0"
         title="Waiting Release Builds"
         :columns="['Package', 'Version', 'Queued']"
         :empty="status.releaseQueue.waitingJobs.length === 0"
@@ -173,12 +178,18 @@
             <a :href="packageUrl(release.package)">{{ release.package }}</a>
           </td>
           <td>{{ release.version }}</td>
-          <td>{{ release.reason }}</td>
+          <td>
+            <a v-if="release.buildId" :href="releaseBuildUrl(release)">
+              {{ releaseReasonText(release) }}
+            </a>
+            <span v-else>{{ releaseReasonText(release) }}</span>
+          </td>
           <td>{{ release.retryable ? "yes" : "no" }}</td>
         </tr>
       </QueueStatusTable>
 
       <QueueStatusTable
+        v-if="status.retainedFailedReleaseJobs.length > 0"
         title="Retained Failed Release Queue Jobs"
         :columns="['Package', 'Version', 'Failed', 'Attempts', 'Last Error']"
         :empty="status.retainedFailedReleaseJobs.length === 0"
@@ -205,10 +216,16 @@
 <script setup lang="ts">
 import axios from "axios";
 import urlJoin from "url-join";
+import { paramCase } from "change-case";
 import { onMounted, ref } from "vue";
-import { getAPIBaseUrl } from "@openupm/common/build/urls.js";
+import { useI18n } from "vue-i18n";
+import {
+  getAPIBaseUrl,
+  getAzureWebBuildUrl,
+} from "@openupm/common/build/urls.js";
 import {
   PublicQueueStatus,
+  PublicReleaseSummary,
   formatDuration,
   formatRelativeTime,
   isQueueStatusEmpty,
@@ -216,10 +233,21 @@ import {
 } from "../queueStatusView";
 import QueueStatusTable from "./QueueStatusTable.vue";
 
+const { t } = useI18n();
 const loading = ref(true);
 const error = ref("");
 const status = ref<PublicQueueStatus | null>(null);
 const nowMs = ref(Date.now());
+
+function releaseReasonText(release: PublicReleaseSummary): string {
+  const key = `release-reason-${paramCase(release.reason)}`;
+  const value = t(key);
+  return value === key ? release.reason : value;
+}
+
+function releaseBuildUrl(release: PublicReleaseSummary): string {
+  return release.buildId ? getAzureWebBuildUrl(release.buildId) : "";
+}
 
 async function fetchQueueStatus(): Promise<void> {
   loading.value = true;
@@ -246,39 +274,41 @@ onMounted(fetchQueueStatus);
 
 <style lang="scss">
 .queue-status {
-  max-width: 1180px;
+  max-width: none;
   margin: 0 auto;
-  padding: 2rem 1rem 4rem;
+  padding: 1rem 0.75rem 2rem;
   color: #1f2933;
+  font-size: 0.75rem;
 }
 
 .queue-status__header {
-  display: flex;
-  gap: 1rem;
-  align-items: flex-start;
-  justify-content: space-between;
-  border-bottom: 1px solid #d9e2ec;
-  padding-bottom: 1rem;
+  display: grid;
+  gap: 0.25rem;
+  padding-bottom: 0.2rem;
 
   h1 {
-    margin: 0 0 0.35rem;
-    font-size: 2rem;
-    line-height: 1.15;
+    margin: 0;
+    font-size: 0.8rem;
+    line-height: 1.2;
   }
 
   p {
     margin: 0;
     color: #52606d;
+    font-size: 0.7rem;
   }
 }
 
-.queue-status__meta {
+.queue-status__intro {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.queue-status__title-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: flex-end;
-  color: #52606d;
-  font-size: 0.9rem;
+  gap: 0.45rem;
+  align-items: baseline;
 }
 
 .queue-status__state {
@@ -299,10 +329,15 @@ onMounted(fetchQueueStatus);
   }
 }
 
+.queue-status__updated {
+  color: #627d98;
+  font-size: 0.65rem;
+}
+
 .queue-status__notice {
-  margin: 1rem 0;
+  margin: 0.75rem 0;
   border: 1px solid #bcccdc;
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 0.65rem;
   background: #f8fafc;
   color: #334e68;
 
@@ -314,9 +349,7 @@ onMounted(fetchQueueStatus);
 }
 
 .queue-status__section {
-  margin-top: 1.5rem;
-  border-top: 1px solid #d9e2ec;
-  padding-top: 1rem;
+  margin-top: 0.9rem;
 }
 
 .queue-status__section-title {
@@ -325,22 +358,22 @@ onMounted(fetchQueueStatus);
   justify-content: space-between;
 
   h2 {
-    margin: 0 0 0.75rem;
-    font-size: 1.1rem;
+    margin: 0 0 0.4rem;
+    font-size: 0.8rem;
     line-height: 1.2;
   }
 }
 
 .queue-status__metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
   border: 1px solid #d9e2ec;
 
   div {
     display: grid;
-    gap: 0.2rem;
+    gap: 0.1rem;
     border-right: 1px solid #d9e2ec;
-    padding: 0.75rem;
+    padding: 0.45rem 0.55rem;
 
     &:last-child {
       border-right: 0;
@@ -349,14 +382,18 @@ onMounted(fetchQueueStatus);
 
   span {
     color: #627d98;
-    font-size: 0.78rem;
+    font-size: 0.68rem;
     text-transform: uppercase;
   }
 
   strong {
-    font-size: 1.35rem;
+    font-size: 0.7rem;
     line-height: 1.1;
   }
+}
+
+.queue-status h2 {
+  border-bottom-width: 0;
 }
 
 .queue-status__error {
@@ -365,15 +402,6 @@ onMounted(fetchQueueStatus);
 }
 
 @media (max-width: 720px) {
-  .queue-status__header {
-    display: block;
-  }
-
-  .queue-status__meta {
-    justify-content: flex-start;
-    margin-top: 0.75rem;
-  }
-
   .queue-status__metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
 

--- a/apps/docs/docs/.vuepress/components/QueueStatusTable.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusTable.vue
@@ -33,27 +33,25 @@ defineProps<{
 
 <style lang="scss">
 .queue-status-table {
-  margin-top: 1.5rem;
-  border-top: 1px solid #d9e2ec;
-  padding-top: 1rem;
+  margin-top: 0.9rem;
 
   h2 {
-    margin: 0 0 0.75rem;
-    font-size: 1.1rem;
+    margin: 0 0 0.4rem;
+    font-size: 0.8rem;
     line-height: 1.2;
   }
 }
 
 .queue-status-table__wrap {
   overflow-x: auto;
-  border: 1px solid #d9e2ec;
 }
 
 .queue-status-table table {
   width: 100%;
   min-width: 640px;
+  margin: 0;
   border-collapse: collapse;
-  font-size: 0.92rem;
+  font-size: 0.7rem;
 }
 
 .queue-status-table th,
@@ -67,12 +65,8 @@ defineProps<{
 .queue-status-table th {
   background: #f0f4f8;
   color: #52606d;
-  font-size: 0.78rem;
+  font-size: 0.7rem;
   text-transform: uppercase;
-}
-
-.queue-status-table tr:last-child td {
-  border-bottom: 0;
 }
 
 .queue-status-table a {

--- a/apps/docs/docs/.vuepress/queueStatusView.ts
+++ b/apps/docs/docs/.vuepress/queueStatusView.ts
@@ -16,6 +16,7 @@ export interface PublicReleaseSummary {
   state: string;
   reason: string;
   updatedAt: string;
+  buildId?: string;
   source: "git" | "githubRelease";
   signed: boolean;
   retryable?: boolean;

--- a/apps/docs/docs/queue/index.md
+++ b/apps/docs/docs/queue/index.md
@@ -1,7 +1,8 @@
 ---
-layout: Layout
+layout: WideLayout
 title: Queue Status
 description: Public OpenUPM package scan and release build queue status.
+editLink: false
 ---
 
 <QueueStatusPage />

--- a/apps/web/__tests__/routers/queueStatus.spec.ts
+++ b/apps/web/__tests__/routers/queueStatus.spec.ts
@@ -42,7 +42,7 @@ describe('queue status router', () => {
   it('returns the public queue status shape', async () => {
     mocks.get.mockResolvedValue({
       generatedAt: '2026-05-14T10:42:00.000Z',
-      cache: { state: 'fresh', ttlSeconds: 10 },
+      cache: { state: 'fresh', ttlSeconds: 15 },
       summary: { state: 'healthy', message: 'ok' },
       packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
       releaseQueue: {
@@ -68,7 +68,7 @@ describe('queue status router', () => {
 
     expect(response.body).toMatchObject({
       generatedAt: '2026-05-14T10:42:00.000Z',
-      cache: { state: 'fresh', ttlSeconds: 10 },
+      cache: { state: 'fresh', ttlSeconds: 15 },
       packageQueue: { failedJobs: [] },
       releaseQueue: { activeJobs: [], waitingJobs: [] },
       recentSuccessfulReleases: [],

--- a/apps/web/__tests__/status/queueStatus.spec.ts
+++ b/apps/web/__tests__/status/queueStatus.spec.ts
@@ -159,7 +159,7 @@ describe('buildPublicQueueStatus', () => {
             reason: ReleaseErrorCode.BuildTimeout,
             commit: '',
             tag: '',
-            buildId: '',
+            buildId: '12345',
             createdAt: now,
             updatedAt: now - 1,
             source: 'git',
@@ -181,7 +181,7 @@ describe('buildPublicQueueStatus', () => {
         ],
         now: () => now,
       },
-      { jobLimit: 20, releaseLimit: 20, ttlSeconds: 10 },
+      { jobLimit: 20, releaseLimit: 20, ttlSeconds: 15 },
     );
 
     expect(status.generatedAt).toEqual(new Date(now).toISOString());
@@ -210,6 +210,10 @@ describe('buildPublicQueueStatus', () => {
     expect(
       status.recentFailedReleases.map((release) => release.retryable),
     ).toEqual([true, false]);
+    expect(status.recentFailedReleases[0]).toMatchObject({
+      reason: 'BuildTimeout',
+      buildId: '12345',
+    });
     expect(JSON.stringify(status)).not.toContain('/srv/private/path');
   });
 
@@ -256,7 +260,7 @@ describe('buildPublicQueueStatus', () => {
 });
 
 describe('createQueueStatusCache', () => {
-  it('single-flights the first refresh and returns stale data while refreshing', async () => {
+  it('single-flights refreshes and waits for expired cache refreshes', async () => {
     let now = 0;
     let resolveRefresh: (value: unknown) => void = () => undefined;
     const refresh = vi.fn(async () => {
@@ -265,7 +269,7 @@ describe('createQueueStatusCache', () => {
       });
       return {
         generatedAt: new Date(now).toISOString(),
-        cache: { state: 'fresh' as const, ttlSeconds: 10 },
+        cache: { state: 'fresh' as const, ttlSeconds: 15 },
         summary: { state: 'healthy' as const, message: 'ok' },
         packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
         releaseQueue: {
@@ -283,7 +287,7 @@ describe('createQueueStatusCache', () => {
         retainedFailedReleaseJobs: [],
       };
     });
-    const cache = createQueueStatusCache(refresh, 10, () => now);
+    const cache = createQueueStatusCache(refresh, 15, () => now);
 
     const first = cache.get();
     const second = cache.get();
@@ -292,20 +296,23 @@ describe('createQueueStatusCache', () => {
     await expect(first).resolves.toMatchObject({ cache: { state: 'fresh' } });
     await expect(second).resolves.toMatchObject({ cache: { state: 'fresh' } });
 
-    now = 11_000;
-    const stale = await cache.get();
-    expect(stale.cache.state).toEqual('stale');
+    now = 16_000;
+    const refreshed = cache.get();
     expect(refresh).toHaveBeenCalledTimes(2);
     resolveRefresh(undefined);
+    await expect(refreshed).resolves.toMatchObject({
+      generatedAt: new Date(now).toISOString(),
+      cache: { state: 'fresh', ttlSeconds: 15 },
+    });
   });
 
-  it('serves stale data when a background refresh fails', async () => {
+  it('serves stale data when an expired cache refresh fails', async () => {
     let now = 0;
     const refresh = vi
       .fn()
       .mockResolvedValueOnce({
         generatedAt: new Date(now).toISOString(),
-        cache: { state: 'fresh' as const, ttlSeconds: 10 },
+        cache: { state: 'fresh' as const, ttlSeconds: 15 },
         summary: { state: 'healthy' as const, message: 'ok' },
         packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
         releaseQueue: {
@@ -323,14 +330,14 @@ describe('createQueueStatusCache', () => {
         retainedFailedReleaseJobs: [],
       })
       .mockRejectedValueOnce(new Error('redis unavailable'));
-    const cache = createQueueStatusCache(refresh, 10, () => now);
+    const cache = createQueueStatusCache(refresh, 15, () => now);
 
     await expect(cache.get()).resolves.toMatchObject({
       cache: { state: 'fresh' },
     });
-    now = 11_000;
+    now = 16_000;
     await expect(cache.get()).resolves.toMatchObject({
-      cache: { state: 'stale' },
+      cache: { state: 'stale', ttlSeconds: 15 },
     });
     expect(refresh).toHaveBeenCalledTimes(2);
   });

--- a/apps/web/src/routers/queueStatus.ts
+++ b/apps/web/src/routers/queueStatus.ts
@@ -6,7 +6,7 @@ import {
   getQueue,
 } from '../status/queueStatus.js';
 
-const CACHE_TTL_SECONDS = 10;
+const CACHE_TTL_SECONDS = 15;
 
 const queueStatusCache = createQueueStatusCache(async (cacheState) => {
   return await buildPublicQueueStatus(

--- a/apps/web/src/status/queueStatus.ts
+++ b/apps/web/src/status/queueStatus.ts
@@ -29,6 +29,7 @@ export interface PublicReleaseSummary {
   state: string;
   reason: string;
   updatedAt: string;
+  buildId?: string;
   source: 'git' | 'githubRelease';
   signed: boolean;
   retryable?: boolean;
@@ -109,7 +110,7 @@ interface CachedStatus {
   value: PublicQueueStatus;
 }
 
-const DEFAULT_TTL_SECONDS = 10;
+const DEFAULT_TTL_SECONDS = 15;
 const DEFAULT_JOB_LIMIT = 20;
 const DEFAULT_RELEASE_LIMIT = 20;
 
@@ -229,6 +230,7 @@ function summarizeRelease(
     state: enumName(ReleaseState, release.state),
     reason: enumName(ReleaseErrorCode, release.reason),
     updatedAt: new Date(release.updatedAt).toISOString(),
+    buildId: release.buildId || undefined,
     source: release.source || 'git',
     signed: release.signed === true,
   };
@@ -414,26 +416,26 @@ export function createQueueStatusCache(
       }
 
       if (!refreshPromise) {
-        const nextRefresh = runRefresh();
-        refreshPromise = (
-          cached ? nextRefresh.catch(() => cached as CachedStatus) : nextRefresh
-        ).finally(() => {
+        refreshPromise = runRefresh().finally(() => {
           refreshPromise = null;
         });
       }
 
-      if (cached) {
+      try {
+        const next = await refreshPromise;
         return {
-          ...cached.value,
-          cache: { ...cached.value.cache, state: 'stale', ttlSeconds },
+          ...next.value,
+          cache: { ...next.value.cache, state: 'fresh', ttlSeconds },
         };
+      } catch (error) {
+        if (cached) {
+          return {
+            ...cached.value,
+            cache: { ...cached.value.cache, state: 'stale', ttlSeconds },
+          };
+        }
+        throw error;
       }
-
-      const next = await refreshPromise;
-      return {
-        ...next.value,
-        cache: { ...next.value.cache, state: 'fresh', ttlSeconds },
-      };
     },
     clear(): void {
       cached = null;


### PR DESCRIPTION
## Summary
- tighten the public queue status page layout, typography, wide layout, and empty-section behavior
- change queue status caching to a 15s TTL that waits for the expired-cache refresh and only serves stale data after refresh failure
- expose release build IDs in the public status API and render failed release reasons as localized Azure build links when available

## Validation
- `npm test --workspace @openupm/web -- queueStatus.spec.ts`
- `npm test --workspace @openupm/docs -- queueStatusView.spec.ts`
- `npm run lint --workspace @openupm/web`
- `npm run lint --workspace @openupm/docs`
- `npm run build --workspace @openupm/web`
- `npm run docs:build:limit --workspace @openupm/docs`