### PR TITLE
Keep archived package cards compact

### DIFF
--- a/apps/docs/__tests__/vue/packageRepositoryStatus.spec.ts
+++ b/apps/docs/__tests__/vue/packageRepositoryStatus.spec.ts
@@ -21,6 +21,12 @@ describe("package repository status UI", () => {
     expect(source).toContain("Archived");
   });
 
+  it("hides the package card update time when the repository is archived", () => {
+    const source = readFileSync(packageCardPath, "utf8");
+
+    expect(source).toContain('v-if="metadata.time && !metadata.repoArchived"');
+  });
+
   it("renders archived and unavailable repository status conditions independently", () => {
     const source = readFileSync(packageDetailLayoutPath, "utf8");
 

--- a/apps/docs/docs/.vuepress/components/PackageCard.vue
+++ b/apps/docs/docs/.vuepress/components/PackageCard.vue
@@ -102,7 +102,7 @@ const imageErrorMessage = computed(() => {
               <LazyImage :src="ownerAvatarUrl" :alt="metadata.owner" class="avatar avatar-sm" />
               {{ metadata.owner }}
             </span>
-            <span v-if="metadata.time" class="chip">
+            <span v-if="metadata.time && !metadata.repoArchived" class="chip">
               <i class="fas fa-clock"></i>{{ timeAgoText }}
             </span>
             <span v-if="metadata.repoArchived" class="chip chip-archived">


### PR DESCRIPTION
## Summary
- hide the update-since chip on archived package cards
- keep the archived chip visible so repository status still shows in the card footer

## Validation
- npm -w @openupm/docs run test -- packageRepositoryStatus.spec.ts
- npm -w @openupm/docs run lint
- git diff --check