### PR TITLE
[codex] Show published release version

### DIFF
--- a/apps/docs/__tests__/vue/packagePipelinesView.spec.ts
+++ b/apps/docs/__tests__/vue/packagePipelinesView.spec.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const packagePipelinesViewPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/PackagePipelinesView.vue",
+    import.meta.url,
+  ),
+);
+
+describe("package pipelines UI", () => {
+  it("displays publishedVersion with version fallback", () => {
+    const source = readFileSync(packagePipelinesViewPath, "utf8");
+
+    expect(source).toContain(
+      "const displayVersion = x.publishedVersion || x.version;",
+    );
+    expect(source).toContain("{{ entry.displayVersion }}");
+  });
+
+  it("shows scheduled version when it differs from publishedVersion", () => {
+    const source = readFileSync(packagePipelinesViewPath, "utf8");
+
+    expect(source).toContain("const hasScheduledVersionMismatch =");
+    expect(source).toContain('v-if="entry.hasScheduledVersionMismatch"');
+    expect(source).toContain(':data-tooltip="entry.version"');
+    expect(source).toContain("scheduled-version");
+  });
+});

--- a/apps/docs/docs/.vuepress/components/PackagePipelinesView.vue
+++ b/apps/docs/docs/.vuepress/components/PackagePipelinesView.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { paramCase } from "change-case";
 import urlJoin from "url-join";
 
 import { ReleaseState, ReleaseErrorCode } from "@openupm/types";
-import { getAzureWebBuildUrl } from '@openupm/common/build/urls.js';
-import { PackageRelease } from '@openupm/types';
+import { getAzureWebBuildUrl } from "@openupm/common/build/urls.js";
+import { PackageRelease } from "@openupm/types";
 
 const { t } = useI18n();
 
@@ -25,50 +25,55 @@ const releaseReasonLocaleNoteKeyMap = computed(() => {
 const props = defineProps({
   invalidTags: {
     type: Array<string>,
-    default: () => []
+    default: () => [],
   },
   releases: {
     type: Array<PackageRelease>,
-    default: () => []
+    default: () => [],
   },
   repoUrl: {
     type: String,
-    default: ""
+    default: "",
   },
   isLoading: {
     type: Boolean,
-    default: true
-  }
+    default: true,
+  },
 });
 
 const invalidTagEntries = computed(() => {
-  return props.invalidTags.map(x => {
+  return props.invalidTags.map((x) => {
     return {
       tag: x,
       tagLink: {
         link: urlJoin(props.repoUrl, "releases/tag", x),
-        text: x
-      }
+        text: x,
+      },
     };
   });
 });
 
 const releaseEntries = computed(() => {
-  return props.releases.map(x => {
+  return props.releases.map((x) => {
+    const displayVersion = x.publishedVersion || x.version;
+    const hasScheduledVersionMismatch =
+      Boolean(x.publishedVersion) && x.publishedVersion !== x.version;
     const entry = {
       ...x,
+      displayVersion,
+      hasScheduledVersionMismatch,
       buildLink: {
         link: getAzureWebBuildUrl(x.buildId),
-        text: x.buildId
+        text: x.buildId,
       },
       commitLink: {
         link: urlJoin(props.repoUrl, "commit", x.commit),
-        text: x.commit.substring(0, 7)
+        text: x.commit.substring(0, 7),
       },
       icon: "",
       note: "",
       errorCode: "",
-      errorMessage: ""
+      errorMessage: "",
     };
     if (entry.state == ReleaseState.Pending) {
       entry.icon = "far fa-clock";
@@ -117,13 +122,29 @@ const releaseEntries = computed(() => {
           </td>
           <td>{{ entry.tag }}</td>
           <td>
-            {{ entry.version }}
-            <span v-if="entry.source === 'githubRelease'" class="release-badge tooltip"
-              :data-tooltip="$t('github-release-asset-package')">
-              <i class="fas fa-paperclip" aria-hidden="true"></i>
-              <span class="sr-only">{{ $t("github-release-asset-package") }}</span>
+            <span>{{ entry.displayVersion }}</span>
+            <span
+              v-if="entry.hasScheduledVersionMismatch"
+              class="scheduled-version tooltip"
+              :data-tooltip="entry.version"
+            >
+              {{ entry.version }}
             </span>
-            <span v-if="entry.signed" class="release-badge tooltip" :data-tooltip="$t('signed-package')">
+            <span
+              v-if="entry.source === 'githubRelease'"
+              class="release-badge tooltip"
+              :data-tooltip="$t('github-release-asset-package')"
+            >
+              <i class="fas fa-paperclip" aria-hidden="true"></i>
+              <span class="sr-only">{{
+                $t("github-release-asset-package")
+              }}</span>
+            </span>
+            <span
+              v-if="entry.signed"
+              class="release-badge tooltip"
+              :data-tooltip="$t('signed-package')"
+            >
               <i class="fas fa-file-signature" aria-hidden="true"></i>
               <span class="sr-only">{{ $t("signed-package") }}</span>
             </span>
@@ -136,7 +157,9 @@ const releaseEntries = computed(() => {
           </td>
           <td>
             <span>{{ entry.note }}</span>
-            <span v-show="entry.errorCode" class="label label-warning mr-2">{{ entry.errorCode }}</span>
+            <span v-show="entry.errorCode" class="label label-warning mr-2">{{
+              entry.errorCode
+            }}</span>
             <span class="hide-sm">{{ entry.errorMessage }}</span>
           </td>
         </tr>
@@ -173,6 +196,13 @@ const releaseEntries = computed(() => {
   .release-badge {
     display: inline-block;
     margin-left: 0.25rem;
+    color: var(--c-text-lightest);
+  }
+
+  .scheduled-version {
+    display: inline-block;
+    margin-left: 0.35rem;
+    font-size: 0.75rem;
     color: var(--c-text-lightest);
   }
 

--- a/apps/queue/__tests__/workers/buildRelease.spec.ts
+++ b/apps/queue/__tests__/workers/buildRelease.spec.ts
@@ -1,42 +1,42 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { ReleaseErrorCode, RetryableReleaseErrorCodes } from '@openupm/types';
+import { ReleaseErrorCode, RetryableReleaseErrorCodes } from "@openupm/types";
 import {
   getPackageResultFromBuildLogText,
   getQueueBuildParameters,
   getReasonFromBuildLogText,
   getReleaseSource,
-} from '../../src/workers/buildRelease.js';
+} from "../../src/workers/buildRelease.js";
 
-describe('buildRelease.getReasonFromBuildLogText', () => {
-  it('None', () => {
-    expect(getReasonFromBuildLogText('')).toEqual(ReleaseErrorCode.None);
+describe("buildRelease.getReasonFromBuildLogText", () => {
+  it("None", () => {
+    expect(getReasonFromBuildLogText("")).toEqual(ReleaseErrorCode.None);
   });
 
-  it('basic npm codes', () => {
-    expect(getReasonFromBuildLogText('error code E400')).toEqual(
+  it("basic npm codes", () => {
+    expect(getReasonFromBuildLogText("error code E400")).toEqual(
       ReleaseErrorCode.BadRequest,
     );
-    expect(getReasonFromBuildLogText('error code E401')).toEqual(
+    expect(getReasonFromBuildLogText("error code E401")).toEqual(
       ReleaseErrorCode.Unauthorized,
     );
-    expect(getReasonFromBuildLogText('error code E403')).toEqual(
+    expect(getReasonFromBuildLogText("error code E403")).toEqual(
       ReleaseErrorCode.Forbidden,
     );
-    expect(getReasonFromBuildLogText('error code E409')).toEqual(
+    expect(getReasonFromBuildLogText("error code E409")).toEqual(
       ReleaseErrorCode.VersionConflict,
     );
   });
 
-  it('PackageNameInvalid', () => {
+  it("PackageNameInvalid", () => {
     expect(
       getReasonFromBuildLogText(
-        'error code E400\\nerror 400 Bad Request - PUT https://package.***.com/@umm%2fcanvas_resizer - unsupported registry call',
+        "error code E400\\nerror 400 Bad Request - PUT https://package.***.com/@umm%2fcanvas_resizer - unsupported registry call",
       ),
     ).toEqual(ReleaseErrorCode.PackageNameInvalid);
   });
 
-  it('NpmHookError and non-retryable', () => {
+  it("NpmHookError and non-retryable", () => {
     expect(
       getReasonFromBuildLogText(`
 /opt/hostedtoolcache/node/22.22.0/x64/bin/npm publish --tag=patch-3.0.0
@@ -50,7 +50,7 @@ npm error command failed
     ).toBe(false);
   });
 
-  it('submodule and lfs errors', () => {
+  it("submodule and lfs errors", () => {
     expect(
       getReasonFromBuildLogText(
         "fatal: Fetched in submodule path 'ext/iOS/sdk', but it did not contain 875b462e73a2619f4a834bf5a009ed760d4789bd.\nDirect fetching of that commit failed.",
@@ -65,18 +65,20 @@ npm error command failed
 
     expect(
       getReasonFromBuildLogText(
-        'batch response: This repository exceeded its LFS budget.',
+        "batch response: This repository exceeded its LFS budget.",
       ),
     ).toEqual(ReleaseErrorCode.LfsBudgetExceeded);
 
     expect(
-      getReasonFromBuildLogText('Object does not exist on the server'),
+      getReasonFromBuildLogText("Object does not exist on the server"),
     ).toEqual(ReleaseErrorCode.LfsObjectNotFound);
   });
 
-  it('RemoteBranchNotFound and InvalidVersion', () => {
+  it("RemoteBranchNotFound and InvalidVersion", () => {
     expect(
-      getReasonFromBuildLogText('fatal: Remote branch 4.7.1a not found in upstream origin'),
+      getReasonFromBuildLogText(
+        "fatal: Remote branch 4.7.1a not found in upstream origin",
+      ),
     ).toEqual(ReleaseErrorCode.RemoteBranchNotFound);
 
     expect(getReasonFromBuildLogText('error Invalid version: "0.1"')).toEqual(
@@ -84,12 +86,12 @@ npm error command failed
     );
   });
 
-  it('GitHub Release asset download errors are retryable', () => {
+  it("GitHub Release asset download errors are retryable", () => {
     expect(
-      getReasonFromBuildLogText('GITHUB_RELEASE_ASSET_DOWNLOAD_NOT_FOUND'),
+      getReasonFromBuildLogText("GITHUB_RELEASE_ASSET_DOWNLOAD_NOT_FOUND"),
     ).toEqual(ReleaseErrorCode.GitHubReleaseAssetNotFound);
     expect(
-      getReasonFromBuildLogText('GITHUB_RELEASE_ASSET_DOWNLOAD_FAILED'),
+      getReasonFromBuildLogText("GITHUB_RELEASE_ASSET_DOWNLOAD_FAILED"),
     ).toEqual(ReleaseErrorCode.GitHubReleaseAssetDownloadFailed);
     expect(
       RetryableReleaseErrorCodes.includes(
@@ -103,23 +105,23 @@ npm error command failed
     ).toBe(true);
   });
 
-  it('GitHub Release asset validation errors are non-retryable', () => {
+  it("GitHub Release asset validation errors are non-retryable", () => {
     expect(
-      getReasonFromBuildLogText('Unsupported package asset extension'),
+      getReasonFromBuildLogText("Unsupported package asset extension"),
     ).toEqual(ReleaseErrorCode.PackageJsonParsingError);
     expect(
       getReasonFromBuildLogText(
-        'Downloaded package asset has no package/package.json',
+        "Downloaded package asset has no package/package.json",
       ),
     ).toEqual(ReleaseErrorCode.PackageNotFound);
     expect(
       getReasonFromBuildLogText(
-        'Downloaded package asset name mismatch: actual=package-a, expected=package-b',
+        "Downloaded package asset name mismatch: actual=package-a, expected=package-b",
       ),
     ).toEqual(ReleaseErrorCode.PackageNameInvalid);
     expect(
       getReasonFromBuildLogText(
-        'Downloaded package asset version mismatch: actual=1.0.0, expected=2.0.0',
+        "Downloaded package asset version mismatch: actual=1.0.0, expected=2.0.0",
       ),
     ).toEqual(ReleaseErrorCode.InvalidVersion);
     expect(
@@ -130,71 +132,68 @@ npm error command failed
   });
 });
 
-describe('buildRelease.getReleaseSource', () => {
-  it('defaults to git', () => {
-    expect(
-      getReleaseSource(
-        { trackingMode: 'git' },
-        {},
-      ),
-    ).toEqual('git');
+describe("buildRelease.getReleaseSource", () => {
+  it("defaults to git", () => {
+    expect(getReleaseSource({ trackingMode: "git" }, {})).toEqual("git");
   });
 
-  it('uses package tracking mode when release source is missing', () => {
-    expect(
-      getReleaseSource(
-        { trackingMode: 'githubRelease' },
-        {},
-      ),
-    ).toEqual('githubRelease');
+  it("uses package tracking mode when release source is missing", () => {
+    expect(getReleaseSource({ trackingMode: "githubRelease" }, {})).toEqual(
+      "githubRelease",
+    );
   });
 
-  it('preserves saved source on retry', () => {
+  it("preserves saved source on retry", () => {
     expect(
-      getReleaseSource(
-        { trackingMode: 'git' },
-        { source: 'githubRelease' },
-      ),
-    ).toEqual('githubRelease');
+      getReleaseSource({ trackingMode: "git" }, { source: "githubRelease" }),
+    ).toEqual("githubRelease");
   });
 });
 
-describe('buildRelease.getQueueBuildParameters', () => {
-  it('queues git releases with source mode', async () => {
+describe("buildRelease.getQueueBuildParameters", () => {
+  it("queues git releases with source mode", async () => {
     await expect(
       getQueueBuildParameters(
         {
-          name: 'com.example.pkg',
-          repoUrl: 'https://github.com/example/pkg',
-          trackingMode: 'git',
+          name: "com.example.pkg",
+          repoUrl: "https://github.com/example/pkg",
+          trackingMode: "git",
         } as never,
         {
-          packageName: 'com.example.pkg',
-          version: '1.0.0',
-          tag: 'v1.0.0',
-          source: 'git',
+          packageName: "com.example.pkg",
+          version: "1.0.0",
+          tag: "v1.0.0",
+          source: "git",
         } as never,
       ),
     ).resolves.toMatchObject({
-      repoUrl: 'https://github.com/example/pkg',
-      repoBranch: 'v1.0.0',
-      packageName: 'com.example.pkg',
-      packageVersion: '1.0.0',
-      packageSource: 'git',
+      repoUrl: "https://github.com/example/pkg",
+      repoBranch: "v1.0.0",
+      packageName: "com.example.pkg",
+      packageVersion: "1.0.0",
+      packageSource: "git",
     });
   });
 });
 
-describe('buildRelease.getPackageResultFromBuildLogText', () => {
-  it('parses the final signed package result marker', () => {
+describe("buildRelease.getPackageResultFromBuildLogText", () => {
+  it("parses the final signed package result marker with publishedVersion", () => {
     expect(
       getPackageResultFromBuildLogText(
-        'setup\nOPENUPM_PACKAGE_RESULT {"signed":false}\nOPENUPM_PACKAGE_RESULT {"signed":true}',
+        'setup\nOPENUPM_PACKAGE_RESULT {"signed":false,"publishedVersion":"1.0.0"}\nOPENUPM_PACKAGE_RESULT {"signed":true,"publishedVersion":"1.0.1"}',
+      ),
+    ).toEqual({ signed: true, publishedVersion: "1.0.1" });
+  });
+
+  it("parses old package result markers without publishedVersion", () => {
+    expect(
+      getPackageResultFromBuildLogText(
+        'OPENUPM_PACKAGE_RESULT {"signed":true}',
       ),
     ).toEqual({ signed: true });
   });
 
-  it('returns null for missing markers', () => {
-    expect(getPackageResultFromBuildLogText('')).toBeNull();
+  it("returns null for missing markers", () => {
+    expect(getPackageResultFromBuildLogText("")).toBeNull();
   });
 });

--- a/apps/queue/src/workers/buildRelease.ts
+++ b/apps/queue/src/workers/buildRelease.ts
@@ -1,6 +1,6 @@
-import configRaw from 'config';
-import superagent from 'superagent';
-import util from 'util';
+import configRaw from "config";
+import superagent from "superagent";
+import util from "util";
 
 import {
   ReleaseErrorCode,
@@ -8,13 +8,13 @@ import {
   ReleaseState,
   RetryableReleaseErrorCodes,
   type PackageMetadataLocal,
-} from '@openupm/types';
-import { loadPackageMetadataLocal } from '@openupm/local-data';
+} from "@openupm/types";
+import { loadPackageMetadataLocal } from "@openupm/local-data";
 import {
   fetchOneOrThrow,
   save,
-} from '@openupm/server-common/build/models/release.js';
-import { createLogger } from '@openupm/server-common/build/log.js';
+} from "@openupm/server-common/build/models/release.js";
+import { createLogger } from "@openupm/server-common/build/log.js";
 
 import {
   BuildResult,
@@ -24,17 +24,17 @@ import {
   getBuildSectionLogUrl,
   queueBuild,
   waitBuild,
-} from '../utils/azure.js';
+} from "../utils/azure.js";
 import {
   GitHubReleaseAssetError,
   resolveGitHubReleaseAsset,
-} from '../utils/githubReleaseAsset.js';
+} from "../utils/githubReleaseAsset.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
 const sleep = util.promisify(setTimeout);
-const logger = createLogger('@openupm/queue/buildRelease');
-const packageResultMarker = 'OPENUPM_PACKAGE_RESULT';
+const logger = createLogger("@openupm/queue/buildRelease");
+const packageResultMarker = "OPENUPM_PACKAGE_RESULT";
 
 export async function buildRelease(
   packageName: string,
@@ -53,14 +53,18 @@ export async function buildRelease(
     const build = await waitReleaseBuild(buildApi, release);
     await handleReleaseBuild(build, release);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ETIMEDOUT') {
+    if ((err as NodeJS.ErrnoException).code === "ETIMEDOUT") {
       release.state = ReleaseState.Failed;
       release.reason = ReleaseErrorCode.ConnectionTimeout;
+      release.signed = false;
+      release.publishedVersion = undefined;
       await save(release);
       logReleaseError(release);
     } else if (err instanceof GitHubReleaseAssetError) {
       release.state = ReleaseState.Failed;
       release.reason = err.reason;
+      release.signed = false;
+      release.publishedVersion = undefined;
       await save(release);
       logReleaseError(release);
     }
@@ -72,7 +76,7 @@ async function updateReleaseState(release: ReleaseModel): Promise<boolean> {
   if (release.state === ReleaseState.Succeeded) {
     logger.debug(
       { rel: `${release.packageName}@${release.version}` },
-      'skip successful release',
+      "skip successful release",
     );
     return false;
   }
@@ -83,6 +87,8 @@ async function updateReleaseState(release: ReleaseModel): Promise<boolean> {
   ) {
     release.state = ReleaseState.Building;
     release.reason = ReleaseErrorCode.None;
+    release.signed = false;
+    release.publishedVersion = undefined;
     await save(release);
     return true;
   }
@@ -92,7 +98,9 @@ async function updateReleaseState(release: ReleaseModel): Promise<boolean> {
     release.state === ReleaseState.Failed
   ) {
     release.state = ReleaseState.Building;
-    release.buildId = '';
+    release.buildId = "";
+    release.signed = false;
+    release.publishedVersion = undefined;
     await save(release);
     return true;
   }
@@ -107,10 +115,14 @@ async function updateReleaseBuild(
   release: ReleaseModel,
 ): Promise<ReleaseModel> {
   if (!release.buildId) {
-    logger.info({ rel: `${release.packageName}@${release.version}` }, 'queue build');
+    logger.info(
+      { rel: `${release.packageName}@${release.version}` },
+      "queue build",
+    );
     if (!pkg) throw new Error(`package not found: ${release.packageName}`);
     release.source = getReleaseSource(pkg, release);
     release.signed = false;
+    release.publishedVersion = undefined;
     release = await save(release);
     const parameters = await getQueueBuildParameters(pkg, release);
     const build = await queueBuild(buildApi, config.azureDevops.definitionId, {
@@ -134,10 +146,10 @@ export async function getQueueBuildParameters(
     packageVersion: release.version,
   };
 
-  if (getReleaseSource(pkg, release) === 'git') {
+  if (getReleaseSource(pkg, release) === "git") {
     return {
       ...baseParameters,
-      packageSource: 'git',
+      packageSource: "git",
     };
   }
 
@@ -150,7 +162,7 @@ export async function getQueueBuildParameters(
 
   return {
     ...baseParameters,
-    packageSource: 'githubRelease',
+    packageSource: "githubRelease",
     packageAssetUrl: resolvedAsset.packageAssetUrl,
     packageAssetName: resolvedAsset.packageAssetName,
   };
@@ -163,8 +175,11 @@ async function waitReleaseBuild(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any | null> {
   logger.debug(
-    { rel: `${release.packageName}@${release.version}`, buildId: release.buildId },
-    'wait build',
+    {
+      rel: `${release.packageName}@${release.version}`,
+      buildId: release.buildId,
+    },
+    "wait build",
   );
   return await waitBuild(buildApi, release.buildId);
 }
@@ -174,7 +189,7 @@ async function handleReleaseBuild(
   build: any | null,
   release: ReleaseModel,
 ): Promise<void> {
-  let fullLogText = '';
+  let fullLogText = "";
   if (release.buildId) {
     fullLogText = await getFullBuildLogText(release.buildId);
   }
@@ -189,17 +204,25 @@ async function handleReleaseBuild(
     const packageResult = getPackageResultFromBuildLogText(fullLogText);
     if (!packageResult) {
       release.signed = false;
+      release.publishedVersion = undefined;
       logger.warn(
-        { rel: `${release.packageName}@${release.version}`, build: release.buildId },
-        'package result marker missing from successful build log',
+        {
+          rel: `${release.packageName}@${release.version}`,
+          build: release.buildId,
+        },
+        "package result marker missing from successful build log",
       );
     } else {
       release.signed = packageResult.signed;
+      release.publishedVersion = packageResult.publishedVersion;
     }
     await save(release);
     logger.info(
-      { rel: `${release.packageName}@${release.version}`, build: release.buildId },
-      'build succeeded',
+      {
+        rel: `${release.packageName}@${release.version}`,
+        build: release.buildId,
+      },
+      "build succeeded",
     );
     return;
   }
@@ -213,6 +236,7 @@ async function handleReleaseBuild(
   release.state = ReleaseState.Failed;
   release.reason = reason;
   release.signed = false;
+  release.publishedVersion = undefined;
   await save(release);
   logReleaseError(release);
 
@@ -224,25 +248,33 @@ async function handleReleaseBuild(
 }
 
 export function getReleaseSource(
-  pkg: Pick<PackageMetadataLocal, 'trackingMode'>,
-  release: Pick<ReleaseModel, 'source'>,
-): 'git' | 'githubRelease' {
-  return release.source || pkg.trackingMode || 'git';
+  pkg: Pick<PackageMetadataLocal, "trackingMode">,
+  release: Pick<ReleaseModel, "source">,
+): "git" | "githubRelease" {
+  return release.source || pkg.trackingMode || "git";
 }
 
 export function getPackageResultFromBuildLogText(
   text: string,
-): { signed: boolean } | null {
-  let result: { signed: boolean } | null = null;
+): { signed: boolean; publishedVersion?: string } | null {
+  let result: { signed: boolean; publishedVersion?: string } | null = null;
   for (const line of text.split(/\r?\n/)) {
     const markerIndex = line.indexOf(packageResultMarker);
     if (markerIndex < 0) continue;
-    const jsonText = line.slice(markerIndex + packageResultMarker.length).trim();
+    const jsonText = line
+      .slice(markerIndex + packageResultMarker.length)
+      .trim();
     try {
-      const parsed = JSON.parse(jsonText) as { signed?: unknown };
+      const parsed = JSON.parse(jsonText) as {
+        signed?: unknown;
+        publishedVersion?: unknown;
+      };
       result = { signed: parsed.signed === true };
+      if (typeof parsed.publishedVersion === "string") {
+        result.publishedVersion = parsed.publishedVersion;
+      }
     } catch {
-      logger.warn({ line }, 'failed to parse package result marker');
+      logger.warn({ line }, "failed to parse package result marker");
     }
   }
   return result;
@@ -255,13 +287,13 @@ function logReleaseError(release: ReleaseModel): void {
       build: release.buildId,
       reason: release.reason,
     },
-    'release failed',
+    "release failed",
   );
 }
 
 async function getFullBuildLogText(buildId: string): Promise<string> {
   const buildLogsUrl = getBuildLogsUrl(buildId);
-  const resp = await superagent.get(buildLogsUrl).type('json');
+  const resp = await superagent.get(buildLogsUrl).type("json");
   const lastStepId = resp.body.value[resp.body.value.length - 1].id;
 
   const buildLogSectionUrl = getBuildSectionLogUrl(buildId, lastStepId);
@@ -271,7 +303,7 @@ async function getFullBuildLogText(buildId: string): Promise<string> {
 
 export function getReasonFromBuildLogText(text: string): ReleaseErrorCode {
   if (
-    text.includes('npm publish') &&
+    text.includes("npm publish") &&
     /(^|\n)(?:\S+\s+)?>\s+.+@\S+\s+(prepublishOnly|prepack|prepare|postpack|publish|postpublish)\s*($|\n)/m.test(
       text,
     ) &&
@@ -282,53 +314,53 @@ export function getReasonFromBuildLogText(text: string): ReleaseErrorCode {
     return ReleaseErrorCode.NpmHookError;
   if (/fatal: Remote branch .* not found/.test(text))
     return ReleaseErrorCode.RemoteBranchNotFound;
-  else if (text.includes('code E409')) return ReleaseErrorCode.VersionConflict;
+  else if (text.includes("code E409")) return ReleaseErrorCode.VersionConflict;
   else if (
-    (text.includes('ENOENT') && text.includes('error path package.json')) ||
-    text.includes('Downloaded package asset has no package/package.json')
+    (text.includes("ENOENT") && text.includes("error path package.json")) ||
+    text.includes("Downloaded package asset has no package/package.json")
   )
     return ReleaseErrorCode.PackageNotFound;
-  else if (text.includes('code E400')) {
+  else if (text.includes("code E400")) {
     if (/400 Bad Request - PUT https:\/\/.*\.com\/@/.test(text)) {
       return ReleaseErrorCode.PackageNameInvalid;
     }
     return ReleaseErrorCode.BadRequest;
-  } else if (text.includes('code E401')) return ReleaseErrorCode.Unauthorized;
-  else if (text.includes('code E403')) return ReleaseErrorCode.Forbidden;
-  else if (text.includes('code E413')) return ReleaseErrorCode.EntityTooLarge;
-  else if (text.includes('code E500')) return ReleaseErrorCode.InternalError;
-  else if (text.includes('code E502')) return ReleaseErrorCode.BadGateway;
-  else if (text.includes('code E503'))
+  } else if (text.includes("code E401")) return ReleaseErrorCode.Unauthorized;
+  else if (text.includes("code E403")) return ReleaseErrorCode.Forbidden;
+  else if (text.includes("code E413")) return ReleaseErrorCode.EntityTooLarge;
+  else if (text.includes("code E500")) return ReleaseErrorCode.InternalError;
+  else if (text.includes("code E502")) return ReleaseErrorCode.BadGateway;
+  else if (text.includes("code E503"))
     return ReleaseErrorCode.ServiceUnavailable;
-  else if (text.includes('code E504')) return ReleaseErrorCode.GatewayTimeout;
-  else if (text.includes('code EPRIVATE')) return ReleaseErrorCode.Private;
+  else if (text.includes("code E504")) return ReleaseErrorCode.GatewayTimeout;
+  else if (text.includes("code EPRIVATE")) return ReleaseErrorCode.Private;
   else if (
-    text.includes('code EJSONPARSE') ||
-    text.includes('Unsupported package asset extension') ||
-    text.includes('Downloaded package asset is not a valid tar archive') ||
-    text.includes('Downloaded package asset package.json is not valid JSON')
+    text.includes("code EJSONPARSE") ||
+    text.includes("Unsupported package asset extension") ||
+    text.includes("Downloaded package asset is not a valid tar archive") ||
+    text.includes("Downloaded package asset package.json is not valid JSON")
   )
     return ReleaseErrorCode.PackageJsonParsingError;
   else if (
-    text.includes('code ERR_STRING_TOO_LONG') ||
-    text.includes('JavaScript heap out of memory')
+    text.includes("code ERR_STRING_TOO_LONG") ||
+    text.includes("JavaScript heap out of memory")
   )
     return ReleaseErrorCode.HeapOutOfMemroy;
-  else if (text.includes('This repository exceeded its LFS budget'))
+  else if (text.includes("This repository exceeded its LFS budget"))
     return ReleaseErrorCode.LfsBudgetExceeded;
-  else if (text.includes('Object does not exist on the server'))
+  else if (text.includes("Object does not exist on the server"))
     return ReleaseErrorCode.LfsObjectNotFound;
-  else if (text.includes('GITHUB_RELEASE_ASSET_DOWNLOAD_NOT_FOUND'))
+  else if (text.includes("GITHUB_RELEASE_ASSET_DOWNLOAD_NOT_FOUND"))
     return ReleaseErrorCode.GitHubReleaseAssetNotFound;
-  else if (text.includes('GITHUB_RELEASE_ASSET_DOWNLOAD_FAILED'))
+  else if (text.includes("GITHUB_RELEASE_ASSET_DOWNLOAD_FAILED"))
     return ReleaseErrorCode.GitHubReleaseAssetDownloadFailed;
-  else if (text.includes('Downloaded package asset name mismatch'))
+  else if (text.includes("Downloaded package asset name mismatch"))
     return ReleaseErrorCode.PackageNameInvalid;
-  else if (text.includes('Downloaded package asset version mismatch'))
+  else if (text.includes("Downloaded package asset version mismatch"))
     return ReleaseErrorCode.InvalidVersion;
-  else if (text.includes('Invalid version') || text.includes('code EBADSEMVER'))
+  else if (text.includes("Invalid version") || text.includes("code EBADSEMVER"))
     return ReleaseErrorCode.InvalidVersion;
-  else if (text.includes('Could not read from remote repository'))
+  else if (text.includes("Could not read from remote repository"))
     return ReleaseErrorCode.RemoteRepositoryUnavailable;
   else if (
     /Fetched in submodule path .*?\s+Direct fetching of that commit failed\./s.test(
@@ -336,7 +368,9 @@ export function getReasonFromBuildLogText(text: string): ReleaseErrorCode {
     )
   )
     return ReleaseErrorCode.SubmoduleFetchingError;
-  else if (/fatal: No url found for submodule path .* in \.gitmodules/.test(text))
+  else if (
+    /fatal: No url found for submodule path .* in \.gitmodules/.test(text)
+  )
     return ReleaseErrorCode.RemoteSubmoduleUnavailable;
   else if (/fatal: clone of .* into submodule path/.test(text))
     return ReleaseErrorCode.RemoteSubmoduleUnavailable;

--- a/apps/web/__tests__/routers/packages.spec.ts
+++ b/apps/web/__tests__/routers/packages.spec.ts
@@ -42,6 +42,7 @@ const releases: ReleaseModel[] = [
     updatedAt: 0,
     source: 'githubRelease',
     signed: true,
+    publishedVersion: '0.2.1',
   },
 ];
 
@@ -82,6 +83,7 @@ describe('packages', () => {
       tag: 'v0.2.0',
       source: 'githubRelease',
       signed: true,
+      publishedVersion: '0.2.1',
     });
     expect(response.body.releases[1]).toMatchObject({
       tag: 'v0.1.0',

--- a/packages/@openupm/server-common/__tests__/models/release.spec.ts
+++ b/packages/@openupm/server-common/__tests__/models/release.spec.ts
@@ -80,6 +80,7 @@ describeWithRedis('save', function () {
       buildId: '123',
       source: 'githubRelease',
       signed: true,
+      publishedVersion: '1.0.1',
       createdAt: 0,
       updatedAt: 0,
     });
@@ -92,6 +93,7 @@ describeWithRedis('save', function () {
     expect(obj2!.reason).toEqual(obj.reason);
     expect(obj2!.source).toEqual('githubRelease');
     expect(obj2!.signed).toEqual(true);
+    expect(obj2!.publishedVersion).toEqual('1.0.1');
     await remove(obj2!.packageName, obj2!.version);
     const obj3 = await fetchOne(obj.packageName, obj.version);
     expect(obj3).toBeNull();

--- a/packages/@openupm/types/src/model-types.ts
+++ b/packages/@openupm/types/src/model-types.ts
@@ -10,6 +10,7 @@ export interface ReleaseModel {
   updatedAt: number;
   source?: 'git' | 'githubRelease';
   signed?: boolean;
+  publishedVersion?: string;
 }
 
 export const releaseModelFields: (keyof ReleaseModel)[] = [
@@ -24,6 +25,7 @@ export const releaseModelFields: (keyof ReleaseModel)[] = [
   'updatedAt',
   'source',
   'signed',
+  'publishedVersion',
 ];
 
 export interface InvalidTag {

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -83,6 +83,7 @@ export interface PackageRelease {
   version: string;
   source?: 'git' | 'githubRelease';
   signed?: boolean;
+  publishedVersion?: string;
 }
 
 export const releaseFields: (keyof PackageRelease)[] = [
@@ -95,6 +96,7 @@ export const releaseFields: (keyof PackageRelease)[] = [
   'version',
   'source',
   'signed',
+  'publishedVersion',
 ];
 
 export interface PackageInfo {


### PR DESCRIPTION
## Summary

- add optional `publishedVersion` release metadata to shared types, Redis persistence, and package API output
- parse new pipeline result markers while preserving old `{ signed }` marker compatibility
- clear stale published-version metadata on new attempts and failed builds
- show `publishedVersion || version` in the package Builds table, with the scheduled version shown when it differs

## Validation

- `npm run build -- --filter=@openupm/types --filter=@openupm/common --filter=@openupm/local-data --filter=@openupm/server-common`
- `npm run build -- --filter=@openupm/ads`
- `npm run test -- buildRelease.spec.ts` from `apps/queue`
- `npm run test -- release.spec.ts` from `packages/@openupm/server-common`
- `npm run test -- packages.spec.ts` from `apps/web`
- `npm run test -- packagePipelinesView.spec.ts` from `apps/docs`
- `npm run lint`
- `npm test`

A temporary local Redis Stack container was used for Redis-backed tests and removed after validation.