### PR TITLE
[codex] Add queue status blog post

### DIFF
--- a/apps/docs/docs/.vuepress/blog.ts
+++ b/apps/docs/docs/.vuepress/blog.ts
@@ -14,6 +14,15 @@ export const BLOG_RSS_PATH = "/blog/rss.xml";
 
 export const BLOG_POSTS: BlogPost[] = [
   {
+    title: "OpenUPM Queue Status Page",
+    slug: "openupm-queue-status-page",
+    author: "Favo Yang",
+    date: "2026-05-14",
+    readingTime: "1 min read",
+    excerpt:
+      "OpenUPM now has a public queue status page for package scan and release build activity.",
+  },
+  {
     title: "UnityNuGet Packages Are Now Code Signed",
     slug: "unitynuget-packages-are-now-code-signed",
     author: "Favo Yang",

--- a/apps/docs/docs/blog/openupm-queue-status-page/index.md
+++ b/apps/docs/docs/blog/openupm-queue-status-page/index.md
@@ -1,0 +1,36 @@
+---
+title: "OpenUPM Queue Status Page"
+author: "Favo Yang"
+date: "2026-05-14"
+readingTime: "1 min read"
+description: "OpenUPM now has a public queue status page for package scan and release build activity."
+editLink: false
+---
+# OpenUPM Queue Status Page
+
+<BlogPostMeta />
+
+OpenUPM now has a public queue status page:
+
+```text
+https://openupm.com/queue/
+```
+
+The page shows package scan activity, release build queue health, recent
+successful releases, and recent failed releases. It is meant to answer a simple
+question without asking maintainers to check private dashboards: is OpenUPM
+currently finding and building packages?
+
+The package scan section shows active, waiting, delayed, and failed job counts.
+It also includes the next scheduled scan countdown, so package maintainers can
+see when the next scan cycle should start.
+
+The release build section shows waiting, active, delayed, and failed release
+jobs, plus the oldest waiting release age. Recent release tables include links
+to packages, and failed release reasons link to the related Azure build when
+that build information is available.
+
+You can also find the page from the site footer under About, next to the
+existing status link.
+
+<BlogPostNav />


### PR DESCRIPTION
## Summary

- Add a short blog post introducing the public OpenUPM queue status page.
- Register the post in blog metadata so it appears in the blog index, navigation, and RSS.

## Validation

- `npm run test -- blog.spec.ts` from `apps/docs`
- `npm run lint` from `apps/docs`
- `npm run docs:build:limit` from `apps/docs`