### PR TITLE
[codex] Add README sync time to package detail

### DIFF
--- a/apps/docs/__tests__/vue/packageReadmeView.spec.ts
+++ b/apps/docs/__tests__/vue/packageReadmeView.spec.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const componentPath = fileURLToPath(
+  new URL("../../docs/.vuepress/components/PackageReadmeView.vue", import.meta.url),
+);
+
+describe("PackageReadmeView", () => {
+  const source = readFileSync(componentPath, "utf8");
+
+  it("renders the README sync footer only when a timestamp formats successfully", () => {
+    expect(source).toContain('readmeUpdatedAt: {');
+    expect(source).toContain('if (!props.readmeUpdatedAt) return "";');
+    expect(source).toContain('<footer v-if="readmeSyncedAgo" class="readme-footer">');
+    expect(source).toContain('t("readme-synced-ago", { time: readmeSyncedAgo })');
+  });
+});

--- a/apps/docs/docs/.vuepress/components/PackageReadmeView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageReadmeView.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { timeAgoFormat } from '@/utils';
+
 const props = defineProps({
   name: {
     type: String,
@@ -9,10 +13,21 @@ const props = defineProps({
     type: String,
     default: ""
   },
+  readmeUpdatedAt: {
+    type: Number,
+    default: null
+  },
   isLoading: {
     type: Boolean,
     default: true
   }
+});
+
+const { t } = useI18n();
+
+const readmeSyncedAgo = computed(() => {
+  if (!props.readmeUpdatedAt) return "";
+  return timeAgoFormat(new Date(props.readmeUpdatedAt));
 });
 </script>
 
@@ -24,6 +39,9 @@ const props = defineProps({
     <div v-else>
       <ReadmeHtml v-if="readmeHtml" :content="readmeHtml" />
       <p v-else>{{ $t("readme-to-found") }}</p>
+      <footer v-if="readmeSyncedAgo" class="readme-footer">
+        {{ t("readme-synced-ago", { time: readmeSyncedAgo }) }}
+      </footer>
     </div>
   </div>
 </template>
@@ -33,5 +51,13 @@ const props = defineProps({
 
 .readme-wrap {
   max-width: 42rem;
+}
+
+.readme-footer {
+  border-top: 1px solid $border-color;
+  color: $gray-color;
+  font-size: 0.7rem;
+  margin-top: 1.2rem;
+  padding-top: 0.6rem;
 }
 </style>

--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -57,6 +57,7 @@ const initState = (): State => ({
     releases: [],
     invalidTags: [],
     readmeHtml: null,
+    readmeUpdatedAt: null,
     scopes: [],
   },
   packument: {
@@ -199,6 +200,8 @@ const pipelinesIcon = computed(() => {
 
 const readmeHtml = computed(() => state.packageInfo.readmeHtml);
 
+const readmeUpdatedAt = computed(() => state.packageInfo.readmeUpdatedAt);
+
 const shouldShowMetadataSubpageEntry = computed(() => {
   return mq.lgMinus;
 });
@@ -216,6 +219,7 @@ const subPages = computed(() => {
       component: PackageReadmeView,
       props: {
         readmeHtml: readmeHtml.value,
+        readmeUpdatedAt: readmeUpdatedAt.value,
         isLoading: !state.__packageInfoFetched,
         name: packageMetadata.value.name,
       }

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -130,6 +130,7 @@ project: Project
 promote: Promote
 published-time: Published time
 readme: readme
+readme-synced-ago: README synced {time} ago
 readme-to-found: Readme is not available, please try again later.
 last-publish: last publish
 region: Region

--- a/apps/jobs/__tests__/jobs/fetchPackageExtra.spec.ts
+++ b/apps/jobs/__tests__/jobs/fetchPackageExtra.spec.ts
@@ -18,6 +18,7 @@ const getReadmeCacheKeyMock = vi.fn();
 const setReadmeMock = vi.fn();
 const setReadmeHtmlMock = vi.fn();
 const setReadmeCacheKeyMock = vi.fn();
+const setReadmeUpdatedAtMock = vi.fn();
 const getImageQueryForPackageMock = vi.fn();
 const getImageQueryForGithubUserMock = vi.fn();
 
@@ -45,6 +46,7 @@ vi.mock('@openupm/server-common/build/models/packageExtra.js', () => ({
   setReadme: setReadmeMock,
   setReadmeHtml: setReadmeHtmlMock,
   setReadmeCacheKey: setReadmeCacheKeyMock,
+  setReadmeUpdatedAt: setReadmeUpdatedAtMock,
   getImageQueryForPackage: getImageQueryForPackageMock,
   getImageQueryForGithubUser: getImageQueryForGithubUserMock,
   getCachedImageFilename: vi.fn().mockResolvedValue(null),
@@ -108,6 +110,10 @@ describe('fetchPackageExtraJob', () => {
       'en-US',
       'v0:main:README.md:1767225600000',
     );
+    expect(setReadmeUpdatedAtMock).toHaveBeenCalledWith(
+      'com.test.pkg',
+      expect.any(Number),
+    );
   });
 
   it('skips README content fetch on cache hit', async () => {
@@ -131,6 +137,7 @@ describe('fetchPackageExtraJob', () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(setReadmeMock).not.toHaveBeenCalled();
     expect(setReadmeHtmlMock).not.toHaveBeenCalled();
+    expect(setReadmeUpdatedAtMock).not.toHaveBeenCalled();
   });
 
   it('stores fallback README content on GitHub content 404', async () => {
@@ -165,6 +172,10 @@ describe('fetchPackageExtraJob', () => {
       'com.test.pkg',
       'en-US',
       'v0:main:README.md:1767225600000',
+    );
+    expect(setReadmeUpdatedAtMock).toHaveBeenCalledWith(
+      'com.test.pkg',
+      expect.any(Number),
     );
   });
 

--- a/apps/jobs/src/jobs/fetchPackageExtra.ts
+++ b/apps/jobs/src/jobs/fetchPackageExtra.ts
@@ -23,6 +23,7 @@ import {
   setReadme,
   setReadmeCacheKey,
   setReadmeHtml,
+  setReadmeUpdatedAt,
   setScopes,
   setStars,
   setUnityVersion,
@@ -360,6 +361,7 @@ async function storePackageReadme({
   await setReadme(packageName, readme);
   await setReadmeHtml(packageName, readmeHtml);
   await setReadmeCacheKey(packageName, 'en-US', cacheKey);
+  await setReadmeUpdatedAt(packageName, Date.now());
 }
 
 async function cacheImage(packageName: string, force: boolean): Promise<void> {

--- a/apps/web/__tests__/routers/packages.spec.ts
+++ b/apps/web/__tests__/routers/packages.spec.ts
@@ -7,7 +7,11 @@ import {
   save,
   getRedisKeyForRelease,
 } from '@openupm/server-common/build/models/release.js';
-import { setAggregatedExtraData } from '@openupm/server-common/build/models/packageExtra.js';
+import {
+  getRedisKeyForPackageExtra,
+  setAggregatedExtraData,
+  setReadmeUpdatedAt,
+} from '@openupm/server-common/build/models/packageExtra.js';
 import { app } from '../../src/apiServer.js';
 
 const SAMPLE_PACKAGE_NAME = 'sample-package';
@@ -47,11 +51,13 @@ describe('packages', () => {
     for (const item of releases) {
       await save(item);
     }
+    await setReadmeUpdatedAt(SAMPLE_PACKAGE_NAME, 1767225600000);
     await setAggregatedExtraData({});
   });
 
   afterEach(async () => {
     await redis.client!.del(getRedisKeyForRelease(SAMPLE_PACKAGE_NAME));
+    await redis.client!.del(getRedisKeyForPackageExtra(SAMPLE_PACKAGE_NAME));
   });
 
   afterAll(async () => {
@@ -82,6 +88,7 @@ describe('packages', () => {
       source: 'git',
       signed: false,
     });
+    expect(response.body.readmeUpdatedAt).toEqual(1767225600000);
   });
 
   it('/packages/:name should return 200 for package-not-exist', async () => {

--- a/apps/web/src/routers/packages.ts
+++ b/apps/web/src/routers/packages.ts
@@ -15,6 +15,7 @@ import {
   getRecentPackages,
   getInvalidTags,
   getReadmeHtml,
+  getReadmeUpdatedAt,
   getScopes,
 } from '@openupm/server-common/build/models/packageExtra.js';
 
@@ -63,6 +64,7 @@ export default function router(server: FastifyInstance): void {
       );
       // Get readme
       const readmeHtml = await getReadmeHtml(pkgName);
+      const readmeUpdatedAt = await getReadmeUpdatedAt(pkgName);
       // Get package scopes
       const scopes = await getScopes(pkgName);
       // Return as JSON
@@ -70,6 +72,7 @@ export default function router(server: FastifyInstance): void {
         invalidTags,
         releases,
         readmeHtml,
+        readmeUpdatedAt,
         scopes,
       };
       res.send(data);

--- a/packages/@openupm/server-common/__tests__/models/packageExtra.spec.ts
+++ b/packages/@openupm/server-common/__tests__/models/packageExtra.spec.ts
@@ -2,7 +2,9 @@ import redis from '../../src/redis.js';
 import {
   getRedisKeyForPackageExtra,
   getInvalidTags,
+  getReadmeUpdatedAt,
   setInvalidTags,
+  setReadmeUpdatedAt,
   getPropKeyForLang,
 } from '../../src/models/packageExtra.js';
 
@@ -37,6 +39,19 @@ describeWithRedis('getInvalidTags', () => {
     await setInvalidTags(SAMPLE_PACKAGE_NAME, invalidTags);
     const result = await getInvalidTags(SAMPLE_PACKAGE_NAME);
     expect(result).toEqual(invalidTags);
+  });
+});
+
+describeWithRedis('getReadmeUpdatedAt', () => {
+  it('returns null when package has no README update timestamp', async () => {
+    const val = await getReadmeUpdatedAt('package-not-existed');
+    expect(val).toEqual(null);
+  });
+
+  it('sets and gets README update timestamp', async () => {
+    await setReadmeUpdatedAt(SAMPLE_PACKAGE_NAME, 1767225600000);
+    const result = await getReadmeUpdatedAt(SAMPLE_PACKAGE_NAME);
+    expect(result).toEqual(1767225600000);
   });
 });
 

--- a/packages/@openupm/server-common/src/models/packageExtra.ts
+++ b/packages/@openupm/server-common/src/models/packageExtra.ts
@@ -19,6 +19,7 @@ export const propKeys: { [key: string]: string } = {
   monthlyDownloads: 'monthlyDownloads',
   readme: 'readme',
   readmeHtml: 'readmeHtml',
+  readmeUpdatedAt: 'readmeUpdatedAt',
   parentStars: 'parentStars',
   scopes: 'scopes',
   invalidTags: 'invalidTags',
@@ -225,6 +226,25 @@ export const getReadmeHtml = async function (
   const key = getPropKeyForLang(propKeys.readmeHtml, lang);
   const text = await getValue(packageName, key);
   return text;
+};
+
+export const setReadmeUpdatedAt = async function (
+  packageName: string,
+  updatedAt: number,
+  lang?: string,
+): Promise<void> {
+  const key = getPropKeyForLang(propKeys.readmeUpdatedAt, lang);
+  await setValue(packageName, key, updatedAt.toString());
+};
+
+export const getReadmeUpdatedAt = async function (
+  packageName: string,
+  lang?: string,
+): Promise<number | null> {
+  const key = getPropKeyForLang(propKeys.readmeUpdatedAt, lang);
+  const text = await getValue(packageName, key);
+  if (text === null) return null;
+  return parseInt(text);
 };
 
 export const setImageUrl = async function (

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -98,6 +98,7 @@ export interface PackageInfo {
   invalidTags: string[];
   releases: PackageRelease[];
   readmeHtml: string | null;
+  readmeUpdatedAt: number | null;
   scopes: string[];
 }
 


### PR DESCRIPTION
## Summary

Adds a README freshness timestamp to package detail data and UI for openupm/openupm#5177.

- stores `readmeUpdatedAt` in package extra data when README content is actually fetched/rendered and saved
- leaves cache-hit README paths unchanged so the timestamp reflects the currently stored README content
- exposes `readmeUpdatedAt` from `/packages/:name` and renders `README synced {time} ago` in the package detail README footer when present
- covers the storage helper, README fetch/cache behavior, package route response, and docs footer wiring

## Validation

- `npm --workspace @openupm/server-common test -- packageExtra.spec.ts`
- `npm --workspace @openupm/jobs test -- fetchPackageExtra.spec.ts`
- `npm --workspace @openupm/web test -- packages.spec.ts`
- `npm --workspace @openupm/docs test -- packageReadmeView.spec.ts`
- `npx npm@10.9.3 run lint`
- `npx npm@10.9.3 run docs:build:limit --workspace @openupm/docs`

Note: the Redis-backed focused tests used the documented temporary local Redis container, which was removed after validation.