### PR TITLE
Add queue status footer link

### DIFF
--- a/apps/docs/docs/.vuepress/components/Footer.vue
+++ b/apps/docs/docs/.vuepress/components/Footer.vue
@@ -20,6 +20,10 @@ const aboutLinks = computed(() => [
   {
     link: "https://openupm.github.io/upptime/",
     text: t("status")
+  },
+  {
+    link: "/queue/",
+    text: t("queue-status")
   }
 ]);
 

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -118,6 +118,7 @@ star: Star
 stars: Stars
 state: State
 status: Status
+queue-status: Queue Status
 submit-pr: Submit Pull Request
 supported-unity-version: supported unity version
 github-release-asset-package: GitHub Release asset package


### PR DESCRIPTION
## Summary
- add a Queue Status link under the footer About section immediately after Status
- add the footer label to the English locale file

## Validation
- `npm run lint --workspace @openupm/docs`
- `npm run build -- --filter=vuepress-plugin-openupm`
- `npm run docs:build:limit --workspace @openupm/docs`