### PR TITLE
[codex] Add docs status navigation links

### DIFF
--- a/apps/docs/docs/.vuepress/components/Footer.vue
+++ b/apps/docs/docs/.vuepress/components/Footer.vue
@@ -19,7 +19,7 @@ const aboutLinks = computed(() => [
   },
   {
     link: "https://openupm.github.io/upptime/",
-    text: t("status")
+    text: t("website-status")
   },
   {
     link: "/queue/",

--- a/apps/docs/docs/.vuepress/config-us.ts
+++ b/apps/docs/docs/.vuepress/config-us.ts
@@ -153,6 +153,8 @@ export const themeConfig: any = {
       children: [
         { text: "Support OpenUPM", link: "/support/" },
         { text: "Contributors", link: "/contributors/" },
+        { text: "Website Status", link: "https://openupm.github.io/upptime/" },
+        { text: "Queue Status", link: "/queue/" },
       ],
     },
     {

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -185,6 +185,7 @@ star: Star
 stars: Stars
 state: State
 status: Status
+website-status: Website Status
 queue-status: Queue Status
 submit-pr: Submit Pull Request
 submit-metadata: submit metadata


### PR DESCRIPTION
## Summary
- Rename the footer Upptime link label to Website Status
- Add Website Status and Queue Status links to the Support navbar dropdown

## Validation
- npm run lint
- npm run docs:build:limit