### PR TITLE
[codex] classify package version mismatches

### DIFF
--- a/apps/docs/docs/docs/adding-upm-package.md
+++ b/apps/docs/docs/docs/adding-upm-package.md
@@ -16,7 +16,7 @@ OpenUPM requires packages to meet the following criteria:
 
 4. **Functionality and Usefulness:** The package should be functional and useful. Test packages are not accepted due to limited resources. It's advised to import your package via Git URL and test it before submission.
 
-5. **Semantic Versioning:** The package should use [semantic versioning (semver)](https://semver.org/). For example, `1.1.0`, `1.1.1-preview`, `v1.1.2`. You can create Git tags using the [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) feature or automate the process using [GitHub actions](/blog/how-to-maintain-upm-package-part-2-f352fbf5f87c/).
+5. **Semantic Versioning:** The package should use [semantic versioning (semver)](https://semver.org/). For example, `1.1.0`, `1.1.1-preview`, `v1.1.2`. You can create Git tags using the [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) feature or automate the process using [GitHub actions](/blog/how-to-maintain-upm-package-part-2-f352fbf5f87c/). The version parsed from the Git tag must match the `version` field in the package's `package.json`.
 
 6. **Package Size:** The package size should be under 512MB due to limited resources. If OpenUPM receives more funding in the future, we may increase this limit.
 
@@ -121,9 +121,19 @@ After a brief pause, during which the build pipelines complete their tasks (usua
 
 The repository you submitted must have at least one versioned Git tag to trigger the build pipelines. Therefore, submissions without a Git tag for an extended period will be removed from the OpenUPM list. If you wish to add such a repository, please create an issue on the author's repository to request the addition of a Git tag. For guidance on automating the release process with GitHub actions, you can refer to [this tutorial](/blog/how-to-maintain-upm-package-part-2-f352fbf5f87c/).
 
+### Naming Git Tags
+
+Use clear semver tags that match `package.json.version`. Recommended tag names include `1.2.3`, `v1.2.3`, `1.2.3-preview.1`, `upm/v1.2.3`, and `com.example.package/v1.2.3`.
+
+For prereleases, prefer the identifiers `alpha`, `beta`, `rc`, or Unity-friendly `preview`. Dot-numbered prerelease tags such as `1.2.3-rc.1` or `1.2.3-preview.1` are clearer than unnumbered tags when you expect more than one prerelease.
+
+OpenUPM tolerates some historical tag shapes, including build metadata tags such as `v2.0.2+002`, loose spellings such as `0.10.7b`, and leading-zero versions such as `1.2.03`. These forms are accepted for compatibility with existing packages and may be normalized when OpenUPM parses them, but they are not recommended for new releases.
+
 ### Handling Prefixed Git Tags
 
 Some repositories use different content for different tags, for example, `1.0.0` for the main branch and `upm/1.0.0` for the UPM branch. In such cases, you need to specify the `gitTagPrefix` field in the package YAML file. For instance, set `gitTagPrefix: "upm/"` to prevent confusion in the build pipelines due to duplicated version tags. Without specifying a prefix, the build pipelines will treat `1.0.0` and `upm/1.0.0` as the same version tag and only build one of them. By default, a tag name with the prefix `upm/` takes higher priority. For example, `1.0.0` and `upm/1.1.0` will result in building only `upm/1.1.0`.
+
+For monorepos or repositories with duplicate tag families, set `gitTagPrefix` to the literal prefix that identifies this package's tags, such as `upm/` or `com.example.package/`. This prevents tags for another package or branch family from queueing builds for the wrong package.
 
 ### Publishing from a GitHub Release Asset
 

--- a/apps/queue/__tests__/workers/buildRelease.spec.ts
+++ b/apps/queue/__tests__/workers/buildRelease.spec.ts
@@ -84,6 +84,9 @@ npm error command failed
     expect(getReasonFromBuildLogText('error Invalid version: "0.1"')).toEqual(
       ReleaseErrorCode.InvalidVersion,
     );
+    expect(
+      RetryableReleaseErrorCodes.includes(ReleaseErrorCode.InvalidVersion),
+    ).toBe(false);
   });
 
   it("GitHub Release asset download errors are retryable", () => {
@@ -121,13 +124,27 @@ npm error command failed
     ).toEqual(ReleaseErrorCode.PackageNameInvalid);
     expect(
       getReasonFromBuildLogText(
-        "Downloaded package asset version mismatch: actual=1.0.0, expected=2.0.0",
+        "Downloaded package asset version mismatch: package.json.version=1.0.0, expectedReleaseVersion=2.0.0",
       ),
-    ).toEqual(ReleaseErrorCode.InvalidVersion);
+    ).toEqual(ReleaseErrorCode.VersionMismatch);
     expect(
       RetryableReleaseErrorCodes.includes(
         ReleaseErrorCode.PackageJsonParsingError,
       ),
+    ).toBe(false);
+    expect(
+      RetryableReleaseErrorCodes.includes(ReleaseErrorCode.VersionMismatch),
+    ).toBe(false);
+  });
+
+  it("git package manifest version mismatch is non-retryable", () => {
+    expect(
+      getReasonFromBuildLogText(
+        "Package manifest version mismatch: package.json.version=1.0.0, expectedReleaseVersion=2.0.0",
+      ),
+    ).toEqual(ReleaseErrorCode.VersionMismatch);
+    expect(
+      RetryableReleaseErrorCodes.includes(ReleaseErrorCode.VersionMismatch),
     ).toBe(false);
   });
 });

--- a/apps/queue/src/workers/buildRelease.ts
+++ b/apps/queue/src/workers/buildRelease.ts
@@ -356,8 +356,11 @@ export function getReasonFromBuildLogText(text: string): ReleaseErrorCode {
     return ReleaseErrorCode.GitHubReleaseAssetDownloadFailed;
   else if (text.includes("Downloaded package asset name mismatch"))
     return ReleaseErrorCode.PackageNameInvalid;
-  else if (text.includes("Downloaded package asset version mismatch"))
-    return ReleaseErrorCode.InvalidVersion;
+  else if (
+    text.includes("Downloaded package asset version mismatch") ||
+    text.includes("Package manifest version mismatch")
+  )
+    return ReleaseErrorCode.VersionMismatch;
   else if (text.includes("Invalid version") || text.includes("code EBADSEMVER"))
     return ReleaseErrorCode.InvalidVersion;
   else if (text.includes("Could not read from remote repository"))

--- a/packages/@openupm/common/__tests__/semver.spec.ts
+++ b/packages/@openupm/common/__tests__/semver.spec.ts
@@ -1,52 +1,33 @@
 import { getVersionFromTag } from '../src/semver.js';
 
 describe('getVersionFromTag()', function () {
-  it('test a.b.c', function () {
-    expect(getVersionFromTag('v1.0.0')).toEqual('1.0.0');
+  it.each([
+    ['1.2.3', '1.2.3'],
+    ['v1.2.3', '1.2.3'],
+    ['V1.2.3', '1.2.3'],
+    ['1.2.3-alpha', '1.2.3-alpha'],
+    ['1.2.3-alpha.1', '1.2.3-alpha.1'],
+    ['1.2.3-beta', '1.2.3-beta'],
+    ['1.2.3-beta.2', '1.2.3-beta.2'],
+    ['1.2.3-rc.1', '1.2.3-rc.1'],
+    ['1.2.3-preview', '1.2.3-preview'],
+    ['1.2.3-preview.1', '1.2.3-preview.1'],
+    ['upm/v1.2.3-beta.2', '1.2.3-beta.2'],
+    ['pkg-1.2.3-rc.1', '1.2.3-rc.1'],
+    ['pkg_1.2.3-preview.1', '1.2.3-preview.1'],
+    ['1.2.3-upm', '1.2.3'],
+    ['v1.2.3_upm', '1.2.3'],
+    ['0.10.7b', '0.10.7-b'],
+    ['1.2.03', '1.2.3'],
+    ['v2.0.2+002', '2.0.2'],
+  ])('parses %s as %s', function (tag, version) {
+    expect(getVersionFromTag(tag)).toEqual(version);
   });
-  it('test va.b.c', function () {
-    expect(getVersionFromTag('v1.0.0')).toEqual('1.0.0');
-  });
-  it('test Va.b.c', function () {
-    expect(getVersionFromTag('V1.0.0')).toEqual('1.0.0');
-  });
-  it('test a.b.c-preview', function () {
-    expect(getVersionFromTag('1.0.0-preview')).toEqual('1.0.0-preview');
-  });
-  it('test va.b.c-preview', function () {
-    expect(getVersionFromTag('v1.0.0-preview')).toEqual('1.0.0-preview');
-  });
-  it('test a.b.c.d', function () {
-    expect(getVersionFromTag('1.0.0.0')).toEqual(null);
-  });
-  it('test va.b.c.d', function () {
-    expect(getVersionFromTag('v1.0.0.0')).toEqual(null);
-  });
-  it('test a.b.c-preview.d', function () {
-    expect(getVersionFromTag('1.0.0-preview.0')).toEqual('1.0.0-preview.0');
-  });
-  it('test va.b.c-preview.d', function () {
-    expect(getVersionFromTag('v1.0.0-preview.0')).toEqual('1.0.0-preview.0');
-  });
-  it('test releases/va.b.c-preview.d', function () {
-    expect(getVersionFromTag('releases/v1.0.0-preview.0')).toEqual(
-      '1.0.0-preview.0',
-    );
-  });
-  it('test releases-va.b.c-preview.d', function () {
-    expect(getVersionFromTag('releases-v1.0.0-preview.0')).toEqual(
-      '1.0.0-preview.0',
-    );
-  });
-  it('test releases_va.b.c-preview.d', function () {
-    expect(getVersionFromTag('releases_v1.0.0-preview.0')).toEqual(
-      '1.0.0-preview.0',
-    );
-  });
-  it('test va.b.c-upm', function () {
-    expect(getVersionFromTag('v1.0.0-upm')).toEqual('1.0.0');
-  });
-  it('test va.b.c_upm', function () {
-    expect(getVersionFromTag('v1.0.0_upm')).toEqual('1.0.0');
-  });
+
+  it.each(['1.0.0.0', 'release', 'package/latest'])(
+    'returns null for %s',
+    function (tag) {
+      expect(getVersionFromTag(tag)).toEqual(null);
+    },
+  );
 });

--- a/packages/@openupm/types/src/constant.ts
+++ b/packages/@openupm/types/src/constant.ts
@@ -57,6 +57,8 @@ export enum ReleaseErrorCode {
   SubmoduleFetchingError = 809,
   // npm publish lifecycle hook failed
   NpmHookError = 810,
+  // Package manifest version does not match the discovered version
+  VersionMismatch = 811,
   // Connection timeout
   ConnectionTimeout = 900,
   // Connection timeout


### PR DESCRIPTION
## Summary

- Add a dedicated `VersionMismatch` release error code for package manifest versions that differ from the discovered release version.
- Keep invalid semver classification under `InvalidVersion` and assert both cases are non-retryable.
- Expand `getVersionFromTag` coverage for common stable, prerelease, prefixed, tolerated legacy, and invalid tag shapes.
- Update package author docs with recommended Git tag naming and `gitTagPrefix` guidance.

## Impact

Git-source manifest mismatches and GitHub Release asset manifest mismatches now resolve to the same author-actionable reason: `VersionMismatch`. This separates "fix your semver syntax" from "align `package.json.version` with the release tag/version".

## Validation

- `npm run build -- --filter=@openupm/types --filter=@openupm/common --filter=@openupm/queue`
- `npm test --workspace @openupm/common -- semver.spec.ts`
- `npm test --workspace @openupm/queue -- buildRelease.spec.ts`
- `npm run test --workspace @openupm/docs`
- `npm run lint --workspace @openupm/docs`
- `npm run lint`
- `npm run docs:build:limit --workspace @openupm/docs`