### PR TITLE
Prioritize package card status chips

### DIFF
--- a/apps/docs/__tests__/vue/packageRepositoryStatus.spec.ts
+++ b/apps/docs/__tests__/vue/packageRepositoryStatus.spec.ts
@@ -14,17 +14,16 @@ const localePath = fileURLToPath(
 );
 
 describe("package repository status UI", () => {
-  it("renders an archived chip on package cards when remote metadata is archived", () => {
+  it("renders one package card repository status chip with unavailable priority", () => {
     const source = readFileSync(packageCardPath, "utf8");
 
-    expect(source).toContain('v-if="metadata.repoArchived"');
+    expect(source).toContain("const repositoryStatusChip = computed(() => {");
+    expect(source).toContain("if (props.metadata.repoUnavailable)");
+    expect(source).toContain('text: "Unavailable"');
     expect(source).toContain("Archived");
-  });
-
-  it("hides the package card update time when the repository is archived", () => {
-    const source = readFileSync(packageCardPath, "utf8");
-
-    expect(source).toContain('v-if="metadata.time && !metadata.repoArchived"');
+    expect(source).toContain("if (props.metadata.time)");
+    expect(source).toContain('v-if="repositoryStatusChip"');
+    expect(source).not.toContain('v-if="metadata.time && !metadata.repoArchived"');
   });
 
   it("renders archived and unavailable repository status conditions independently", () => {

--- a/apps/docs/docs/.vuepress/components/PackageCard.vue
+++ b/apps/docs/docs/.vuepress/components/PackageCard.vue
@@ -36,6 +36,29 @@ const timeAgoText = computed(() => {
   return timeAgoFormat(new Date(props.metadata.time));
 });
 
+const repositoryStatusChip = computed(() => {
+  if (props.metadata.repoUnavailable) {
+    return {
+      className: "chip-unavailable",
+      icon: "fas fa-exclamation-triangle",
+      text: "Unavailable",
+    };
+  }
+  if (props.metadata.repoArchived) {
+    return {
+      className: "chip-archived",
+      text: "Archived",
+    };
+  }
+  if (props.metadata.time) {
+    return {
+      icon: "fas fa-clock",
+      text: timeAgoText.value,
+    };
+  }
+  return null;
+});
+
 const defaultImageInlineStyle = computed(() => {
   return `background: linear-gradient(37deg, ${stopColor1.value}, ${stopColor2.value});`
 });
@@ -102,11 +125,8 @@ const imageErrorMessage = computed(() => {
               <LazyImage :src="ownerAvatarUrl" :alt="metadata.owner" class="avatar avatar-sm" />
               {{ metadata.owner }}
             </span>
-            <span v-if="metadata.time && !metadata.repoArchived" class="chip">
-              <i class="fas fa-clock"></i>{{ timeAgoText }}
-            </span>
-            <span v-if="metadata.repoArchived" class="chip chip-archived">
-              Archived
+            <span v-if="repositoryStatusChip" class="chip" :class="repositoryStatusChip.className">
+              <i v-if="repositoryStatusChip.icon" :class="repositoryStatusChip.icon"></i>{{ repositoryStatusChip.text }}
             </span>
           </div>
           <div class="row2">
@@ -214,6 +234,11 @@ const imageErrorMessage = computed(() => {
           overflow: hidden;
           text-overflow: ellipsis;
           max-width: 16ch;
+        }
+
+        &.chip-unavailable {
+          background-color: var(--c-warning);
+          color: var(--c-warning-text, #746000);
         }
       }
     }


### PR DESCRIPTION
## Summary
- add a package card chip for inaccessible repositories
- render a single card status chip in priority order: unavailable, archived, updated
- keep package detail unavailable and archived callouts independent

## Validation
- npm -w @openupm/docs run test -- packageRepositoryStatus.spec.ts
- npm -w @openupm/docs run lint
- git diff --check