### PR TITLE
[codex] Make queue status blog link clickable

### DIFF
--- a/apps/docs/docs/blog/openupm-queue-status-page/index.md
+++ b/apps/docs/docs/blog/openupm-queue-status-page/index.md
@@ -12,9 +12,7 @@ editLink: false
 
 OpenUPM now has a public queue status page:
 
-```text
-https://openupm.com/queue/
-```
+[https://openupm.com/queue/](https://openupm.com/queue/)
 
 The page shows package scan activity, release build queue health, recent
 successful releases, and recent failed releases. It is meant to answer a simple


### PR DESCRIPTION
## Summary

- Replace the fenced plain-text queue status URL in the blog post with a Markdown link.
- This makes the main `https://openupm.com/queue/` link clickable when rendered on the docs site.

## Validation

- `npm run test -- blog.spec.ts`
- `npm run lint`
- `npm run build -- --filter=vuepress-plugin-openupm`
- `npm run docs:build:limit`