### PR TITLE
Improve queue status page polish

### DIFF
--- a/apps/docs/__tests__/vue/queueStatusView.spec.ts
+++ b/apps/docs/__tests__/vue/queueStatusView.spec.ts
@@ -74,11 +74,19 @@ describe("@/queueStatusView", () => {
     formatCountdown(
       "2026-05-14T10:02:15.000Z",
       now,
-    ).should.equal("Next scan in 2m 15s");
+    ).should.equal("Next scan in 2m");
+    formatCountdown(
+      "2026-05-14T10:00:45.000Z",
+      now,
+    ).should.equal("Next scan in 45s");
+    formatCountdown(
+      "2026-05-14T10:00:59.500Z",
+      now,
+    ).should.equal("Next scan in 60s");
     formatCountdown(
       "2026-05-14T10:02:59.999Z",
       now,
-    ).should.equal("Next scan in 3m");
+    ).should.equal("Next scan in 2m");
     formatCountdown("2026-05-14T09:59:59.000Z", now).should.equal(
       "Next scan soon",
     );

--- a/apps/docs/docs/.vuepress/components/PackagePipelinesView.vue
+++ b/apps/docs/docs/.vuepress/components/PackagePipelinesView.vue
@@ -157,7 +157,7 @@ const releaseEntries = computed(() => {
       </tbody>
     </table>
     <p class="queue-status-link">
-      <RouterLink to="/queue/">{{ $t("queue-status-link-text") }}</RouterLink>
+      <RouterLink to="/queue/">{{ $t("queue-status") }}</RouterLink>
     </p>
   </div>
 </template>
@@ -198,6 +198,5 @@ const releaseEntries = computed(() => {
 <i18n locale="en-US" lang="yaml">
   invalid-git-tag-col-text: Invalid Git tag (e.g. not semver-compliant or duplicate version)
   github-release-asset-package: GitHub Release asset package
-  queue-status-link-text: Queue status
   signed-package: Signed package
 </i18n>

--- a/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
@@ -320,7 +320,7 @@ onUnmounted(() => {
   max-width: none;
   margin: 0 auto;
   padding: 1rem 0.75rem 2rem;
-  color: #1f2933;
+  color: var(--c-text);
   font-size: 0.75rem;
 }
 
@@ -337,7 +337,7 @@ onUnmounted(() => {
 
   p {
     margin: 0;
-    color: #52606d;
+    color: var(--c-text-light);
     font-size: 0.7rem;
   }
 }
@@ -355,7 +355,7 @@ onUnmounted(() => {
 }
 
 .queue-status__state {
-  color: #102a43;
+  color: var(--c-text);
   font-weight: 700;
   text-transform: uppercase;
 
@@ -373,16 +373,16 @@ onUnmounted(() => {
 }
 
 .queue-status__updated {
-  color: #627d98;
+  color: var(--c-text-lighter);
   font-size: 0.65rem;
 }
 
 .queue-status__notice {
   margin: 0.75rem 0;
-  border: 1px solid #bcccdc;
+  border: 1px solid var(--c-border);
   padding: 0.5rem 0.65rem;
-  background: #f8fafc;
-  color: #334e68;
+  background: var(--c-bg-light);
+  color: var(--c-text);
 
   &.is-error {
     border-color: #f1aeb5;
@@ -409,7 +409,7 @@ onUnmounted(() => {
 
 .queue-status__section-meta {
   margin-left: 0.45rem;
-  color: #627d98;
+  color: var(--c-text-lighter);
   font-size: 0.65rem;
   font-weight: 400;
   white-space: nowrap;
@@ -418,12 +418,12 @@ onUnmounted(() => {
 .queue-status__metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
-  border: 1px solid #d9e2ec;
+  border: 1px solid var(--c-border);
 
   div {
     display: grid;
     gap: 0.1rem;
-    border-right: 1px solid #d9e2ec;
+    border-right: 1px solid var(--c-border);
     padding: 0.45rem 0.55rem;
 
     &:last-child {
@@ -432,7 +432,7 @@ onUnmounted(() => {
   }
 
   span {
-    color: #627d98;
+    color: var(--c-text-lighter);
     font-size: 0.68rem;
     text-transform: uppercase;
   }
@@ -457,7 +457,31 @@ onUnmounted(() => {
     grid-template-columns: repeat(2, minmax(0, 1fr));
 
     div {
-      border-bottom: 1px solid #d9e2ec;
+      border-bottom: 1px solid var(--c-border);
+    }
+  }
+}
+
+.dark {
+  .queue-status__state {
+    &.is-healthy {
+      color: #4dd0e1;
+    }
+
+    &.is-backlog {
+      color: #ffd166;
+    }
+
+    &.is-degraded {
+      color: #ff8a80;
+    }
+  }
+
+  .queue-status__notice {
+    &.is-error {
+      border-color: rgba(255, 138, 128, 0.42);
+      background: rgba(180, 35, 24, 0.14);
+      color: #ff8a80;
     }
   }
 }

--- a/apps/docs/docs/.vuepress/components/QueueStatusTable.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusTable.vue
@@ -56,15 +56,15 @@ defineProps<{
 
 .queue-status-table th,
 .queue-status-table td {
-  border-bottom: 1px solid #e4e7eb;
+  border-bottom: 1px solid var(--c-border);
   padding: 0.55rem 0.65rem;
   text-align: left;
   vertical-align: top;
 }
 
 .queue-status-table th {
-  background: #f0f4f8;
-  color: #52606d;
+  background: var(--c-bg-light);
+  color: var(--c-text-light);
   font-size: 0.7rem;
   text-transform: uppercase;
 }
@@ -75,6 +75,17 @@ defineProps<{
 }
 
 .queue-status-table__empty {
-  color: #627d98;
+  color: var(--c-text-lighter);
+}
+
+.dark {
+  .queue-status-table th {
+    background: var(--c-bg-dark);
+    color: var(--c-text-lighter);
+  }
+
+  .queue-status-table tbody tr:nth-child(even) td {
+    background: rgba(255, 255, 255, 0.02);
+  }
 }
 </style>

--- a/apps/docs/docs/.vuepress/queueStatusView.ts
+++ b/apps/docs/docs/.vuepress/queueStatusView.ts
@@ -121,16 +121,11 @@ export function formatCountdown(value: string | null, nowMs = Date.now()): strin
   const second = 1000;
   const minute = 60 * second;
   const hour = 60 * minute;
-  const totalSeconds = Math.ceil(remaining / second);
-  if (totalSeconds < 60) {
-    return `Next scan in ${totalSeconds}s`;
+  if (remaining < minute) {
+    return `Next scan in ${Math.ceil(remaining / second)}s`;
   }
   if (remaining < hour) {
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    return seconds > 0
-      ? `Next scan in ${minutes}m ${seconds}s`
-      : `Next scan in ${minutes}m`;
+    return `Next scan in ${Math.floor(remaining / minute)}m`;
   }
   return `Next scan in ${formatDuration(remaining)}`;
 }


### PR DESCRIPTION
## Summary
- improve queue status page dark-mode colors by using theme variables
- simplify the package scan countdown so seconds only show below one minute
- fix the package build pipeline widget queue-status link translation

## Root Cause
The queue page used several hard-coded light-mode colors, which rendered poorly in dark mode. The pipeline widget introduced a component-local translation key that did not resolve in the rendered package detail view, so the raw key was displayed.

## Validation
- `npm run lint`
- `npm run test -- queueStatusView.spec.ts`
- `npm run docs:build:limit`