### PR TITLE
[codex] Rename website status label

### DIFF
--- a/apps/docs/docs/.vuepress/config-us.ts
+++ b/apps/docs/docs/.vuepress/config-us.ts
@@ -153,7 +153,7 @@ export const themeConfig: any = {
       children: [
         { text: "Support OpenUPM", link: "/support/" },
         { text: "Contributors", link: "/contributors/" },
-        { text: "Website Status", link: "https://openupm.github.io/upptime/" },
+        { text: "Uptime Status", link: "https://openupm.github.io/upptime/" },
         { text: "Queue Status", link: "/queue/" },
       ],
     },

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -185,7 +185,7 @@ star: Star
 stars: Stars
 state: State
 status: Status
-website-status: Website Status
+website-status: Uptime Status
 queue-status: Queue Status
 submit-pr: Submit Pull Request
 submit-metadata: submit metadata


### PR DESCRIPTION
## Summary

- Rename the docs support navbar uptime link from `Website Status` to `Uptime Status`.
- Update the English footer locale text used by the same status link.

## Validation

- `npm run lint` from `apps/docs`
- `npm run build -- --filter=vuepress-plugin-openupm`
- `npm run docs:build:limit` from `apps/docs`