### PR TITLE
Surface archived repository metadata

### DIFF
--- a/apps/docs/__tests__/vue/packageRepositoryStatus.spec.ts
+++ b/apps/docs/__tests__/vue/packageRepositoryStatus.spec.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const packageCardPath = fileURLToPath(
+  new URL("../../docs/.vuepress/components/PackageCard.vue", import.meta.url),
+);
+const packageDetailLayoutPath = fileURLToPath(
+  new URL("../../docs/.vuepress/layouts/PackageDetailLayout.vue", import.meta.url),
+);
+const localePath = fileURLToPath(
+  new URL("../../docs/.vuepress/locales/en-US.yml", import.meta.url),
+);
+
+describe("package repository status UI", () => {
+  it("renders an archived chip on package cards when remote metadata is archived", () => {
+    const source = readFileSync(packageCardPath, "utf8");
+
+    expect(source).toContain('v-if="metadata.repoArchived"');
+    expect(source).toContain("Archived");
+  });
+
+  it("renders archived and unavailable repository status conditions independently", () => {
+    const source = readFileSync(packageDetailLayoutPath, "utf8");
+
+    expect(source).toContain('v-if="packageMetadata.repoUnavailable"');
+    expect(source).toContain('v-if="packageMetadata.repoArchived"');
+    expect(source).toContain('repository-is-unavailable-title');
+    expect(source).toContain('repository-is-archived-title');
+    expect(source).toContain('repository-is-archived-desc');
+  });
+
+  it("defines archived repository status copy", () => {
+    const source = readFileSync(localePath, "utf8");
+
+    expect(source).toContain(
+      "repository-is-archived-title: The source code repository is archived",
+    );
+    expect(source).toContain("repository-is-archived-desc:");
+  });
+});

--- a/apps/docs/docs/.vuepress/components/PackageCard.vue
+++ b/apps/docs/docs/.vuepress/components/PackageCard.vue
@@ -105,6 +105,9 @@ const imageErrorMessage = computed(() => {
             <span v-if="metadata.time" class="chip">
               <i class="fas fa-clock"></i>{{ timeAgoText }}
             </span>
+            <span v-if="metadata.repoArchived" class="chip chip-archived">
+              Archived
+            </span>
           </div>
           <div class="row2">
             <span v-if="metadata.stars" class="chip">

--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -482,6 +482,10 @@ const buildRouterLinkQuery = function (subPage: string): Record<string, string> 
               <p class="custom-container-title">{{ $t("repository-is-unavailable-title") }}</p>
               <p>{{ $t("repository-is-unavailable-desc") }}</p>
             </div>
+            <div v-if="packageMetadata.repoArchived" class="custom-container warning">
+              <p class="custom-container-title">{{ $t("repository-is-archived-title") }}</p>
+              <p>{{ $t("repository-is-archived-desc") }}</p>
+            </div>
             <div v-if="topics.length" class="topic-list">
               <a v-for="item in topics" :key="item.slug" :href="item.urlPath">
                 <span class="label label-default label-rounded mr-1">{{ item.localeName }}</span>

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -166,6 +166,8 @@ relevance: Relevance
 report-abuse: Report
 report-malware-or-abuse: report malware or abuse
 repository: repository
+repository-is-archived-desc: The repository is read-only and no longer accepts active development. Evaluate the package maintenance status before adopting it.
+repository-is-archived-title: The source code repository is archived
 repository-is-unavailable-desc: This may be a temporary network issue. However, if the repository is deleted or made private by its author, OpenUPM will no longer track further changes. Any packages already published will not be affected.
 repository-is-unavailable-title: The source code repository is currently inaccessible to OpenUPM
 repository-placeholder: owner/project-name

--- a/apps/jobs/__tests__/jobs/aggregatePackageExtra.spec.ts
+++ b/apps/jobs/__tests__/jobs/aggregatePackageExtra.spec.ts
@@ -10,6 +10,7 @@ const getUpdatedTimeMock = vi.fn();
 const getRepoPushedTimeMock = vi.fn();
 const getVersionMock = vi.fn();
 const getRepoUnavailableMock = vi.fn();
+const getRepoArchivedMock = vi.fn();
 const getMonthlyDownloadsMock = vi.fn();
 const setAggregatedExtraDataMock = vi.fn();
 
@@ -27,6 +28,7 @@ vi.mock('@openupm/server-common/build/models/packageExtra.js', () => ({
   getRepoPushedTime: getRepoPushedTimeMock,
   getVersion: getVersionMock,
   getRepoUnavailable: getRepoUnavailableMock,
+  getRepoArchived: getRepoArchivedMock,
   getMonthlyDownloads: getMonthlyDownloadsMock,
   setAggregatedExtraData: setAggregatedExtraDataMock,
 }));
@@ -47,6 +49,7 @@ describe('aggregatePackageExtraJob', () => {
     getRepoPushedTimeMock.mockResolvedValue(2000);
     getVersionMock.mockResolvedValue('');
     getRepoUnavailableMock.mockResolvedValue(false);
+    getRepoArchivedMock.mockResolvedValue(false);
     getMonthlyDownloadsMock.mockResolvedValue(99);
 
     const { aggregatePackageExtraJob } = await import('../../src/jobs/aggregatePackageExtra.js');
@@ -61,8 +64,34 @@ describe('aggregatePackageExtraJob', () => {
         time: 2000,
         ver: undefined,
         repoUnavailable: undefined,
+        repoArchived: undefined,
         dl30d: 99,
       },
+    });
+  });
+
+  it('emits repoArchived only when true', async () => {
+    loadPackageNamesMock.mockResolvedValue(['pkg.one']);
+    loadPackageMetadataLocalMock.mockResolvedValue({ name: 'pkg.one' });
+    getStarsMock.mockResolvedValue(0);
+    getParentStarsMock.mockResolvedValue(0);
+    getUnityVersionMock.mockResolvedValue('');
+    getCachedImageFilenameMock.mockResolvedValue('');
+    getUpdatedTimeMock.mockResolvedValue(0);
+    getRepoPushedTimeMock.mockResolvedValue(0);
+    getVersionMock.mockResolvedValue('');
+    getRepoUnavailableMock.mockResolvedValue(false);
+    getRepoArchivedMock.mockResolvedValue(true);
+    getMonthlyDownloadsMock.mockResolvedValue(0);
+
+    const { aggregatePackageExtraJob } = await import('../../src/jobs/aggregatePackageExtra.js');
+    await aggregatePackageExtraJob();
+
+    expect(setAggregatedExtraDataMock).toHaveBeenCalledWith({
+      'pkg.one': expect.objectContaining({
+        repoUnavailable: undefined,
+        repoArchived: true,
+      }),
     });
   });
 });

--- a/apps/jobs/__tests__/jobs/fetchPackageExtra.spec.ts
+++ b/apps/jobs/__tests__/jobs/fetchPackageExtra.spec.ts
@@ -13,6 +13,7 @@ const setParentStarsMock = vi.fn();
 const setRepoPushedTimeMock = vi.fn();
 const setRepoUpdatedTimeMock = vi.fn();
 const setRepoUnavailableMock = vi.fn();
+const setRepoArchivedMock = vi.fn();
 const setMonthlyDownloadsMock = vi.fn();
 const getReadmeCacheKeyMock = vi.fn();
 const setReadmeMock = vi.fn();
@@ -41,6 +42,7 @@ vi.mock('@openupm/server-common/build/models/packageExtra.js', () => ({
   setRepoPushedTime: setRepoPushedTimeMock,
   setRepoUpdatedTime: setRepoUpdatedTimeMock,
   setRepoUnavailable: setRepoUnavailableMock,
+  setRepoArchived: setRepoArchivedMock,
   setMonthlyDownloads: setMonthlyDownloadsMock,
   getReadmeCacheKey: getReadmeCacheKeyMock,
   setReadme: setReadmeMock,
@@ -300,6 +302,7 @@ describe('fetchPackageExtraJob', () => {
         ok: true,
         json: async () => ({
           stargazers_count: 10,
+          archived: false,
           pushed_at: '2026-01-01T00:00:00.000Z',
         }),
       })
@@ -325,6 +328,7 @@ describe('fetchPackageExtraJob', () => {
     expect(setVersionMock).toHaveBeenCalledWith('com.test.pkg', '1.0.0');
     expect(setScopesMock).toHaveBeenCalled();
     expect(setStarsMock).toHaveBeenCalledWith('com.test.pkg', 10);
+    expect(setRepoArchivedMock).toHaveBeenCalledWith('com.test.pkg', false);
     expect(setMonthlyDownloadsMock).toHaveBeenCalledWith('com.test.pkg', 20);
     expect(fetchMock).toHaveBeenLastCalledWith(
       expect.stringContaining('/downloads/point/last-month/com.test.pkg'),
@@ -399,6 +403,60 @@ describe('fetchPackageExtraJob', () => {
       'en-US',
       'v0:main:README.md:unavailable',
     );
+    expect(setRepoArchivedMock).not.toHaveBeenCalled();
+  });
+
+  it('stores archived repository metadata from successful GitHub repo responses', async () => {
+    packageMetadataLocalExistsMock.mockReturnValue(true);
+    loadPackageMetadataLocalMock.mockResolvedValue({
+      name: 'com.test.pkg',
+      repo: 'openupm/archived-package',
+      repoUrl: 'https://github.com/openupm/archived-package',
+      owner: null,
+      parentOwner: null,
+      hunter: null,
+    });
+    getReadmeCacheKeyMock.mockResolvedValue('v0:main:README.md:1767225600000');
+    getImageQueryForPackageMock.mockResolvedValue(null);
+    getImageQueryForGithubUserMock.mockResolvedValue(null);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.0.0' },
+          versions: { '1.0.0': { dependencies: {} } },
+          time: { '1.0.0': '2026-01-01T00:00:00.000Z' },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.0.0' },
+          versions: { '1.0.0': { dependencies: {} } },
+          time: { '1.0.0': '2026-01-01T00:00:00.000Z' },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          archived: true,
+          stargazers_count: 10,
+          pushed_at: '2026-01-01T00:00:00.000Z',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ downloads: 0 }),
+      });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const { fetchPackageExtraJob } = await import('../../src/jobs/fetchPackageExtra.js');
+    await fetchPackageExtraJob(['com.test.pkg'], { force: false });
+
+    expect(setRepoUnavailableMock).toHaveBeenCalledWith('com.test.pkg', false);
+    expect(setRepoArchivedMock).toHaveBeenCalledWith('com.test.pkg', true);
   });
 
   it('cacheAvatarImageForGithubUser should add image when cache unavailable', async () => {

--- a/apps/jobs/src/jobs/aggregatePackageExtra.ts
+++ b/apps/jobs/src/jobs/aggregatePackageExtra.ts
@@ -4,6 +4,7 @@ import {
   getMonthlyDownloads,
   getParentStars,
   getRepoPushedTime,
+  getRepoArchived,
   getRepoUnavailable,
   getStars,
   getUnityVersion,
@@ -23,6 +24,7 @@ type AggregatedEntry = {
   time?: number;
   ver?: string;
   repoUnavailable?: boolean;
+  repoArchived?: boolean;
   dl30d: number;
 };
 
@@ -45,6 +47,7 @@ export async function aggregatePackageExtraJob(): Promise<void> {
     const pushedTime = await getRepoPushedTime(packageName);
     const version = await getVersion(packageName);
     const repoUnavailable = await getRepoUnavailable(packageName);
+    const repoArchived = await getRepoArchived(packageName);
     const dl30d = await getMonthlyDownloads(packageName);
 
     aggregated[packageName] = {
@@ -55,6 +58,7 @@ export async function aggregatePackageExtraJob(): Promise<void> {
       time: updatedTime || pushedTime || undefined,
       ver: version || undefined,
       repoUnavailable: repoUnavailable || undefined,
+      repoArchived: repoArchived || undefined,
       dl30d,
     };
   }

--- a/apps/jobs/src/jobs/fetchPackageExtra.ts
+++ b/apps/jobs/src/jobs/fetchPackageExtra.ts
@@ -18,6 +18,7 @@ import {
   setMonthlyDownloads,
   setParentStars,
   setRepoPushedTime,
+  setRepoArchived,
   setRepoUnavailable,
   setRepoUpdatedTime,
   setReadme,
@@ -246,11 +247,13 @@ async function fetchRepoInfo(
     const repoInfo = (await resp.json()) as {
       stargazers_count?: number;
       parent?: { stargazers_count?: number };
+      archived?: boolean;
       pushed_at?: string;
       updated_at?: string;
     };
 
     await setRepoUnavailable(packageName, false);
+    await setRepoArchived(packageName, repoInfo.archived === true);
     await setStars(packageName, repoInfo.stargazers_count || 0);
     if (repoInfo.parent) {
       await setParentStars(packageName, repoInfo.parent.stargazers_count || 0);

--- a/packages/@openupm/common/__tests__/utils.spec.ts
+++ b/packages/@openupm/common/__tests__/utils.spec.ts
@@ -184,6 +184,32 @@ describe('parsePackageMetadataRemote', () => {
     const result = parsePackageMetadataRemote(input);
     expect(result.repoUnavailable).toEqual(expected);
   });
+
+  it('should set repoArchived to false if not defined', () => {
+    const input = {
+      ver: '1.0.0',
+      stars: 10,
+      pstars: 5,
+      imageFilename: 'test.png',
+      dl30d: 100,
+    };
+    const expected = false;
+    const result = parsePackageMetadataRemote(input);
+    expect(result.repoArchived).toEqual(expected);
+  });
+
+  it('should preserve repoArchived when defined', () => {
+    const input = {
+      ver: '1.0.0',
+      stars: 10,
+      pstars: 5,
+      imageFilename: 'test.png',
+      dl30d: 100,
+      repoArchived: true,
+    };
+    const result = parsePackageMetadataRemote(input);
+    expect(result.repoArchived).toEqual(true);
+  });
 });
 
 describe('filterMetadatabyTopicSlug', () => {

--- a/packages/@openupm/common/src/utils.ts
+++ b/packages/@openupm/common/src/utils.ts
@@ -122,6 +122,8 @@ export function parsePackageMetadataRemote(
       obj.repoUnavailable === undefined
         ? false
         : (obj.repoUnavailable as boolean),
+    repoArchived:
+      obj.repoArchived === undefined ? false : (obj.repoArchived as boolean),
   };
   return parsedObj;
 }

--- a/packages/@openupm/server-common/__tests__/models/packageExtra.spec.ts
+++ b/packages/@openupm/server-common/__tests__/models/packageExtra.spec.ts
@@ -3,8 +3,10 @@ import {
   getRedisKeyForPackageExtra,
   getInvalidTags,
   getReadmeUpdatedAt,
+  getRepoArchived,
   setInvalidTags,
   setReadmeUpdatedAt,
+  setRepoArchived,
   getPropKeyForLang,
 } from '../../src/models/packageExtra.js';
 
@@ -52,6 +54,21 @@ describeWithRedis('getReadmeUpdatedAt', () => {
     await setReadmeUpdatedAt(SAMPLE_PACKAGE_NAME, 1767225600000);
     const result = await getReadmeUpdatedAt(SAMPLE_PACKAGE_NAME);
     expect(result).toEqual(1767225600000);
+  });
+});
+
+describeWithRedis('getRepoArchived', () => {
+  it('returns false when package has no archived flag', async () => {
+    const val = await getRepoArchived('package-not-existed');
+    expect(val).toEqual(false);
+  });
+
+  it('sets and gets archived flag', async () => {
+    await setRepoArchived(SAMPLE_PACKAGE_NAME, true);
+    expect(await getRepoArchived(SAMPLE_PACKAGE_NAME)).toEqual(true);
+
+    await setRepoArchived(SAMPLE_PACKAGE_NAME, false);
+    expect(await getRepoArchived(SAMPLE_PACKAGE_NAME)).toEqual(false);
   });
 });
 

--- a/packages/@openupm/server-common/src/models/packageExtra.ts
+++ b/packages/@openupm/server-common/src/models/packageExtra.ts
@@ -28,6 +28,7 @@ export const propKeys: { [key: string]: string } = {
   imageUrl: 'imageUrl',
   readmeCacheKey: 'readmeCacheKey',
   repoUnavailable: 'repoUnavailable',
+  repoArchived: 'repoArchived',
   repoUpdatedTime: 'repoUpdatedTime',
   repoPushedTime: 'repoPushedTime',
   updatedTime: 'updatedTime',
@@ -378,6 +379,20 @@ export const getRepoUnavailable = async function (
   packageName: string,
 ): Promise<boolean> {
   const text = await getValue(packageName, propKeys.repoUnavailable);
+  return text === '1';
+};
+
+export const setRepoArchived = async function (
+  packageName: string,
+  value: boolean,
+): Promise<void> {
+  await setValue(packageName, propKeys.repoArchived, value ? '1' : '0');
+};
+
+export const getRepoArchived = async function (
+  packageName: string,
+): Promise<boolean> {
+  const text = await getValue(packageName, propKeys.repoArchived);
   return text === '1';
 };
 

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -64,6 +64,8 @@ export interface PackageMetadataRemote {
   dl30d: number;
   // Repo unavailable
   repoUnavailable: boolean;
+  // Repo archived
+  repoArchived: boolean;
 }
 
 // PackageMetadata merges PackageMetadataLocal and PackageMetadataRemote.


### PR DESCRIPTION
## Summary
- persist GitHub repo archived state as repoArchived alongside repoUnavailable
- expose repoArchived through aggregated package extra metadata and remote parsing defaults
- render archived status on package cards and package detail pages

Fixes openupm/openupm#5060

## Validation
- npm run build -- --filter=@openupm/types --filter=@openupm/test --filter=@openupm/common --filter=@openupm/local-data --filter=@openupm/server-common
- npm -w @openupm/jobs run test -- fetchPackageExtra.spec.ts aggregatePackageExtra.spec.ts
- npm -w @openupm/common run test -- utils.spec.ts
- npm -w @openupm/docs run test -- packageRepositoryStatus.spec.ts
- npm -w @openupm/server-common run test -- packageExtra.spec.ts
- npm run lint
- npm run build -- --filter=vuepress-plugin-openupm
- npm run docs:build:limit