### PR TITLE
fix(docs): decode package json with BOM

### DIFF
--- a/apps/docs/__tests__/vue/utils.spec.ts
+++ b/apps/docs/__tests__/vue/utils.spec.ts
@@ -3,7 +3,12 @@ import chai from "chai";
 chai.should();
 
 import { DailyDownload } from "@openupm/types";
-import { fillMissingDates, generateHueFromStringInRange } from "@/utils";
+import {
+  decodeGitHubBase64Content,
+  fillMissingDates,
+  generateHueFromStringInRange,
+  stripLeadingBom,
+} from "@/utils";
 
 describe("@/utils.ts", function () {
   describe("fillMissingDates", () => {
@@ -83,6 +88,36 @@ describe("@/utils.ts", function () {
       const result = generateHueFromStringInRange(str, rangeMin, rangeMax);
       result.should.be.a("number");
       result.should.be.within(rangeMin, 255);
+    });
+  });
+
+  describe("stripLeadingBom", () => {
+    it("removes a leading UTF-8 BOM", () => {
+      stripLeadingBom('\uFEFF{"name":"package-a"}').should.equal(
+        '{"name":"package-a"}',
+      );
+    });
+
+    it("leaves text without a leading UTF-8 BOM unchanged", () => {
+      stripLeadingBom('{"name":"package-a"}').should.equal(
+        '{"name":"package-a"}',
+      );
+    });
+  });
+
+  describe("decodeGitHubBase64Content", () => {
+    it("decodes UTF-8 GitHub content and strips a leading BOM", () => {
+      const content = Buffer.from(
+        '\uFEFF{"name":"package-a","displayName":"\\u6e2c\\u8a66"}',
+        "utf8",
+      ).toString("base64");
+
+      const decoded = decodeGitHubBase64Content(content);
+
+      JSON.parse(decoded).should.deep.equal({
+        name: "package-a",
+        displayName: "測試",
+      });
     });
   });
 });

--- a/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
@@ -18,6 +18,7 @@ import { getVersionFromTag } from "@openupm/common/build/semver.js";
 import { isPackageBlockedByScope, isPackageRequiresManualVerification, validPackageName } from "@openupm/common/build/utils.js";
 import { topicsWithAll } from '@temp/topics.js';
 import { BLOCKED_SCOPES_FILENAME, SDPXLIST_FILENAME } from "@openupm/types";
+import { decodeGitHubBase64Content } from "@/utils";
 
 const store = useDefaultStore();
 const { t } = useI18n();
@@ -351,7 +352,7 @@ const fetchPackageJson = async (): Promise<void> => {
       headers: { Accept: "application/vnd.github.v3.json" },
     });
     // Assign data.
-    let content = atob(resp.data.content);
+    let content = decodeGitHubBase64Content(resp.data.content);
     state.packageJsonObj = JSON.parse(content);
     let packageName = state.packageJsonObj.name;
     // Verify private

--- a/apps/docs/docs/.vuepress/utils.ts
+++ b/apps/docs/docs/.vuepress/utils.ts
@@ -82,6 +82,26 @@ export const generateHueFromStringInRange = function (
 };
 
 /**
+ * Remove a leading UTF-8 byte order mark from decoded text.
+ * @param text decoded text
+ * @returns text without a leading BOM
+ */
+export const stripLeadingBom = function (text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+};
+
+/**
+ * Decode GitHub Contents API base64 payloads as UTF-8 text.
+ * @param content base64-encoded GitHub file content
+ * @returns UTF-8 decoded text without a leading BOM
+ */
+export const decodeGitHubBase64Content = function (content: string): string {
+  const binary = atob(content);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return stripLeadingBom(new TextDecoder("utf-8").decode(bytes));
+};
+
+/**
  * Translate a string with fallback.
  * @param t translation function
  * @param tkey translation key


### PR DESCRIPTION
## Summary
- decode GitHub Contents API package.json payloads as UTF-8 instead of raw atob output
- strip a leading UTF-8 BOM before JSON.parse in the package submission form
- add regression tests for BOM stripping and UTF-8 base64 decoding

Closes openupm/openupm#4135

## Validation
- npm run test -- utils.spec.ts
- npm run lint
- npm run build -- --filter=vuepress-plugin-openupm
- npm run docs:build:limit