### PR TITLE
[codex] Fix docs package setup modal deep links

### DIFF
--- a/apps/docs/__tests__/vue/packageSetupDeepLink.spec.ts
+++ b/apps/docs/__tests__/vue/packageSetupDeepLink.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const packageDetailLayoutPath = fileURLToPath(
+  new URL("../../docs/.vuepress/layouts/PackageDetailLayout.vue", import.meta.url),
+);
+const modalPath = fileURLToPath(
+  new URL("../../docs/.vuepress/components/Modal.vue", import.meta.url),
+);
+
+describe("package setup modal deep links", () => {
+  it("opens async-rendered modals when the browser hash already targets them", () => {
+    const source = readFileSync(modalPath, "utf8");
+
+    expect(source).toContain('import { computed, onMounted, onUnmounted, ref } from "vue";');
+    expect(source).toContain("currentHash.value === `#${props.id}`");
+    expect(source).toContain('window.addEventListener("hashchange", syncCurrentHash);');
+    expect(source).toContain('window.removeEventListener("hashchange", syncCurrentHash);');
+    expect(source).toContain(':class="{ active: isActiveHashTarget }"');
+  });
+
+  it("renders the installation subpage for setup modal hashes on narrow screens", () => {
+    const source = readFileSync(packageDetailLayoutPath, "utf8");
+
+    expect(source).toContain("const packageSetupModalHashes = new Set([");
+    expect(source).toContain("const getCurrentHash = (): string => {");
+    expect(source).toContain('"#modal-manualinstallation"');
+    expect(source).toContain("shouldShowMetadataSubpageEntry.value");
+    expect(source).toContain("packageSetupModalHashes.has(getCurrentHash())");
+    expect(source).toContain("return SubPageSlug.metadata;");
+  });
+});

--- a/apps/docs/docs/.vuepress/components/Modal.vue
+++ b/apps/docs/docs/.vuepress/components/Modal.vue
@@ -1,5 +1,7 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const props = defineProps({
   id: {
@@ -15,10 +17,29 @@ const props = defineProps({
     default: true
   }
 });
+
+const currentHash = ref("");
+
+const syncCurrentHash = (): void => {
+  currentHash.value = typeof window === "undefined" ? "" : window.location.hash;
+};
+
+const isActiveHashTarget = computed(() => {
+  return props.id ? currentHash.value === `#${props.id}` : false;
+});
+
+onMounted(() => {
+  syncCurrentHash();
+  window.addEventListener("hashchange", syncCurrentHash);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("hashchange", syncCurrentHash);
+});
 </script>
 
 <template>
-  <div :id="id" class="modal">
+  <div :id="id" class="modal" :class="{ active: isActiveHashTarget }">
     <a href="#close" class="modal-overlay" aria-label="Close"></a>
     <div class="modal-container">
       <div v-if="showHeader" class="modal-header">

--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -38,6 +38,15 @@ const SubPageSlug = {
   versions: "versions"
 };
 
+const packageSetupModalHashes = new Set([
+  "#modal-commandlinetool",
+  "#modal-manualinstallation",
+]);
+
+const getCurrentHash = (): string => {
+  return route.hash || (typeof window === "undefined" ? "" : window.location.hash);
+};
+
 // State
 interface State {
   packageInfo: PackageInfo,
@@ -98,8 +107,21 @@ const packageMetadata = computed(() => {
   return getPackageMetadata(metadataLocal, metadataRemote);
 });
 
+const shouldShowMetadataSubpageEntry = computed(() => {
+  return mq.lgMinus;
+});
+
+const shouldShowMetadataSection = computed(() => {
+  return !shouldShowMetadataSubpageEntry.value;
+});
+
 // The current sub page slug from the query parameter
 const currentSubPageSlug = computed(() => {
+  if (
+    shouldShowMetadataSubpageEntry.value &&
+    packageSetupModalHashes.has(getCurrentHash())
+  )
+    return SubPageSlug.metadata;
   const subPageSlug = route.query.subPage;
   if (Object.values(SubPageSlug).filter(x => x == subPageSlug).length > 0)
     return subPageSlug as string;
@@ -201,14 +223,6 @@ const pipelinesIcon = computed(() => {
 const readmeHtml = computed(() => state.packageInfo.readmeHtml);
 
 const readmeUpdatedAt = computed(() => state.packageInfo.readmeUpdatedAt);
-
-const shouldShowMetadataSubpageEntry = computed(() => {
-  return mq.lgMinus;
-});
-
-const shouldShowMetadataSection = computed(() => {
-  return !shouldShowMetadataSubpageEntry.value;
-});
 
 const subPages = computed(() => {
   return [


### PR DESCRIPTION
## Summary
- Open hash-targeted modals when their component is rendered after initial page hydration.
- Route package setup modal hashes to the installation subpage on narrow package-detail layouts so the modal component exists.
- Add focused docs regression checks for package setup modal deep-link behavior.

Refs openupm/openupm#6305.

## Validation
- npm run test -- packageSetupDeepLink.spec.ts
- npm run lint
- npm run docs:build:limit
- Headless Chromium check: /packages/ai.natml.natcorder/#modal-manualinstallation renders #modal-manualinstallation with class "modal active", opacity 1, and display flex.