### PR TITLE
Document UnityNuGet search through OpenUPM

### DIFF
--- a/apps/docs/docs/.vuepress/blog.ts
+++ b/apps/docs/docs/.vuepress/blog.ts
@@ -14,6 +14,15 @@ export const BLOG_RSS_PATH = "/blog/rss.xml";
 
 export const BLOG_POSTS: BlogPost[] = [
   {
+    title: "UnityNuGet Search Now Works Through OpenUPM",
+    slug: "unitynuget-search-now-works-through-openupm",
+    author: "Favo Yang",
+    date: "2026-05-15",
+    readingTime: "1 min read",
+    excerpt:
+      "OpenUPM's registry upgrade makes org.nuget packages visible through registry search while keeping UnityNuGet package resolution behind the OpenUPM endpoint.",
+  },
+  {
     title: "OpenUPM Queue Status Page",
     slug: "openupm-queue-status-page",
     author: "Favo Yang",

--- a/apps/docs/docs/.vuepress/blog.ts
+++ b/apps/docs/docs/.vuepress/blog.ts
@@ -20,7 +20,7 @@ export const BLOG_POSTS: BlogPost[] = [
     date: "2026-05-15",
     readingTime: "1 min read",
     excerpt:
-      "OpenUPM's registry upgrade makes org.nuget packages visible through registry search while keeping UnityNuGet package resolution behind the OpenUPM endpoint.",
+      "OpenUPM's registry upgrade experimentally makes org.nuget packages visible through registry search while keeping UnityNuGet package resolution behind the OpenUPM endpoint.",
   },
   {
     title: "OpenUPM Queue Status Page",

--- a/apps/docs/docs/blog/unitynuget-search-now-works-through-openupm/index.md
+++ b/apps/docs/docs/blog/unitynuget-search-now-works-through-openupm/index.md
@@ -3,14 +3,14 @@ title: "UnityNuGet Search Now Works Through OpenUPM"
 author: "Favo Yang"
 date: "2026-05-15"
 readingTime: "1 min read"
-description: "OpenUPM's registry upgrade makes org.nuget packages visible through registry search while keeping UnityNuGet package resolution behind the OpenUPM endpoint."
+description: "OpenUPM's registry upgrade experimentally makes org.nuget packages visible through registry search while keeping UnityNuGet package resolution behind the OpenUPM endpoint."
 ---
 
 # UnityNuGet Search Now Works Through OpenUPM
 
-OpenUPM has upgraded its package registry runtime. One visible change for Unity
-developers is better UnityNuGet uplink behavior: packages under the `org.nuget`
-scope can now appear in OpenUPM registry search results.
+OpenUPM has upgraded its package registry runtime. One visible experimental
+change for Unity developers is better UnityNuGet uplink behavior: packages
+under the `org.nuget` scope can now appear in OpenUPM registry search results.
 
 Previously, `org.nuget` packages resolved correctly when a project requested a
 specific package, but registry search returned `404 packages not found` for
@@ -21,6 +21,11 @@ With the new registry runtime, the OpenUPM registry includes uplink search
 results from UnityNuGet. You can still install and resolve packages through
 `https://package.openupm.com`, and searches for `org.nuget` packages should now
 work through the same OpenUPM registry endpoint.
+
+We still treat searchable UnityNuGet uplinks as experimental. It is backed by
+the current registry behavior and we expect it to be retained in future
+upgrades, but it can still depend on UnityNuGet availability, cache freshness,
+and upstream registry behavior.
 
 The OpenUPM website package browser remains focused on curated OpenUPM packages,
 so UnityNuGet packages are not listed as normal website package pages. For the

--- a/apps/docs/docs/blog/unitynuget-search-now-works-through-openupm/index.md
+++ b/apps/docs/docs/blog/unitynuget-search-now-works-through-openupm/index.md
@@ -1,0 +1,31 @@
+---
+title: "UnityNuGet Search Now Works Through OpenUPM"
+author: "Favo Yang"
+date: "2026-05-15"
+readingTime: "1 min read"
+description: "OpenUPM's registry upgrade makes org.nuget packages visible through registry search while keeping UnityNuGet package resolution behind the OpenUPM endpoint."
+---
+
+# UnityNuGet Search Now Works Through OpenUPM
+
+OpenUPM has upgraded its package registry runtime. One visible change for Unity
+developers is better UnityNuGet uplink behavior: packages under the `org.nuget`
+scope can now appear in OpenUPM registry search results.
+
+Previously, `org.nuget` packages resolved correctly when a project requested a
+specific package, but registry search returned `404 packages not found` for
+NuGet packages. That affected `openupm search` and the Unity Package Manager
+search interface.
+
+With the new registry runtime, the OpenUPM registry includes uplink search
+results from UnityNuGet. You can still install and resolve packages through
+`https://package.openupm.com`, and searches for `org.nuget` packages should now
+work through the same OpenUPM registry endpoint.
+
+The OpenUPM website package browser remains focused on curated OpenUPM packages,
+so UnityNuGet packages are not listed as normal website package pages. For the
+complete UnityNuGet package list, continue to use the UnityNuGet registry list
+and documentation.
+
+See the updated [NuGet Packages](/nuget/) documentation for usage details and
+the remaining limitations.

--- a/apps/docs/docs/nuget/index.md
+++ b/apps/docs/docs/nuget/index.md
@@ -24,13 +24,12 @@ To improve convenience, the OpenUPM registry [uplinks](https://verdaccio.org/doc
 - The OpenUPM registry synchronizes with the UnityNuGet registry on an hourly basis.
 - Package tarballs are hosted on our CDN server, ensuring fast access.
 - You can view package details via `https://package.openupm.com/org.nuget.some-package` or by using the openupm-cli command `openupm view org.nuget.some-package`.
+- You can search `org.nuget` packages through the OpenUPM registry search endpoint, openupm-cli search, and the Unity Package Manager search interface.
 
 The integration comes with a few limitations:
 
 - NuGet packages are neither searchable nor browsable on the OpenUPM website.
-- Searching for NuGet packages via the OpenUPM registry's search endpoint will return "404 packages not found." This affects both the openupm-cli's search command and the Unity Package Manager's search interface. As a side effect:
-  - NuGet packages will be invisible in the Unity Package Manager's "My Registries" section, although they remain visible in the "In Project" section.
-  - The Unity console will display a warning "Error searching for packages" the first time you open the Package Manager.
+- Search results are served by the registry uplink and may depend on UnityNuGet availability and cache freshness. If UnityNuGet is temporarily unavailable, already cached package metadata and tarballs continue to resolve through OpenUPM, but new uncached search results may be delayed until the uplink recovers.
 
 To demonstrate the uplinks feature, we have created a staging package at [https://github.com/openupm/com.example.nuget-consumer](https://github.com/openupm/com.example.nuget-consumer) which includes:
 
@@ -41,7 +40,7 @@ If you install a package via openupm-cli, the uplink is used by default— all p
 
 ## Using UnityNuGet Directly
 
-In general, we recommend using the uplink feature to take advantage of the CDN and openupm-cli. However, if you wish to bypass the limitations mentioned above, you can use the UnityNuGet registry directly by adding it as a scoped registry in your `manifest.json`:
+In general, we recommend using the uplink feature to take advantage of the CDN and openupm-cli. If you prefer to query UnityNuGet directly, you can add the UnityNuGet registry as a scoped registry in your `manifest.json`:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- update the NuGet docs now that org.nuget packages are included in registry search results
- add a short blog post explaining the UnityNuGet search behavior change after the registry upgrade
- register the new blog post in VuePress blog metadata

## Validation
- npx npm@10.9.3 install
- npm run test -- blog.spec.ts
- npm run lint
- npm run build -- --filter=vuepress-plugin-openupm
- npm run docs:build:limit
- git diff --check