### PR TITLE
[codex] add package alias redirects

### DIFF
--- a/apps/docs/__tests__/vue/packageMetadata.spec.ts
+++ b/apps/docs/__tests__/vue/packageMetadata.spec.ts
@@ -1,0 +1,25 @@
+import { getPackageAliasNavLinks } from '../../docs/.vuepress/components/package-metadata';
+import { describe, expect, it } from 'vitest';
+
+describe('package metadata aliases', () => {
+  it('returns no links for packages without aliases', () => {
+    expect(getPackageAliasNavLinks({ aliases: [] })).toEqual([]);
+  });
+
+  it('returns links to redirected package pages for aliases', () => {
+    expect(
+      getPackageAliasNavLinks({
+        aliases: ['com.example.old', 'com.example.older'],
+      }),
+    ).toEqual([
+      {
+        link: '/packages/com.example.old/',
+        text: 'com.example.old',
+      },
+      {
+        link: '/packages/com.example.older/',
+        text: 'com.example.older',
+      },
+    ]);
+  });
+});

--- a/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
@@ -5,6 +5,7 @@ import { PropType, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { timeAgoFormat } from '@/utils';
+import { getPackageAliasNavLinks } from './package-metadata';
 import { getAvatarImageUrl, getGitHubPackageMetadataUrl, getPackageDetailPageUrl } from '@openupm/common/build/urls.js';
 import { DownloadsRange, PackageInfo, PackageMetadata, Packument } from "@openupm/types";
 
@@ -88,6 +89,10 @@ const hunterNavLink = computed(() => {
     link: props.metadata.hunterUrl,
     text: props.metadata.hunter,
   };
+});
+
+const aliasNavLinks = computed(() => {
+  return getPackageAliasNavLinks(props.metadata);
 });
 
 const isLoadingPackageSetup = computed(() => {
@@ -270,6 +275,14 @@ const trackingModeTooltip = computed(() => {
           {{ trackingModeText }}
           <i class="fas fa-info-circle" aria-hidden="true"></i>
         </span>
+      </section>
+      <section v-if="aliasNavLinks.length" class="col-12">
+        <div class="metadata-title">Aliases</div>
+        <ul class="section-list alias-list">
+          <li v-for="aliasNavLink in aliasNavLinks" :key="aliasNavLink.text">
+            <AutoLink :item="aliasNavLink" />
+          </li>
+        </ul>
       </section>
       <section class="col-6">
         <div class="metadata-title">{{ $capitalize($t("authors")) }}</div>

--- a/apps/docs/docs/.vuepress/components/package-metadata.ts
+++ b/apps/docs/docs/.vuepress/components/package-metadata.ts
@@ -1,0 +1,16 @@
+import { PackageMetadata } from '@openupm/types';
+import { getPackageDetailPagePath } from '@openupm/common/build/urls.js';
+
+export type PackageAliasNavLink = {
+  link: string;
+  text: string;
+};
+
+export function getPackageAliasNavLinks(
+  metadata: Pick<PackageMetadata, 'aliases'>,
+): PackageAliasNavLink[] {
+  return metadata.aliases.map((alias) => ({
+    link: getPackageDetailPagePath(alias),
+    text: alias,
+  }));
+}

--- a/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
@@ -524,6 +524,7 @@ const genYaml = (): string => {
   const packageJsonObj = state.packageJsonObj;
   const content: Record<string, unknown> = {
     name: packageJsonObj.name,
+    aliases: [],
     displayName: packageJsonObj.displayName,
     description: packageJsonObj.description || repoInfo.description || "",
     repoUrl: repoInfo.html_url,

--- a/apps/docs/docs/docs/adding-upm-package.md
+++ b/apps/docs/docs/docs/adding-upm-package.md
@@ -62,6 +62,8 @@ OpenUPM utilizes a YAML file to store package information. Below is an example o
 ```yaml
 # The package name
 name: com.namespace.unitypackageexample
+# Old package names that should redirect to this package page. This does not create registry aliases.
+aliases: []
 # The package display name
 displayName: Unity Package Example
 # The short package description

--- a/apps/docs/docs/docs/modifying-upm-package.md
+++ b/apps/docs/docs/docs/modifying-upm-package.md
@@ -34,9 +34,15 @@ To rename a published package, please follow these steps:
 
 - In your repository, modify the package name in the `package.json`, bump the version, and create a new Git tag.
 
-- Locate the package metadata YAML file and update the filename and the `name` field to the new name. If the repository name is also changed, update the `repoUrl` field as well.
+- Locate the package metadata YAML file and rename it to match the new package name.
+
+- Update the `name` field to the new package name. If the repository name is also changed, update the `repoUrl` field as well.
+
+- Add the old package name to the `aliases` list. Aliases only redirect old website package pages to the current package page; they do not create registry aliases or make the old package name installable.
 
 - Set the `minVersion` field to the newly created Git tag version so that the build-pipelines will ignore the old versions with the old package name.
+
+- Tell users to update their Unity dependencies from the old package name to the new package name.
 
 - Create a pull request. Your PR will be merged after review.
 

--- a/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
+++ b/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
@@ -416,6 +416,28 @@ describe('validateDataDirectory', () => {
     }
   });
 
+  it('does not treat metadata filenames as current package names for alias collisions', async () => {
+    const dataDir = await createDataDir();
+    try {
+      await writePackage(dataDir, 'com.example.old', {
+        ...validPackage,
+        name: 'com.example.other',
+      });
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        aliases: ['com.example.old'],
+      });
+
+      const result = await validateDataDirectory(dataDir);
+      const issueCodes = result.issues.map((x) => x.code);
+
+      expect(issueCodes).toContain('package-alias-filename-collision');
+      expect(issueCodes).not.toContain('package-alias-current-package-collision');
+    } finally {
+      await afs.rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('allows custom license names when licenseSpdxId is null', async () => {
     const dataDir = await createDataDir();
     try {

--- a/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
+++ b/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
@@ -8,6 +8,7 @@ import { validateDataDirectory } from '../../src/validation/data-validator.js';
 
 type PackageFixture = {
   name: string;
+  aliases: string[];
   repoUrl: string;
   displayName: string;
   description: string;
@@ -31,6 +32,7 @@ const topLevelFiles = [
 
 const validPackage: PackageFixture = {
   name: 'com.example.package',
+  aliases: [],
   repoUrl: 'https://github.com/example/package',
   displayName: 'Example Package',
   description: 'Example package description',
@@ -125,6 +127,34 @@ describe('validateDataDirectory', () => {
     } finally {
       await afs.rm(dataDir, { recursive: true, force: true });
     }
+  });
+
+  it('requires aliases as an array', async () => {
+    expect.assertions(3);
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          aliases: undefined,
+        }),
+      'package-metadata-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          aliases: null,
+        }),
+      'package-metadata-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          aliases: 'com.example.old',
+        }),
+      'package-metadata-invalid',
+    );
   });
 
   it('rejects malformed GitHub Release repo URLs', async () => {
@@ -301,6 +331,89 @@ describe('validateDataDirectory', () => {
         }),
       'package-github-release-asset-name-path-invalid',
     );
+  });
+
+  it('validates package aliases', async () => {
+    expect.assertions(8);
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          aliases: ['Com.Example.Package'],
+        }),
+      'package-alias-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          aliases: [validPackage.name],
+        }),
+      'package-alias-self',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          aliases: ['com.example.old', 'com.example.old'],
+        }),
+      'package-alias-duplicate',
+    );
+    await expectIssue(async (dataDir) => {
+      const otherPackage = {
+        ...validPackage,
+        name: 'com.example.other',
+      };
+      await writePackage(dataDir, otherPackage.name, otherPackage);
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        aliases: [otherPackage.name],
+      });
+    }, 'package-alias-current-package-collision');
+    await expectIssue(async (dataDir) => {
+      const otherPackage = {
+        ...validPackage,
+        name: 'com.example.other',
+      };
+      await writePackage(dataDir, otherPackage.name, otherPackage);
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        aliases: ['com.example.other'],
+      });
+    }, 'package-alias-filename-collision');
+    await expectIssue(async (dataDir) => {
+      await writePackage(dataDir, 'com.example.old', {
+        ...validPackage,
+        name: 'com.example.other',
+      });
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        aliases: ['com.example.old'],
+      });
+    }, 'package-alias-filename-collision');
+    await expectIssue(async (dataDir) => {
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        aliases: ['com.example.old'],
+      });
+      await writePackage(dataDir, 'com.example.other', {
+        ...validPackage,
+        name: 'com.example.other',
+        aliases: ['com.example.old'],
+      });
+    }, 'package-alias-global-duplicate');
+
+    const dataDir = await createDataDir();
+    try {
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        aliases: ['com.example.old'],
+      });
+      const result = await validateDataDirectory(dataDir);
+      expect(result).toEqual({ valid: true, issues: [] });
+    } finally {
+      await afs.rm(dataDir, { recursive: true, force: true });
+    }
   });
 
   it('allows custom license names when licenseSpdxId is null', async () => {

--- a/packages/@openupm/local-data/src/validation/data-validator.ts
+++ b/packages/@openupm/local-data/src/validation/data-validator.ts
@@ -26,6 +26,13 @@ export type ValidateDataDirectoryOptions = {
   topLevelYamlFiles?: string[];
 };
 
+type AliasValidationEntry = {
+  alias: string;
+  packageName: string;
+  pkgName: string;
+  relPath: string;
+};
+
 const defaultTopLevelYamlFiles = [
   'backers.yml',
   'blocked-scopes.yml',
@@ -142,8 +149,9 @@ export async function validateDataDirectory(
       .filter((file) => file.endsWith('.yml'))
       .map((file) => file.replace(/\.yml$/, '')),
   );
-  const currentPackageNames = new Set(packageFilenames);
+  const currentPackageNames = new Set<string>();
   const aliasOwners = new Map<string, string>();
+  const aliasEntries: AliasValidationEntry[] = [];
 
   for (const file of packageFiles) {
     const relPath = path.join('packages', file);
@@ -266,22 +274,7 @@ export async function validateDataDirectory(
           });
         }
         localAliases.add(alias);
-        if (alias !== pkg.name && currentPackageNames.has(alias)) {
-          addIssue(issues, {
-            code: 'package-alias-current-package-collision',
-            message: `alias ${alias} collides with an existing package name`,
-            path: relPath,
-            packageName,
-          });
-        }
-        if (alias !== packageName && packageFilenames.has(alias)) {
-          addIssue(issues, {
-            code: 'package-alias-filename-collision',
-            message: `alias ${alias} collides with an existing package metadata filename`,
-            path: relPath,
-            packageName,
-          });
-        }
+        aliasEntries.push({ alias, packageName, pkgName: pkg.name, relPath });
         const existingOwner = aliasOwners.get(alias);
         if (existingOwner && existingOwner !== pkg.name) {
           addIssue(issues, {
@@ -375,6 +368,25 @@ export async function validateDataDirectory(
       addIssue(issues, {
         code: 'package-metadata-invalid',
         message: `${relPath} metadata should be valid: ${messageFromError(error)}`,
+        path: relPath,
+        packageName,
+      });
+    }
+  }
+
+  for (const { alias, packageName, pkgName, relPath } of aliasEntries) {
+    if (alias !== pkgName && currentPackageNames.has(alias)) {
+      addIssue(issues, {
+        code: 'package-alias-current-package-collision',
+        message: `alias ${alias} collides with an existing package name`,
+        path: relPath,
+        packageName,
+      });
+    }
+    if (alias !== packageName && packageFilenames.has(alias)) {
+      addIssue(issues, {
+        code: 'package-alias-filename-collision',
+        message: `alias ${alias} collides with an existing package metadata filename`,
         path: relPath,
         packageName,
       });

--- a/packages/@openupm/local-data/src/validation/data-validator.ts
+++ b/packages/@openupm/local-data/src/validation/data-validator.ts
@@ -137,6 +137,13 @@ export async function validateDataDirectory(
       path: 'packages',
     });
   }
+  const packageFilenames = new Set(
+    packageFiles
+      .filter((file) => file.endsWith('.yml'))
+      .map((file) => file.replace(/\.yml$/, '')),
+  );
+  const currentPackageNames = new Set(packageFilenames);
+  const aliasOwners = new Map<string, string>();
 
   for (const file of packageFiles) {
     const relPath = path.join('packages', file);
@@ -168,6 +175,7 @@ export async function validateDataDirectory(
       const normalizedRaw = normalizePackageForLegacyData(raw);
       const rawPackage = asRecord(normalizedRaw);
       const pkg = parsePackageMetadata(normalizedRaw);
+      currentPackageNames.add(pkg.name);
       if (!isNonEmptyString(pkg.repoUrl)) {
         addIssue(issues, {
           code: 'package-repo-url-empty',
@@ -226,6 +234,65 @@ export async function validateDataDirectory(
           path: relPath,
           packageName,
         });
+      }
+      const aliases = pkg.aliases || [];
+      const localAliases = new Set<string>();
+      for (const alias of aliases) {
+        const [aliasValid, aliasValidError] = isValidPackageName(alias);
+        if (!aliasValid) {
+          addIssue(issues, {
+            code: 'package-alias-invalid',
+            message:
+              aliasValidError?.message ||
+              `alias ${alias} should be valid OpenUPM name`,
+            path: relPath,
+            packageName,
+          });
+        }
+        if (alias === pkg.name) {
+          addIssue(issues, {
+            code: 'package-alias-self',
+            message: `alias ${alias} should not match package name`,
+            path: relPath,
+            packageName,
+          });
+        }
+        if (localAliases.has(alias)) {
+          addIssue(issues, {
+            code: 'package-alias-duplicate',
+            message: `alias ${alias} should not be repeated`,
+            path: relPath,
+            packageName,
+          });
+        }
+        localAliases.add(alias);
+        if (alias !== pkg.name && currentPackageNames.has(alias)) {
+          addIssue(issues, {
+            code: 'package-alias-current-package-collision',
+            message: `alias ${alias} collides with an existing package name`,
+            path: relPath,
+            packageName,
+          });
+        }
+        if (alias !== packageName && packageFilenames.has(alias)) {
+          addIssue(issues, {
+            code: 'package-alias-filename-collision',
+            message: `alias ${alias} collides with an existing package metadata filename`,
+            path: relPath,
+            packageName,
+          });
+        }
+        const existingOwner = aliasOwners.get(alias);
+        if (existingOwner && existingOwner !== pkg.name) {
+          addIssue(issues, {
+            code: 'package-alias-global-duplicate',
+            message: `alias ${alias} is already used by ${existingOwner}`,
+            path: relPath,
+            packageName,
+          });
+        } else {
+          aliasOwners.set(alias, pkg.name);
+        }
       }
       for (const scope of blockedScopes) {
         if (isPackageBlockedByScope(pkg.name, scope)) {

--- a/packages/@openupm/test/src/arbitraries.ts
+++ b/packages/@openupm/test/src/arbitraries.ts
@@ -94,6 +94,7 @@ export const readme = fc.oneof(
 
 export const packageMetadataLocalBaseArb = fc.record<PackageMetadataLocalBase>({
   name: reverseDomainName,
+  aliases: fc.array(reverseDomainName),
   repoUrl: githubRepoUrl,
   parentRepoUrl: fc.oneof(fc.constant(undefined), fc.option(githubRepoUrl)),
   displayName: fc.string(),

--- a/packages/@openupm/types/__tests__/example.test.ts
+++ b/packages/@openupm/types/__tests__/example.test.ts
@@ -1,12 +1,42 @@
-describe('Dummy test', () => {
-  // Act before assertions
-  beforeAll(async () => {});
+import { PackageMetadataLocalBaseSchema } from '../src/schema.js';
 
-  // Teardown (cleanup) after assertions
-  afterAll(() => {});
+const validMetadata = {
+  name: 'com.example.package',
+  aliases: [],
+  repoUrl: 'https://github.com/example/package',
+  displayName: 'Example Package',
+  description: 'Example package description',
+  licenseSpdxId: 'MIT',
+  licenseName: 'MIT License',
+  topics: ['utilities'],
+  hunter: 'hunter',
+  createdAt: 1_700_000_000_000,
+  trackingMode: 'git',
+};
 
-  // Assert greeter result
-  it('Hello world', () => {
-    expect('hello world').toEqual('hello world');
+describe('PackageMetadataLocalBaseSchema', () => {
+  it('requires aliases as an array', () => {
+    expect(PackageMetadataLocalBaseSchema.parse(validMetadata).aliases).toEqual(
+      [],
+    );
+
+    expect(() =>
+      PackageMetadataLocalBaseSchema.parse({
+        ...validMetadata,
+        aliases: undefined,
+      }),
+    ).toThrow();
+    expect(() =>
+      PackageMetadataLocalBaseSchema.parse({
+        ...validMetadata,
+        aliases: null,
+      }),
+    ).toThrow();
+    expect(() =>
+      PackageMetadataLocalBaseSchema.parse({
+        ...validMetadata,
+        aliases: 'com.example.old',
+      }),
+    ).toThrow();
   });
 });

--- a/packages/@openupm/types/src/schema.ts
+++ b/packages/@openupm/types/src/schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const PackageMetadataLocalBaseSchema = z.object({
   name: z.string(),
+  aliases: z.array(z.string()),
   repoUrl: z.string().url(),
   displayName: z.string(),
   description: z.string(),

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -3,6 +3,7 @@ import { ReleaseErrorCode, ReleaseState } from './constant.js';
 // The package metadata YAML file format.
 export interface PackageMetadataLocalBase {
   name: string;
+  aliases: string[];
   repoUrl: string;
   displayName: string;
   description: string;

--- a/packages/vuepress-plugin-openupm/__tests__/example.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/example.test.ts
@@ -1,12 +1,45 @@
-describe('Dummy test', () => {
-  // Act before assertions
-  beforeAll(async () => {});
+import {
+  buildPackageAliasRedirects,
+  mergePackageAliasRedirects,
+} from '../src/redirects.js';
+import { PackageMetadataLocal } from '@openupm/types';
 
-  // Teardown (cleanup) after assertions
-  afterAll(() => {});
+describe('package alias redirects', () => {
+  it('generates Netlify redirects from package aliases', () => {
+    const metadata = [
+      {
+        name: 'com.example.current',
+        aliases: ['com.example.old', 'com.example.older'],
+      },
+      {
+        name: 'com.example.no-aliases',
+        aliases: [],
+      },
+    ] as PackageMetadataLocal[];
 
-  // Assert greeter result
-  it('Hello world', () => {
-    expect('hello world').toEqual('hello world');
+    expect(buildPackageAliasRedirects(metadata)).toEqual(
+      [
+        '/packages/com.example.old/ /packages/com.example.current/ 301',
+        '/packages/com.example.older/ /packages/com.example.current/ 301',
+      ].join('\n'),
+    );
+  });
+
+  it('preserves existing static redirects when appending alias redirects', () => {
+    expect(
+      mergePackageAliasRedirects(
+        '# static\n/feeds/* https://api.openupm.com/feeds/:splat 200\n',
+        '/packages/com.example.old/ /packages/com.example.current/ 301',
+      ),
+    ).toEqual(
+      [
+        '# static',
+        '/feeds/* https://api.openupm.com/feeds/:splat 200',
+        '',
+        '# Package rename redirects generated from package aliases.',
+        '/packages/com.example.old/ /packages/com.example.current/ 301',
+        '',
+      ].join('\n'),
+    );
   });
 });

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -2,6 +2,7 @@
 import { groupBy } from 'lodash-es';
 import { App, createPage } from '@vuepress/core';
 import { Page } from '@vuepress/core';
+import { fs, path } from '@vuepress/utils';
 import spdx from 'spdx-license-list';
 
 import {
@@ -30,6 +31,10 @@ import {
   getPackageListPagePath,
 } from '@openupm/common/build/urls.js';
 
+import {
+  buildPackageAliasRedirects,
+  mergePackageAliasRedirects,
+} from './redirects.js';
 import { writePublicGen } from './utils/write-file.js';
 
 type Contributor = GithubUserWithScore & {
@@ -52,6 +57,7 @@ type VuePressPlugin = {
   onInitialized: (app: App) => Promise<void>;
   extendsPage: (page: Page) => Promise<void>;
   onPrepared: (app: App) => Promise<void>;
+  onGenerated: (app: App) => Promise<void>;
 };
 
 /**
@@ -243,5 +249,18 @@ export default (): VuePressPlugin => ({
         JSON.stringify(PLUGIN_DATA.metadataGroupByNamespace[namespace]),
       );
     }
+  },
+  onGenerated: async (app: App): Promise<void> => {
+    const redirectsPath = path.join(app.dir.dest(), '_redirects');
+    const staticRedirects = (await fs.pathExists(redirectsPath))
+      ? await fs.readFile(redirectsPath, 'utf8')
+      : '';
+    await fs.outputFile(
+      redirectsPath,
+      mergePackageAliasRedirects(
+        staticRedirects,
+        buildPackageAliasRedirects(PLUGIN_DATA.metadataLocalList),
+      ),
+    );
   },
 });

--- a/packages/vuepress-plugin-openupm/src/redirects.ts
+++ b/packages/vuepress-plugin-openupm/src/redirects.ts
@@ -1,0 +1,32 @@
+import { PackageMetadataLocal } from '@openupm/types';
+import { getPackageDetailPagePath } from '@openupm/common/build/urls.js';
+
+export const PACKAGE_ALIAS_REDIRECTS_HEADER =
+  '# Package rename redirects generated from package aliases.';
+
+export function buildPackageAliasRedirects(
+  metadataLocalList: PackageMetadataLocal[],
+): string {
+  return metadataLocalList
+    .flatMap((metadataLocal) =>
+      metadataLocal.aliases.map(
+        (alias) =>
+          `${getPackageDetailPagePath(alias)} ${getPackageDetailPagePath(
+            metadataLocal.name,
+          )} 301`,
+      ),
+    )
+    .join('\n');
+}
+
+export function mergePackageAliasRedirects(
+  staticRedirects: string,
+  packageAliasRedirects: string,
+): string {
+  const staticContent = staticRedirects
+    .split(`\n\n${PACKAGE_ALIAS_REDIRECTS_HEADER}\n`)[0]
+    .trimEnd();
+  const generatedContent = packageAliasRedirects.trim();
+  if (!generatedContent) return `${staticContent}\n`;
+  return `${staticContent}\n\n${PACKAGE_ALIAS_REDIRECTS_HEADER}\n${generatedContent}\n`;
+}


### PR DESCRIPTION
## Summary

- Add required package metadata aliases as website-only rename redirects.
- Validate aliases for invalid names, self-aliases, duplicates, current package collisions, and metadata filename collisions.
- Generate Netlify package-page redirects in the docs build output without changing registry or package API resolution.
- Show aliases on package detail metadata only when present and add aliases to package-add generated YAML.
- Update package rename docs to tell maintainers to rename metadata, add aliases, set minVersion, and tell users to update dependencies.

## Validation

- npm run build -- --filter=@openupm/types --filter=@openupm/test --filter=@openupm/common --filter=@openupm/local-data --filter=vuepress-plugin-openupm
- npm run test -w @openupm/types
- OPENUPM_DATA_PATH=<openupm-data-worktree>/data npm run test -w @openupm/local-data -- validation/data-validator.spec.ts utils/parse-pkg.spec.ts
- npm run test -w vuepress-plugin-openupm
- npm run test -w @openupm/docs -- packageMetadata.spec.ts
- npm run lint
- npm run lint -- --filter=vuepress-plugin-openupm --filter=@openupm/docs
- OPENUPM_DATA_PATH=<openupm-data-worktree>/data npm run docs:build:limit -w @openupm/docs
- OPENUPM_NEXT_PATH=<openupm-next-worktree> npm test in the data worktree

## Notes

This is website-only. Old package names redirect on openupm.com package pages, but registry installs and package API lookups still require the current package name.

Data backfill is in the companion openupm PR.