### PR TITLE
[codex] fix package alias metadata links

### DIFF
--- a/apps/docs/__tests__/vue/packageMetadata.spec.ts
+++ b/apps/docs/__tests__/vue/packageMetadata.spec.ts
@@ -13,11 +13,11 @@ describe('package metadata aliases', () => {
       }),
     ).toEqual([
       {
-        link: '/packages/com.example.old/',
+        link: 'https://openupm.com/packages/com.example.old/',
         text: 'com.example.old',
       },
       {
-        link: '/packages/com.example.older/',
+        link: 'https://openupm.com/packages/com.example.older/',
         text: 'com.example.older',
       },
     ]);

--- a/apps/docs/docs/.vuepress/components/package-metadata.ts
+++ b/apps/docs/docs/.vuepress/components/package-metadata.ts
@@ -1,5 +1,5 @@
 import { PackageMetadata } from '@openupm/types';
-import { getPackageDetailPagePath } from '@openupm/common/build/urls.js';
+import { getPackageDetailPageUrl } from '@openupm/common/build/urls.js';
 
 export type PackageAliasNavLink = {
   link: string;
@@ -10,7 +10,7 @@ export function getPackageAliasNavLinks(
   metadata: Pick<PackageMetadata, 'aliases'>,
 ): PackageAliasNavLink[] {
   return metadata.aliases.map((alias) => ({
-    link: getPackageDetailPagePath(alias),
+    link: getPackageDetailPageUrl(alias),
     text: alias,
   }));
 }


### PR DESCRIPTION
## Summary
- change package metadata alias links from site-relative paths to absolute package URLs
- keep redirect targets unchanged, but avoid VuePress router 404 handling before Netlify redirects can run

## Validation
- npm run build -- --filter=@openupm/common
- npm run test -w @openupm/docs -- packageMetadata.spec.ts
- npm run lint -- --filter=@openupm/docs
- npm run build -- --filter=vuepress-plugin-openupm
- OPENUPM_DATA_PATH=<openupm-data> npm run docs:build:limit -w @openupm/docs