### PR TITLE
[codex] Add stable install selector

### DIFF
--- a/apps/docs/__tests__/vue/packageInstallTargets.spec.ts
+++ b/apps/docs/__tests__/vue/packageInstallTargets.spec.ts
@@ -1,0 +1,62 @@
+import {
+  getInstallCliCommand,
+  getInstallTargets,
+  getStableVersion,
+} from "../../docs/.vuepress/components/package-install-targets";
+import { describe, expect, it } from "vitest";
+
+describe("package install targets", () => {
+  it("returns one latest option when stable and latest are the same", () => {
+    expect(
+      getInstallTargets({
+        "dist-tags": { latest: "1.2.3" },
+        versions: {
+          "1.2.2": {},
+          "1.2.3": {},
+        },
+      }),
+    ).toEqual([{ kind: "latest", version: "1.2.3" }]);
+  });
+
+  it("returns stable first when latest is a newer prerelease", () => {
+    expect(
+      getInstallTargets({
+        "dist-tags": { latest: "2.0.0-preview.1" },
+        versions: {
+          "1.9.0": {},
+          "2.0.0-preview.1": {},
+        },
+      }),
+    ).toEqual([
+      { kind: "stable", version: "1.9.0" },
+      { kind: "latest", version: "2.0.0-preview.1" },
+    ]);
+  });
+
+  it("returns only latest when only prerelease versions exist", () => {
+    expect(
+      getInstallTargets({
+        "dist-tags": { latest: "1.0.0-preview.2" },
+        versions: {
+          "1.0.0-preview.1": {},
+          "1.0.0-preview.2": {},
+        },
+      }),
+    ).toEqual([{ kind: "latest", version: "1.0.0-preview.2" }]);
+  });
+
+  it("does not treat build metadata as a prerelease", () => {
+    expect(getStableVersion(["1.0.0-preview.1", "1.0.0+build.2"])).toBe(
+      "1.0.0+build.2",
+    );
+  });
+
+  it("pins CLI commands only when an explicit version is provided", () => {
+    expect(getInstallCliCommand("com.example.pkg")).toBe(
+      "openupm add com.example.pkg",
+    );
+    expect(getInstallCliCommand("com.example.pkg", "1.2.3")).toBe(
+      "openupm add com.example.pkg@1.2.3",
+    );
+  });
+});

--- a/apps/docs/__tests__/vue/packageSetup.spec.ts
+++ b/apps/docs/__tests__/vue/packageSetup.spec.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const packageSetupPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/PackageSetup.vue",
+    import.meta.url,
+  ),
+);
+
+const packageCliPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/PackageSetupViaCLI.vue",
+    import.meta.url,
+  ),
+);
+
+const packageMetadataViewPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/PackageMetadataView.vue",
+    import.meta.url,
+  ),
+);
+
+describe("PackageSetup install version selector", () => {
+  it("renders the selector only when stable and latest differ", () => {
+    const source = readFileSync(packageSetupPath, "utf8");
+
+    expect(source).toContain("v-if=\"hasInstallTargetSelector\"");
+    expect(source).toContain("v-for=\"target in installTargets\"");
+    expect(source).toContain("$t(target.kind)");
+  });
+
+  it("defaults to the first derived target and switches on button click", () => {
+    const source = readFileSync(packageSetupPath, "utf8");
+
+    expect(source).toContain("selectedInstallKind.value = targets[0]?.kind");
+    expect(source).toContain("@click=\"selectedInstallKind = target.kind\"");
+  });
+
+  it("passes selected versions to copy command and both modals", () => {
+    const setupSource = readFileSync(packageSetupPath, "utf8");
+    const cliSource = readFileSync(packageCliPath, "utf8");
+    const metadataSource = readFileSync(packageMetadataViewPath, "utf8");
+
+    expect(metadataSource).toContain(":packument=\"packument\"");
+    expect(setupSource).toContain("getInstallCliCommand(props.metadata.name, explicitCliVersion.value)");
+    expect(setupSource).toContain(":version=\"selectedPackageManagerVersion\"");
+    expect(setupSource).toContain(":version=\"explicitCliVersion\"");
+    expect(cliSource).toContain("getInstallCliCommand(props.name, props.version)");
+  });
+});

--- a/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
@@ -227,7 +227,7 @@ const trackingModeTooltip = computed(() => {
   <div class="meta-section container">
     <div class="columns">
       <PackageSetup :has-not-succeeded-build="hasNotSucceededBuild" :is-loading="isLoadingPackageSetup"
-        :metadata="metadata" :version="version || ''" :scopes="scopes" />
+        :metadata="metadata" :version="version || ''" :packument="packument" :scopes="scopes" />
       <section class="col-12">
         <div class="metadata-title">{{ $capitalize($t("repository")) }}</div>
         <span class="repo-link">

--- a/apps/docs/docs/.vuepress/components/PackageSetup.vue
+++ b/apps/docs/docs/.vuepress/components/PackageSetup.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { PropType, computed } from 'vue';
+import { PropType, computed, ref, watch } from 'vue';
 import urlJoin from "url-join";
 
-import { PackageMetadata } from "@openupm/types";
+import { PackageMetadata, Packument } from "@openupm/types";
+import { getInstallCliCommand, getInstallTargets, InstallTargetKind } from './package-install-targets';
 
 const props = defineProps({
   isLoading: {
@@ -21,14 +22,44 @@ const props = defineProps({
     type: String,
     default: "",
   },
+  packument: {
+    type: Object as PropType<Partial<Packument>>,
+    default: () => { },
+  },
   scopes: {
     type: Array<string>,
     default: () => [],
   },
 });
 
+const selectedInstallKind = ref<InstallTargetKind | null>(null);
+
+const installTargets = computed(() => {
+  return getInstallTargets(props.packument);
+});
+
+watch(installTargets, (targets) => {
+  selectedInstallKind.value = targets[0]?.kind || null;
+}, { immediate: true });
+
+const selectedInstallTarget = computed(() => {
+  return installTargets.value.find((target) => target.kind === selectedInstallKind.value) || installTargets.value[0] || null;
+});
+
+const hasInstallTargetSelector = computed(() => {
+  return installTargets.value.length > 1;
+});
+
+const selectedPackageManagerVersion = computed(() => {
+  return selectedInstallTarget.value?.version || props.version;
+});
+
+const explicitCliVersion = computed(() => {
+  return hasInstallTargetSelector.value ? selectedPackageManagerVersion.value : "";
+});
+
 const installCli = computed(() => {
-  return `openupm add ${props.metadata.name}`;
+  return getInstallCliCommand(props.metadata.name, explicitCliVersion.value);
 });
 
 const pipelinesLink = computed(() => {
@@ -50,6 +81,13 @@ const repoTagsNavLink = computed(() => {
     </div>
     <div v-else>
       <div v-if="version">
+        <div v-if="hasInstallTargetSelector" class="install-version-selector btn-group btn-group-block">
+          <button v-for="target in installTargets" :key="target.kind" type="button" class="btn btn-sm"
+            :class="{ active: selectedInstallTarget?.kind === target.kind }" @click="selectedInstallKind = target.kind">
+            <span class="install-version-label">{{ $capitalize($t(target.kind)) }}</span>
+            <span class="install-version-number">{{ target.version }}</span>
+          </button>
+        </div>
         <div class="install-option">
           <h3>
             {{ $capitalize($t("install-via-package-manager")) }}
@@ -58,7 +96,7 @@ const repoTagsNavLink = computed(() => {
             </div>
           </h3>
         </div>
-        <PackageSetupViaPackageManager :name="metadata.name" :version="version" :scopes="scopes" />
+        <PackageSetupViaPackageManager :name="metadata.name" :version="selectedPackageManagerVersion" :scopes="scopes" />
         <div class="install-option last">
           <h3>
             <a href="#modal-commandlinetool">
@@ -71,7 +109,7 @@ const repoTagsNavLink = computed(() => {
             </CopyWrapper>
           </div>
         </div>
-        <PackageSetupViaCLI :name="metadata.name" />
+        <PackageSetupViaCLI :name="metadata.name" :version="explicitCliVersion" />
       </div>
     </div>
   </section>
@@ -126,6 +164,34 @@ const repoTagsNavLink = computed(() => {
       font-size: $font-size-md;
     }
 
+  }
+
+  .install-version-selector {
+    margin-bottom: 0.75rem;
+
+    .btn {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.7rem;
+      height: auto;
+      line-height: 1.15;
+      min-height: 2.4rem;
+      padding: 0.25rem 0.3rem;
+      white-space: normal;
+    }
+
+    .install-version-label,
+    .install-version-number {
+      display: block;
+      max-width: 100%;
+      overflow-wrap: anywhere;
+    }
+
+    .install-version-number {
+      font-size: 0.65rem;
+    }
   }
 
   .package-installer-btn-wrap {

--- a/apps/docs/docs/.vuepress/components/PackageSetupViaCLI.vue
+++ b/apps/docs/docs/.vuepress/components/PackageSetupViaCLI.vue
@@ -5,11 +5,13 @@ import { useI18n } from 'vue-i18n';
 import highlightjs from "highlight.js";
 
 import { getNodeJsUrl, getOpenupmCliRepoUrl } from '@openupm/common/build/urls.js';
+import { getInstallCliCommand } from './package-install-targets';
 
 const { t } = useI18n();
 
 const props = defineProps({
-  name: { type: String, default: "" }
+  name: { type: String, default: "" },
+  version: { type: String, default: "" },
 });
 
 const bashScript = computed(() => {
@@ -20,7 +22,7 @@ npm install -g openupm-cli
 cd YOUR_UNITY_PROJECT_DIR
 
 # ${capitalize(t("install-package"))}: ${props.name}
-openupm add ${props.name}`;
+${getInstallCliCommand(props.name, props.version)}`;
 });
 
 const highlighted = computed(() => {

--- a/apps/docs/docs/.vuepress/components/package-install-targets.ts
+++ b/apps/docs/docs/.vuepress/components/package-install-targets.ts
@@ -1,0 +1,76 @@
+import type { Packument } from "@openupm/types";
+
+export type InstallTargetKind = "stable" | "latest";
+
+export interface InstallTarget {
+  kind: InstallTargetKind;
+  version: string;
+}
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+}
+
+const semverPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+function parseSemver(version: string): ParsedVersion | null {
+  const match = semverPattern.exec(version);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] || null,
+  };
+}
+
+function compareParsedVersions(a: ParsedVersion, b: ParsedVersion): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+export function getStableVersion(versions: string[]): string | null {
+  let bestVersion: string | null = null;
+  let bestParsed: ParsedVersion | null = null;
+
+  for (const version of versions) {
+    const parsed = parseSemver(version);
+    if (!parsed || parsed.prerelease) continue;
+    if (!bestParsed || compareParsedVersions(parsed, bestParsed) > 0) {
+      bestVersion = version;
+      bestParsed = parsed;
+    }
+  }
+
+  return bestVersion;
+}
+
+export function getInstallTargets(packument: Partial<Packument>): InstallTarget[] {
+  const latest = packument["dist-tags"]?.latest;
+  if (!latest) return [];
+
+  const stable = getStableVersion(Object.keys(packument.versions || {}));
+  if (stable && stable !== latest) {
+    return [
+      { kind: "stable", version: stable },
+      { kind: "latest", version: latest },
+    ];
+  }
+
+  return [{ kind: "latest", version: latest }];
+}
+
+export function getInstallCliCommand(
+  packageName: string,
+  explicitVersion = "",
+): string {
+  const installTarget = explicitVersion
+    ? `${packageName}@${explicitVersion}`
+    : packageName;
+  return `openupm add ${installTarget}`;
+}

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -195,6 +195,7 @@ submit-metadata: submit metadata
 supported-unity-version: supported unity version
 github-release-asset-package: GitHub Release asset package
 signed-package: Signed package
+stable: stable
 team: Team
 terms-of-use: Terms of Use
 top-package-hunters: Top Package Hunters


### PR DESCRIPTION
## Summary
- derive package install targets from packument data so prerelease latest versions can be shown alongside the highest stable release
- default split packages to stable while keeping latest selectable
- update the manual install modal, CLI modal, and copyable command to follow the selected version
- render selector buttons as two-line labels, for example Stable / 1.0.0

Example page for review: /packages/com.coffee.csharp-compiler-settings/

## Validation
- npm run test -- packageInstallTargets.spec.ts packageSetup.spec.ts
- npm run lint
- npm run build -- --filter=vuepress-plugin-openupm
- npm run docs:build:limit
- LAN staging review at http://192.168.3.90:8080/