### PR TITLE
[codex] Add package queue countdown

### DIFF
--- a/apps/docs/__tests__/vue/queueStatusView.spec.ts
+++ b/apps/docs/__tests__/vue/queueStatusView.spec.ts
@@ -75,6 +75,10 @@ describe("@/queueStatusView", () => {
       "2026-05-14T10:02:15.000Z",
       now,
     ).should.equal("Next scan in 2m 15s");
+    formatCountdown(
+      "2026-05-14T10:02:59.999Z",
+      now,
+    ).should.equal("Next scan in 3m");
     formatCountdown("2026-05-14T09:59:59.000Z", now).should.equal(
       "Next scan soon",
     );

--- a/apps/docs/__tests__/vue/queueStatusView.spec.ts
+++ b/apps/docs/__tests__/vue/queueStatusView.spec.ts
@@ -17,7 +17,15 @@ function createStatus(
     generatedAt: "2026-05-14T10:00:00.000Z",
     cache: { state: "fresh", ttlSeconds: 15 },
     summary: { state: "healthy", message: "ok" },
-    packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
+    packageQueue: {
+      waiting: 0,
+      active: 0,
+      delayed: 0,
+      failed: 0,
+      workers: 0,
+      oldestWaitingMs: null,
+      failedJobs: [],
+    },
     releaseQueue: {
       waiting: 0,
       active: 0,
@@ -40,15 +48,14 @@ describe("@/queueStatusView", () => {
     isQueueStatusEmpty(createStatus()).should.equal(true);
     isQueueStatusEmpty(
       createStatus({
-        releaseQueue: {
+        packageQueue: {
           waiting: 1,
           active: 0,
           delayed: 0,
           failed: 0,
           workers: 0,
           oldestWaitingMs: 60_000,
-          activeJobs: [],
-          waitingJobs: [],
+          failedJobs: [],
         },
       }),
     ).should.equal(false);

--- a/apps/docs/__tests__/vue/queueStatusView.spec.ts
+++ b/apps/docs/__tests__/vue/queueStatusView.spec.ts
@@ -4,6 +4,7 @@ chai.should();
 
 import {
   PublicQueueStatus,
+  formatCountdown,
   formatDuration,
   formatRelativeTime,
   isQueueStatusEmpty,
@@ -24,6 +25,7 @@ function createStatus(
       failed: 0,
       workers: 0,
       oldestWaitingMs: null,
+      nextScanAt: null,
       failedJobs: [],
     },
     releaseQueue: {
@@ -55,6 +57,7 @@ describe("@/queueStatusView", () => {
           failed: 0,
           workers: 0,
           oldestWaitingMs: 60_000,
+          nextScanAt: null,
           failedJobs: [],
         },
       }),
@@ -68,6 +71,13 @@ describe("@/queueStatusView", () => {
       "2h 15m ago",
     );
     formatDuration(2 * 60 * 60 * 1000 + 14 * 60 * 1000).should.equal("2h 14m");
+    formatCountdown(
+      "2026-05-14T10:02:15.000Z",
+      now,
+    ).should.equal("Next scan in 2m 15s");
+    formatCountdown("2026-05-14T09:59:59.000Z", now).should.equal(
+      "Next scan soon",
+    );
   });
 
   it("builds package links with encoded names", () => {

--- a/apps/docs/docs/.vuepress/components/PackagePipelinesView.vue
+++ b/apps/docs/docs/.vuepress/components/PackagePipelinesView.vue
@@ -156,6 +156,9 @@ const releaseEntries = computed(() => {
         </tr>
       </tbody>
     </table>
+    <p class="queue-status-link">
+      <RouterLink to="/queue/">{{ $t("queue-status-link-text") }}</RouterLink>
+    </p>
   </div>
 </template>
 
@@ -184,11 +187,17 @@ const releaseEntries = computed(() => {
     white-space: nowrap;
     border: 0;
   }
+
+  .queue-status-link {
+    margin: 0.35rem 0 0;
+    font-size: 0.75rem;
+  }
 }
 </style>
 
 <i18n locale="en-US" lang="yaml">
   invalid-git-tag-col-text: Invalid Git tag (e.g. not semver-compliant or duplicate version)
   github-release-asset-package: GitHub Release asset package
+  queue-status-link-text: Queue status
   signed-package: Signed package
 </i18n>

--- a/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
@@ -35,7 +35,12 @@
     <template v-if="status">
       <section class="queue-status__section">
         <div class="queue-status__section-title">
-          <h2>Package Scan Queue</h2>
+          <h2>
+            Package Scan Queue
+            <span v-if="packageNextScanText" class="queue-status__section-meta">
+              {{ packageNextScanText }}
+            </span>
+          </h2>
         </div>
         <div class="queue-status__metrics">
           <div>
@@ -231,7 +236,7 @@
 import axios from "axios";
 import urlJoin from "url-join";
 import { paramCase } from "change-case";
-import { onMounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   getAPIBaseUrl,
@@ -240,6 +245,7 @@ import {
 import {
   PublicQueueStatus,
   PublicReleaseSummary,
+  formatCountdown,
   formatDuration,
   formatRelativeTime,
   isQueueStatusEmpty,
@@ -252,6 +258,14 @@ const loading = ref(true);
 const error = ref("");
 const status = ref<PublicQueueStatus | null>(null);
 const nowMs = ref(Date.now());
+let clockTimer: ReturnType<typeof setInterval> | undefined;
+let refreshTimer: ReturnType<typeof setInterval> | undefined;
+
+const packageNextScanText = computed(() =>
+  status.value
+    ? formatCountdown(status.value.packageQueue.nextScanAt, nowMs.value)
+    : "",
+);
 
 function releaseReasonText(release: PublicReleaseSummary): string {
   const key = `release-reason-${paramCase(release.reason)}`;
@@ -263,8 +277,8 @@ function releaseBuildUrl(release: PublicReleaseSummary): string {
   return release.buildId ? getAzureWebBuildUrl(release.buildId) : "";
 }
 
-async function fetchQueueStatus(): Promise<void> {
-  loading.value = true;
+async function fetchQueueStatus(isInitial = false): Promise<void> {
+  if (isInitial) loading.value = true;
   error.value = "";
   try {
     const response = await axios.get(
@@ -276,14 +290,29 @@ async function fetchQueueStatus(): Promise<void> {
     status.value = response.data as PublicQueueStatus;
     nowMs.value = Date.now();
   } catch {
-    status.value = null;
-    error.value = "Queue status is temporarily unavailable.";
+    if (!status.value) {
+      status.value = null;
+      error.value = "Queue status is temporarily unavailable.";
+    }
   } finally {
-    loading.value = false;
+    if (isInitial) loading.value = false;
   }
 }
 
-onMounted(fetchQueueStatus);
+onMounted(() => {
+  void fetchQueueStatus(true);
+  clockTimer = setInterval(() => {
+    nowMs.value = Date.now();
+  }, 1000);
+  refreshTimer = setInterval(() => {
+    void fetchQueueStatus(false);
+  }, 15_000);
+});
+
+onUnmounted(() => {
+  if (clockTimer) clearInterval(clockTimer);
+  if (refreshTimer) clearInterval(refreshTimer);
+});
 </script>
 
 <style lang="scss">
@@ -376,6 +405,14 @@ onMounted(fetchQueueStatus);
     font-size: 0.8rem;
     line-height: 1.2;
   }
+}
+
+.queue-status__section-meta {
+  margin-left: 0.45rem;
+  color: #627d98;
+  font-size: 0.65rem;
+  font-weight: 400;
+  white-space: nowrap;
 }
 
 .queue-status__metrics {

--- a/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
@@ -39,7 +39,15 @@
         </div>
         <div class="queue-status__metrics">
           <div>
+            <span>Waiting</span
+            ><strong>{{ status.packageQueue.waiting }}</strong>
+          </div>
+          <div>
             <span>Active</span><strong>{{ status.packageQueue.active }}</strong>
+          </div>
+          <div>
+            <span>Delayed</span
+            ><strong>{{ status.packageQueue.delayed }}</strong>
           </div>
           <div>
             <span>Failed Jobs</span
@@ -48,6 +56,12 @@
           <div>
             <span>Workers</span
             ><strong>{{ status.packageQueue.workers }}</strong>
+          </div>
+          <div>
+            <span>Oldest Waiting</span>
+            <strong>{{
+              formatDuration(status.packageQueue.oldestWaitingMs) || "-"
+            }}</strong>
           </div>
         </div>
       </section>

--- a/apps/docs/docs/.vuepress/queueStatusView.ts
+++ b/apps/docs/docs/.vuepress/queueStatusView.ts
@@ -121,12 +121,13 @@ export function formatCountdown(value: string | null, nowMs = Date.now()): strin
   const second = 1000;
   const minute = 60 * second;
   const hour = 60 * minute;
-  if (remaining < minute) {
-    return `Next scan in ${Math.ceil(remaining / second)}s`;
+  const totalSeconds = Math.ceil(remaining / second);
+  if (totalSeconds < 60) {
+    return `Next scan in ${totalSeconds}s`;
   }
   if (remaining < hour) {
-    const minutes = Math.floor(remaining / minute);
-    const seconds = Math.ceil((remaining % minute) / second);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
     return seconds > 0
       ? `Next scan in ${minutes}m ${seconds}s`
       : `Next scan in ${minutes}m`;

--- a/apps/docs/docs/.vuepress/queueStatusView.ts
+++ b/apps/docs/docs/.vuepress/queueStatusView.ts
@@ -39,6 +39,7 @@ export interface PublicQueueStatus {
     failed: number;
     workers: number;
     oldestWaitingMs: number | null;
+    nextScanAt: string | null;
     failedJobs: PublicQueueJobSummary[];
   };
   releaseQueue: {
@@ -109,6 +110,28 @@ export function formatDuration(value: number | null): string {
     return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
   }
   return `${Math.floor(value / day)}d`;
+}
+
+export function formatCountdown(value: string | null, nowMs = Date.now()): string {
+  if (!value) return "";
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return "";
+  const remaining = timestamp - nowMs;
+  if (remaining <= 0) return "Next scan soon";
+  const second = 1000;
+  const minute = 60 * second;
+  const hour = 60 * minute;
+  if (remaining < minute) {
+    return `Next scan in ${Math.ceil(remaining / second)}s`;
+  }
+  if (remaining < hour) {
+    const minutes = Math.floor(remaining / minute);
+    const seconds = Math.ceil((remaining % minute) / second);
+    return seconds > 0
+      ? `Next scan in ${minutes}m ${seconds}s`
+      : `Next scan in ${minutes}m`;
+  }
+  return `Next scan in ${formatDuration(remaining)}`;
 }
 
 export function packageUrl(packageName: string): string {

--- a/apps/docs/docs/.vuepress/queueStatusView.ts
+++ b/apps/docs/docs/.vuepress/queueStatusView.ts
@@ -33,9 +33,12 @@ export interface PublicQueueStatus {
     message: string;
   };
   packageQueue: {
+    waiting: number;
     active: number;
+    delayed: number;
     failed: number;
     workers: number;
+    oldestWaitingMs: number | null;
     failedJobs: PublicQueueJobSummary[];
   };
   releaseQueue: {
@@ -56,6 +59,8 @@ export interface PublicQueueStatus {
 export function isQueueStatusEmpty(status: PublicQueueStatus): boolean {
   return (
     status.packageQueue.active === 0 &&
+    status.packageQueue.waiting === 0 &&
+    status.packageQueue.delayed === 0 &&
     status.packageQueue.failed === 0 &&
     status.releaseQueue.waiting === 0 &&
     status.releaseQueue.active === 0 &&

--- a/apps/web/__tests__/routers/queueStatus.spec.ts
+++ b/apps/web/__tests__/routers/queueStatus.spec.ts
@@ -51,6 +51,7 @@ describe('queue status router', () => {
         failed: 0,
         workers: 0,
         oldestWaitingMs: null,
+        nextScanAt: null,
         failedJobs: [],
       },
       releaseQueue: {

--- a/apps/web/__tests__/routers/queueStatus.spec.ts
+++ b/apps/web/__tests__/routers/queueStatus.spec.ts
@@ -44,7 +44,15 @@ describe('queue status router', () => {
       generatedAt: '2026-05-14T10:42:00.000Z',
       cache: { state: 'fresh', ttlSeconds: 15 },
       summary: { state: 'healthy', message: 'ok' },
-      packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
+      packageQueue: {
+        waiting: 0,
+        active: 0,
+        delayed: 0,
+        failed: 0,
+        workers: 0,
+        oldestWaitingMs: null,
+        failedJobs: [],
+      },
       releaseQueue: {
         waiting: 0,
         active: 0,

--- a/apps/web/__tests__/status/queueStatus.spec.ts
+++ b/apps/web/__tests__/status/queueStatus.spec.ts
@@ -85,6 +85,13 @@ describe('buildPublicQueueStatus', () => {
       counts: { active: 4, failed: 1, waiting: 5000, delayed: 1000 },
       workers: [{ private: 'worker-host' }],
       jobs: {
+        waiting: [
+          createJob({
+            id: 'build-pkg|com.old.waiting',
+            state: 'waiting',
+            timestamp: now - 120_000,
+          }),
+        ],
         failed: [
           createJob({
             id: 'build-pkg|com.bad.repo',
@@ -186,11 +193,13 @@ describe('buildPublicQueueStatus', () => {
 
     expect(status.generatedAt).toEqual(new Date(now).toISOString());
     expect(status.packageQueue).toMatchObject({
+      waiting: 5000,
       active: 4,
+      delayed: 1000,
       failed: 1,
       workers: 1,
+      oldestWaitingMs: 120_000,
     });
-    expect(status.packageQueue).not.toHaveProperty('waiting');
     expect(status.packageQueue.failedJobs[0]).toMatchObject({
       package: 'com.bad.repo',
       attempts: 3,
@@ -221,6 +230,12 @@ describe('buildPublicQueueStatus', () => {
     const packageQueue = createQueue({
       counts: { active: 0, failed: 3 },
       jobs: {
+        waiting: [
+          createJob({
+            id: 'build-pkg|com.old.waiting',
+            timestamp: 1_700_000_000_000,
+          }),
+        ],
         failed: [
           createJob({ id: 'build-pkg|com.one' }),
           createJob({ id: 'build-pkg|com.two' }),
@@ -256,6 +271,7 @@ describe('buildPublicQueueStatus', () => {
     expect(status.packageQueue.failedJobs).toHaveLength(2);
     expect(status.recentSuccessfulReleases).toHaveLength(2);
     expect(packageQueue.getJobs).toHaveBeenCalledWith(['failed'], 0, 1, false);
+    expect(packageQueue.getJobs).toHaveBeenCalledWith(['waiting'], 0, 0, true);
   });
 });
 
@@ -271,7 +287,15 @@ describe('createQueueStatusCache', () => {
         generatedAt: new Date(now).toISOString(),
         cache: { state: 'fresh' as const, ttlSeconds: 15 },
         summary: { state: 'healthy' as const, message: 'ok' },
-        packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
+        packageQueue: {
+          waiting: 0,
+          active: 0,
+          delayed: 0,
+          failed: 0,
+          workers: 0,
+          oldestWaitingMs: null,
+          failedJobs: [],
+        },
         releaseQueue: {
           waiting: 0,
           active: 0,
@@ -314,7 +338,15 @@ describe('createQueueStatusCache', () => {
         generatedAt: new Date(now).toISOString(),
         cache: { state: 'fresh' as const, ttlSeconds: 15 },
         summary: { state: 'healthy' as const, message: 'ok' },
-        packageQueue: { active: 0, failed: 0, workers: 0, failedJobs: [] },
+        packageQueue: {
+          waiting: 0,
+          active: 0,
+          delayed: 0,
+          failed: 0,
+          workers: 0,
+          oldestWaitingMs: null,
+          failedJobs: [],
+        },
         releaseQueue: {
           waiting: 0,
           active: 0,

--- a/apps/web/__tests__/status/queueStatus.spec.ts
+++ b/apps/web/__tests__/status/queueStatus.spec.ts
@@ -4,6 +4,7 @@ import { ReleaseErrorCode, ReleaseState } from '@openupm/types';
 import {
   buildPublicQueueStatus,
   createQueueStatusCache,
+  getNextPackageScanAt,
   parseReleaseJobIdentity,
 } from '../../src/status/queueStatus.js';
 
@@ -75,6 +76,14 @@ describe('parseReleaseJobIdentity', () => {
       packageName: 'com.example.camera',
       version: '1.0.0-preview+build',
     });
+  });
+});
+
+describe('getNextPackageScanAt', () => {
+  it('returns the next package scan cron timestamp', () => {
+    expect(getNextPackageScanAt(Date.parse('2026-05-14T10:02:45.000Z'))).toBe(
+      '2026-05-14T10:05:00.000Z',
+    );
   });
 });
 
@@ -199,6 +208,7 @@ describe('buildPublicQueueStatus', () => {
       failed: 1,
       workers: 1,
       oldestWaitingMs: 120_000,
+      nextScanAt: '2023-11-14T22:20:00.000Z',
     });
     expect(status.packageQueue.failedJobs[0]).toMatchObject({
       package: 'com.bad.repo',
@@ -294,6 +304,7 @@ describe('createQueueStatusCache', () => {
           failed: 0,
           workers: 0,
           oldestWaitingMs: null,
+          nextScanAt: null,
           failedJobs: [],
         },
         releaseQueue: {
@@ -345,6 +356,7 @@ describe('createQueueStatusCache', () => {
           failed: 0,
           workers: 0,
           oldestWaitingMs: null,
+          nextScanAt: null,
           failedJobs: [],
         },
         releaseQueue: {

--- a/apps/web/config/default.json5
+++ b/apps/web/config/default.json5
@@ -85,6 +85,14 @@
     },
   },
 
+  // Internal schedules. Defaults mirror legacy PM2 cron_restart values.
+  schedules: {
+    addBuildPackageJob: {
+      enabled: true,
+      cronTime: '*/5 * * * *',
+    },
+  },
+
   // GitHub.
   github: {
     graphqlEndpoint: 'https://api.github.com/graphql',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@openupm/server-common": "*",
     "bullmq": "^5.58.5",
     "config": "^4.4.1",
+    "cron": "^3.1.6",
     "dotenv-flow": "^4.0.1",
     "fastify": "^4.25.2",
     "supertest": "^6.3.4",

--- a/apps/web/src/status/queueStatus.ts
+++ b/apps/web/src/status/queueStatus.ts
@@ -46,9 +46,12 @@ export interface PublicQueueStatus {
     message: string;
   };
   packageQueue: {
+    waiting: number;
     active: number;
+    delayed: number;
     failed: number;
     workers: number;
+    oldestWaitingMs: number | null;
     failedJobs: PublicQueueJobSummary[];
   };
   releaseQueue: {
@@ -278,7 +281,12 @@ export async function buildPublicQueueStatus(
   const releaseLimit = options.releaseLimit ?? DEFAULT_RELEASE_LIMIT;
   const [packageCounts, packageWorkers, releaseCounts, releaseWorkers] =
     await Promise.all([
-      sources.packageQueue.getJobCounts('active', 'failed'),
+      sources.packageQueue.getJobCounts(
+        'waiting',
+        'active',
+        'delayed',
+        'failed',
+      ),
       sources.packageQueue.getWorkers(),
       sources.releaseQueue.getJobCounts(
         'waiting',
@@ -291,6 +299,7 @@ export async function buildPublicQueueStatus(
 
   const [
     failedPackageJobs,
+    oldestWaitingPackageJobs,
     activeReleaseJobs,
     waitingReleaseJobs,
     failedReleaseJobs,
@@ -298,6 +307,7 @@ export async function buildPublicQueueStatus(
     recentFailedReleases,
   ] = await Promise.all([
     getLimitedJobs(sources.packageQueue, ['failed'], jobLimit),
+    getLimitedJobs(sources.packageQueue, ['waiting'], 1, true),
     getLimitedJobs(sources.releaseQueue, ['active'], jobLimit),
     getLimitedJobs(sources.releaseQueue, ['waiting'], jobLimit, true),
     getLimitedJobs(sources.releaseQueue, ['failed'], jobLimit),
@@ -322,6 +332,9 @@ export async function buildPublicQueueStatus(
         now - Math.min(...waitingReleaseJobs.map((job) => job.timestamp)),
       )
     : null;
+  const packageOldestWaitingMs = oldestWaitingPackageJobs.length
+    ? Math.max(0, now - oldestWaitingPackageJobs[0].timestamp)
+    : null;
   const packageFailed = countValue(packageCounts, 'failed');
   const releaseFailed = countValue(releaseCounts, 'failed');
   const releaseWaiting = countValue(releaseCounts, 'waiting');
@@ -339,9 +352,12 @@ export async function buildPublicQueueStatus(
       oldestWaitingMs,
     }),
     packageQueue: {
+      waiting: countValue(packageCounts, 'waiting'),
       active: countValue(packageCounts, 'active'),
+      delayed: countValue(packageCounts, 'delayed'),
       failed: packageFailed,
       workers: packageWorkers.length,
+      oldestWaitingMs: packageOldestWaitingMs,
       failedJobs: await Promise.all(
         failedPackageJobs.map(
           async (job) => await summarizeJob(job, 'package'),

--- a/apps/web/src/status/queueStatus.ts
+++ b/apps/web/src/status/queueStatus.ts
@@ -1,5 +1,6 @@
 import configRaw from 'config';
 import { Job, JobType, Queue } from 'bullmq';
+import { CronTime } from 'cron';
 import {
   ReleaseErrorCode,
   ReleaseModel,
@@ -52,6 +53,7 @@ export interface PublicQueueStatus {
     failed: number;
     workers: number;
     oldestWaitingMs: number | null;
+    nextScanAt: string | null;
     failedJobs: PublicQueueJobSummary[];
   };
   releaseQueue: {
@@ -212,6 +214,25 @@ function countValue(counts: Record<string, number>, key: string): number {
   return Number(counts[key] || 0);
 }
 
+export function getNextPackageScanAt(now: number): string | null {
+  const jobConfig = config.schedules?.addBuildPackageJob ?? {};
+  if (jobConfig.enabled === false) return null;
+
+  try {
+    const cronTime = new CronTime(jobConfig.cronTime || '*/5 * * * *');
+    const next = cronTime.getNextDateFrom(new Date(now));
+    const nextDate = next as unknown as { toMillis?: () => number };
+    const nextMs =
+      typeof nextDate.toMillis === 'function'
+        ? nextDate.toMillis()
+        : new Date(String(next)).getTime();
+    if (!Number.isFinite(nextMs)) return null;
+    return new Date(nextMs).toISOString();
+  } catch {
+    return null;
+  }
+}
+
 async function getLimitedJobs(
   queue: QueueLike,
   types: JobType[],
@@ -358,6 +379,7 @@ export async function buildPublicQueueStatus(
       failed: packageFailed,
       workers: packageWorkers.length,
       oldestWaitingMs: packageOldestWaitingMs,
+      nextScanAt: getNextPackageScanAt(now),
       failedJobs: await Promise.all(
         failedPackageJobs.map(
           async (job) => await summarizeJob(job, 'package'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,7 @@
         "@openupm/server-common": "*",
         "bullmq": "^5.58.5",
         "config": "^4.4.1",
+        "cron": "^3.1.6",
         "dotenv-flow": "^4.0.1",
         "fastify": "^4.25.2",
         "supertest": "^6.3.4",


### PR DESCRIPTION
## Summary

- Show package scan waiting, delayed, and oldest waiting aggregate values in the public queue status page.
- Add a small live `Next scan in ...` countdown next to the Package Scan Queue heading.
- Expose `packageQueue.nextScanAt` from the public queue status API based on the package scan scheduler cron.
- Add a Queue status link at the end of the package detail build pipelines widget.

## Validation

- `npm run test -- __tests__/status/queueStatus.spec.ts __tests__/routers/queueStatus.spec.ts` from `apps/web`
- `npm run test -- queueStatusView.spec.ts` from `apps/docs`
- `npm run lint` from `apps/web`
- `npm run lint` from `apps/docs`
- `npm run docs:build:limit` from `apps/docs`