### PR TITLE
[codex] Add contributor profile pages

### DIFF
--- a/apps/docs/__tests__/vue/contributorProfile.spec.ts
+++ b/apps/docs/__tests__/vue/contributorProfile.spec.ts
@@ -143,8 +143,11 @@ describe("contributor profile filtering", () => {
   it("keeps non-GitHub parent owner chips on their original upstream profile URL", () => {
     const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
 
+    expect(metadataViewSource).toContain('toLowerCase()');
+    expect(metadataViewSource).toContain('.includes("github")');
+    expect(metadataViewSource).toContain("external: !isGithubParentOwner");
     expect(metadataViewSource).toContain(
-      'parentOwnerUrl.toLowerCase().includes("github")',
+      "parentOwnerNavLink && parentOwnerNavLink.external && parentOwnerNavLink.link",
     );
     expect(metadataViewSource).toContain(": parentOwnerUrl");
   });

--- a/apps/docs/__tests__/vue/contributorProfile.spec.ts
+++ b/apps/docs/__tests__/vue/contributorProfile.spec.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { PackageMetadataLocal } from "@openupm/types";
+import { describe, expect, it } from "vitest";
+
+import {
+  getContributorDiscoveredPackages,
+  getContributorOwnedPackages,
+  getContributorProfileStats,
+  toPackageMetadata,
+} from "../../docs/.vuepress/components/contributor-profile";
+
+const layoutPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/layouts/ContributorProfileLayout.vue",
+    import.meta.url,
+  ),
+);
+
+const packageMetadataViewPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/PackageMetadataView.vue",
+    import.meta.url,
+  ),
+);
+
+const packageCardPath = fileURLToPath(
+  new URL("../../docs/.vuepress/components/PackageCard.vue", import.meta.url),
+);
+
+const metadata = [
+  {
+    name: "com.example.owner",
+    owner: "Alice",
+    parentOwner: null,
+    hunter: "carol",
+    displayName: "Owner Package",
+    description: "",
+    topics: [],
+  },
+  {
+    name: "com.example.parent",
+    owner: "fork-owner",
+    parentOwner: "alice",
+    hunter: "dave",
+    displayName: "Parent Package",
+    description: "",
+    topics: [],
+  },
+  {
+    name: "com.example.discovered",
+    owner: "bob",
+    parentOwner: null,
+    hunter: "ALICE",
+    displayName: "Discovered Package",
+    description: "",
+    topics: [],
+  },
+  {
+    name: "com.example.both",
+    owner: "Alice",
+    parentOwner: null,
+    hunter: "alice",
+    displayName: "Both Package",
+    description: "",
+    topics: [],
+  },
+  {
+    name: "com.example.local-only",
+    owner: "alice",
+    parentOwner: null,
+    hunter: "eve",
+    displayName: "Local Only Package",
+    description: "",
+    topics: [],
+  },
+] as PackageMetadataLocal[];
+
+describe("contributor profile filtering", () => {
+  it("matches owned packages by owner case-insensitively", () => {
+    expect(getContributorOwnedPackages(metadata, "alice").map((x) => x.name)).toContain(
+      "com.example.owner",
+    );
+  });
+
+  it("matches owned packages by GitHub parent owner case-insensitively", () => {
+    expect(getContributorOwnedPackages(metadata, "Alice").map((x) => x.name)).toContain(
+      "com.example.parent",
+    );
+  });
+
+  it("matches discovered packages by hunter case-insensitively", () => {
+    expect(
+      getContributorDiscoveredPackages(metadata, "alice").map((x) => x.name),
+    ).toContain("com.example.discovered");
+  });
+
+  it("allows the same user to appear in both sections", () => {
+    expect(getContributorOwnedPackages(metadata, "alice").map((x) => x.name)).toContain(
+      "com.example.both",
+    );
+    expect(
+      getContributorDiscoveredPackages(metadata, "alice").map((x) => x.name),
+    ).toContain("com.example.both");
+  });
+
+  it("keeps local-only packages without remote or published metadata", () => {
+    const packageMetadata = toPackageMetadata(metadata[4]);
+
+    expect(packageMetadata.name).toEqual("com.example.local-only");
+    expect(packageMetadata.ver).toBeNull();
+    expect(packageMetadata.repoUnavailable).toBe(false);
+  });
+
+  it("reports empty owned and discovered sections", () => {
+    expect(getContributorOwnedPackages(metadata, "nobody")).toEqual([]);
+    expect(getContributorDiscoveredPackages(metadata, "nobody")).toEqual([]);
+    expect(getContributorProfileStats(metadata, "nobody")).toEqual({
+      ownedCount: 0,
+      discoveredCount: 0,
+      totalSubmittedCount: 0,
+    });
+  });
+
+  it("renders separate owned and discovered sections without version filtering", () => {
+    const source = readFileSync(layoutPath, "utf8");
+
+    expect(source).toContain("Owned packages");
+    expect(source).toContain("Discovered packages");
+    expect(source).toContain("PackageCard");
+    expect(source).not.toContain(".filter((x) => x.ver)");
+  });
+
+  it("links package metadata and package cards to OpenUPM contributor profiles", () => {
+    const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
+    const packageCardSource = readFileSync(packageCardPath, "utf8");
+
+    expect(metadataViewSource).toContain("getContributorProfilePagePath");
+    expect(packageCardSource).toContain("getContributorProfilePagePath");
+  });
+});

--- a/apps/docs/__tests__/vue/contributorProfile.spec.ts
+++ b/apps/docs/__tests__/vue/contributorProfile.spec.ts
@@ -139,4 +139,13 @@ describe("contributor profile filtering", () => {
     expect(metadataViewSource).toContain("getContributorProfilePagePath");
     expect(packageCardSource).toContain("getContributorProfilePagePath");
   });
+
+  it("keeps non-GitHub parent owner chips on their original upstream profile URL", () => {
+    const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
+
+    expect(metadataViewSource).toContain(
+      'parentOwnerUrl.toLowerCase().includes("github")',
+    );
+    expect(metadataViewSource).toContain(": parentOwnerUrl");
+  });
 });

--- a/apps/docs/docs/.vuepress/client.ts
+++ b/apps/docs/docs/.vuepress/client.ts
@@ -16,6 +16,7 @@ import PackageDetailLayout from "@/layouts/PackageDetailLayout.vue";
 import PackageListLayout from "@/layouts/PackageListLayout.vue";
 import PackageAddLayout from "@/layouts/PackageAddLayout.vue";
 import HomeLayout from "@/layouts/HomeLayout.vue";
+import ContributorProfileLayout from "@/layouts/ContributorProfileLayout.vue";
 
 export default defineClientConfig({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -83,5 +84,6 @@ export default defineClientConfig({
     PackageListLayout,
     PackageAddLayout,
     HomeLayout,
+    ContributorProfileLayout,
   },
 });

--- a/apps/docs/docs/.vuepress/components/GitHubAvatar.vue
+++ b/apps/docs/docs/.vuepress/components/GitHubAvatar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { PropType } from 'vue';
 
-import { getAvatarImageUrl } from "@openupm/common/build/urls.js";
+import { getAvatarImageUrl, getContributorProfilePagePath } from "@openupm/common/build/urls.js";
 
 interface Profile {
   githubUser: string;
@@ -13,11 +13,17 @@ const props = defineProps({
   profile: {
     type: Object as PropType<Profile>,
     required: true
+  },
+  linkToProfile: {
+    type: Boolean,
+    default: false
   }
 });
 
 const { text, abbr, githubUser } = props.profile;
-const url = `https://github.com/${githubUser}`;
+const url = props.linkToProfile
+  ? getContributorProfilePagePath(githubUser)
+  : `https://github.com/${githubUser}`;
 const imageUrl = getAvatarImageUrl(githubUser, 128);
 </script>
 

--- a/apps/docs/docs/.vuepress/components/GitHubUserList.vue
+++ b/apps/docs/docs/.vuepress/components/GitHubUserList.vue
@@ -14,6 +14,10 @@ const props = defineProps({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     type: Array<any>,
     default: () => []
+  },
+  linkToProfile: {
+    type: Boolean,
+    default: false
   }
 });
 
@@ -31,7 +35,7 @@ const users = computed(() => {
 <template>
   <div class="github-user-container">
     <div v-for="(profile, index) in users" :key="index" class="github-user-item">
-      <GitHubAvatar :profile="profile" />
+      <GitHubAvatar :profile="profile" :link-to-profile="linkToProfile" />
     </div>
   </div>
 </template>

--- a/apps/docs/docs/.vuepress/components/PackageCard.vue
+++ b/apps/docs/docs/.vuepress/components/PackageCard.vue
@@ -3,7 +3,7 @@ import { PropType, computed } from "vue";
 
 import { generateHueFromStringInRange, timeAgoFormat } from '@/utils';
 import { PackageMetadata } from '@openupm/types';
-import { getAvatarImageUrl, getGitHubAvatarUrl, getPackageDetailPagePath } from '@openupm/common/build/urls.js';
+import { getAvatarImageUrl, getContributorProfilePagePath, getGitHubAvatarUrl, getPackageDetailPagePath } from '@openupm/common/build/urls.js';
 import { getLocalePackageDescription, getLocalePackageDisplayName } from "@openupm/common/build/utils.js";
 
 const props = defineProps({
@@ -93,6 +93,10 @@ const packageLink = computed(() => {
   };
 });
 
+const ownerProfileLink = computed(() => {
+  return getContributorProfilePagePath(props.metadata.owner);
+});
+
 const imageErrorMessage = computed(() => {
   return `Failed to load image for ${props.metadata.name}: `;
 });
@@ -121,10 +125,10 @@ const imageErrorMessage = computed(() => {
         </div>
         <div class="card-footer">
           <div class="row1">
-            <span v-if="metadata.owner" class="chip chip-avatar">
+            <RouterLink v-if="metadata.owner" :to="ownerProfileLink" class="chip chip-avatar contributor-chip">
               <LazyImage :src="ownerAvatarUrl" :alt="metadata.owner" class="avatar avatar-sm" />
               {{ metadata.owner }}
-            </span>
+            </RouterLink>
             <span v-if="repositoryStatusChip" class="chip" :class="repositoryStatusChip.className">
               <i v-if="repositoryStatusChip.icon" :class="repositoryStatusChip.icon"></i>{{ repositoryStatusChip.text }}
             </span>
@@ -240,6 +244,11 @@ const imageErrorMessage = computed(() => {
           background-color: var(--c-warning);
           color: var(--c-warning-text, #746000);
         }
+      }
+
+      .contributor-chip {
+        color: inherit;
+        text-decoration: none;
       }
     }
   }

--- a/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
@@ -128,11 +128,15 @@ const parentOwnerAvatarUrl = computed(() => {
 });
 
 const parentOwnerNavLink = computed(() => {
-  if (props.metadata.parentRepoUrl && props.metadata.parentOwner)
+  if (props.metadata.parentRepoUrl && props.metadata.parentOwner) {
+    const parentOwnerUrl = props.metadata.parentOwnerUrl || "";
     return {
-      link: getContributorProfilePagePath(props.metadata.parentOwner),
+      link: parentOwnerUrl.toLowerCase().includes("github")
+        ? getContributorProfilePagePath(props.metadata.parentOwner)
+        : parentOwnerUrl,
       text: props.metadata.parentOwner,
     };
+  }
   return null;
 });
 

--- a/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
@@ -6,7 +6,7 @@ import { useI18n } from 'vue-i18n';
 
 import { timeAgoFormat } from '@/utils';
 import { getPackageAliasNavLinks } from './package-metadata';
-import { getAvatarImageUrl, getGitHubPackageMetadataUrl, getPackageDetailPageUrl } from '@openupm/common/build/urls.js';
+import { getAvatarImageUrl, getContributorProfilePagePath, getGitHubPackageMetadataUrl, getPackageDetailPageUrl } from '@openupm/common/build/urls.js';
 import { DownloadsRange, PackageInfo, PackageMetadata, Packument } from "@openupm/types";
 
 const { t } = useI18n();
@@ -86,7 +86,7 @@ const hunterAvatarUrl = computed(() => {
 
 const hunterNavLink = computed(() => {
   return {
-    link: props.metadata.hunterUrl,
+    link: getContributorProfilePagePath(props.metadata.hunter),
     text: props.metadata.hunter,
   };
 });
@@ -116,7 +116,7 @@ const ownerAvatarUrl = computed(() => {
 
 const ownerNavLink = computed(() => {
   return {
-    link: props.metadata.ownerUrl,
+    link: getContributorProfilePagePath(props.metadata.owner),
     text: props.metadata.owner,
   };
 });
@@ -128,9 +128,9 @@ const parentOwnerAvatarUrl = computed(() => {
 });
 
 const parentOwnerNavLink = computed(() => {
-  if (props.metadata.parentRepoUrl)
+  if (props.metadata.parentRepoUrl && props.metadata.parentOwner)
     return {
-      link: props.metadata.parentOwnerUrl,
+      link: getContributorProfilePagePath(props.metadata.parentOwner),
       text: props.metadata.parentOwner,
     };
   return null;
@@ -286,28 +286,28 @@ const trackingModeTooltip = computed(() => {
       </section>
       <section class="col-6">
         <div class="metadata-title">{{ $capitalize($t("authors")) }}</div>
-        <a v-if="parentOwnerNavLink && parentOwnerNavLink.link" :href="parentOwnerNavLink.link" class="nav-link external">
+        <RouterLink v-if="parentOwnerNavLink && parentOwnerNavLink.link" :to="parentOwnerNavLink.link" class="nav-link">
           <span class="chip">
             <LazyImage v-if="parentOwnerAvatarUrl" :src="parentOwnerAvatarUrl" :alt="metadata.parentOwner"
               class="avatar avatar-sm" />
             {{ parentOwnerNavLink.text }}
           </span>
-        </a>
-        <a :href="ownerNavLink.link" class="nav-link external">
+        </RouterLink>
+        <RouterLink :to="ownerNavLink.link" class="nav-link">
           <span class="chip">
             <LazyImage :src="ownerAvatarUrl" :alt="metadata.owner" class="avatar avatar-sm" />
             {{ ownerNavLink.text }}
           </span>
-        </a>
+        </RouterLink>
       </section>
       <section class="col-6">
         <div class="metadata-title">{{ $capitalize($t("discovered-by")) }}</div>
-        <a v-if="hunterNavLink.link" :href="hunterNavLink.link" class="nav-link external">
+        <RouterLink v-if="hunterNavLink.link" :to="hunterNavLink.link" class="nav-link">
           <span class="chip">
             <LazyImage :src="hunterAvatarUrl" :alt="hunterNavLink.text" class="avatar avatar-sm" />
             {{ hunterNavLink.text }}
           </span>
-        </a>
+        </RouterLink>
         <span v-else>{{ metadata.hunter }}</span>
       </section>
       <section class="col-12">

--- a/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
@@ -130,8 +130,12 @@ const parentOwnerAvatarUrl = computed(() => {
 const parentOwnerNavLink = computed(() => {
   if (props.metadata.parentRepoUrl && props.metadata.parentOwner) {
     const parentOwnerUrl = props.metadata.parentOwnerUrl || "";
+    const isGithubParentOwner = parentOwnerUrl
+      .toLowerCase()
+      .includes("github");
     return {
-      link: parentOwnerUrl.toLowerCase().includes("github")
+      external: !isGithubParentOwner,
+      link: isGithubParentOwner
         ? getContributorProfilePagePath(props.metadata.parentOwner)
         : parentOwnerUrl,
       text: props.metadata.parentOwner,
@@ -290,7 +294,16 @@ const trackingModeTooltip = computed(() => {
       </section>
       <section class="col-6">
         <div class="metadata-title">{{ $capitalize($t("authors")) }}</div>
-        <RouterLink v-if="parentOwnerNavLink && parentOwnerNavLink.link" :to="parentOwnerNavLink.link" class="nav-link">
+        <a v-if="parentOwnerNavLink && parentOwnerNavLink.external && parentOwnerNavLink.link"
+          :href="parentOwnerNavLink.link" class="nav-link external">
+          <span class="chip">
+            <LazyImage v-if="parentOwnerAvatarUrl" :src="parentOwnerAvatarUrl" :alt="metadata.parentOwner"
+              class="avatar avatar-sm" />
+            {{ parentOwnerNavLink.text }}
+          </span>
+        </a>
+        <RouterLink v-else-if="parentOwnerNavLink && parentOwnerNavLink.link" :to="parentOwnerNavLink.link"
+          class="nav-link">
           <span class="chip">
             <LazyImage v-if="parentOwnerAvatarUrl" :src="parentOwnerAvatarUrl" :alt="metadata.parentOwner"
               class="avatar avatar-sm" />

--- a/apps/docs/docs/.vuepress/components/contributor-profile.ts
+++ b/apps/docs/docs/.vuepress/components/contributor-profile.ts
@@ -1,0 +1,101 @@
+import {
+  PackageMetadata,
+  PackageMetadataLocal,
+  PackageMetadataRemote,
+} from '@openupm/types';
+import { getPackageMetadata } from '@openupm/common/build/utils.js';
+
+export type ContributorProfileStats = {
+  ownedCount: number;
+  discoveredCount: number;
+  totalSubmittedCount: number;
+};
+
+const emptyMetadataRemote: PackageMetadataRemote = {
+  ver: null,
+  time: 0,
+  stars: 0,
+  pstars: 0,
+  unity: '2017.2',
+  imageFilename: null,
+  dl30d: 0,
+  repoUnavailable: false,
+  repoArchived: false,
+};
+
+export const normalizeGithubUser = function (githubUser: string): string {
+  return githubUser.trim().toLowerCase();
+};
+
+export const githubUserMatches = function (
+  actual: string | null | undefined,
+  expected: string,
+): boolean {
+  return actual
+    ? normalizeGithubUser(actual) === normalizeGithubUser(expected)
+    : false;
+};
+
+export const isOwnedByContributor = function (
+  metadata: PackageMetadataLocal,
+  githubUser: string,
+): boolean {
+  return (
+    githubUserMatches(metadata.owner, githubUser) ||
+    githubUserMatches(metadata.parentOwner, githubUser)
+  );
+};
+
+export const isDiscoveredByContributor = function (
+  metadata: PackageMetadataLocal,
+  githubUser: string,
+): boolean {
+  return githubUserMatches(metadata.hunter, githubUser);
+};
+
+export const toPackageMetadata = function (
+  metadataLocal: PackageMetadataLocal,
+  metadataRemote?: PackageMetadataRemote,
+): PackageMetadata {
+  return getPackageMetadata(
+    metadataLocal,
+    metadataRemote || emptyMetadataRemote,
+  );
+};
+
+export const getContributorOwnedPackages = function (
+  metadataLocalList: PackageMetadataLocal[],
+  githubUser: string,
+): PackageMetadataLocal[] {
+  return metadataLocalList.filter((metadata) =>
+    isOwnedByContributor(metadata, githubUser),
+  );
+};
+
+export const getContributorDiscoveredPackages = function (
+  metadataLocalList: PackageMetadataLocal[],
+  githubUser: string,
+): PackageMetadataLocal[] {
+  return metadataLocalList.filter((metadata) =>
+    isDiscoveredByContributor(metadata, githubUser),
+  );
+};
+
+export const getContributorProfileStats = function (
+  metadataLocalList: PackageMetadataLocal[],
+  githubUser: string,
+): ContributorProfileStats {
+  const ownedCount = getContributorOwnedPackages(
+    metadataLocalList,
+    githubUser,
+  ).length;
+  const discoveredCount = getContributorDiscoveredPackages(
+    metadataLocalList,
+    githubUser,
+  ).length;
+  return {
+    ownedCount,
+    discoveredCount,
+    totalSubmittedCount: ownedCount + discoveredCount,
+  };
+};

--- a/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { usePageFrontmatter } from "@vuepress/client";
+
+import ParentLayout from "@/layouts/WideLayout.vue";
+import {
+  getContributorDiscoveredPackages,
+  getContributorOwnedPackages,
+  getContributorProfileStats,
+  toPackageMetadata,
+} from "@/components/contributor-profile";
+import { useDefaultStore } from "@/store";
+import {
+  getAvatarImageUrl,
+  getContributorProfilePagePath,
+} from "@openupm/common/build/urls.js";
+import {
+  PackageMetadata,
+  PackageMetadataLocal,
+  PackageMetadataRemote,
+} from "@openupm/types";
+
+type ContributorProfileFrontmatter = {
+  contributorProfile?: {
+    githubUser: string;
+    ownedCount: number;
+    discoveredCount: number;
+    totalSubmittedCount: number;
+  };
+};
+
+const frontmatter = usePageFrontmatter<ContributorProfileFrontmatter>();
+const store = useDefaultStore();
+
+const githubUser = computed(() => {
+  return frontmatter.value.contributorProfile?.githubUser || "";
+});
+
+const githubUrl = computed(() => {
+  return `https://github.com/${githubUser.value}`;
+});
+
+const profilePath = computed(() => {
+  return getContributorProfilePagePath(githubUser.value);
+});
+
+const avatarUrl = computed(() => {
+  return githubUser.value ? getAvatarImageUrl(githubUser.value, 128) : "";
+});
+
+const metadataLocalList = computed(() => {
+  return store.packageMetadataLocalList as PackageMetadataLocal[];
+});
+
+const stats = computed(() => {
+  if (metadataLocalList.value.length) {
+    return getContributorProfileStats(metadataLocalList.value, githubUser.value);
+  }
+  return (
+    frontmatter.value.contributorProfile || {
+      ownedCount: 0,
+      discoveredCount: 0,
+      totalSubmittedCount: 0,
+    }
+  );
+});
+
+const mapMetadata = (metadataLocal: PackageMetadataLocal): PackageMetadata => {
+  const metadataRemote = store.packageMetadataRemoteDict[
+    metadataLocal.name
+  ] as PackageMetadataRemote | undefined;
+  return toPackageMetadata(metadataLocal, metadataRemote);
+};
+
+const ownedPackages = computed(() => {
+  return getContributorOwnedPackages(
+    metadataLocalList.value,
+    githubUser.value,
+  ).map(mapMetadata);
+});
+
+const discoveredPackages = computed(() => {
+  return getContributorDiscoveredPackages(
+    metadataLocalList.value,
+    githubUser.value,
+  ).map(mapMetadata);
+});
+
+const isLoading = computed(() => {
+  return !metadataLocalList.value.length;
+});
+</script>
+
+<template>
+  <ParentLayout class="contributor-profile">
+    <template #sidebar-top>
+      <ClientOnly>
+        <section class="state-section">
+          <ul class="menu">
+            <li class="menu-item">
+              Submitted
+              <div class="menu-badge">
+                <label class="label label-default">{{ stats.totalSubmittedCount }}</label>
+              </div>
+            </li>
+            <li class="menu-item">
+              Owned
+              <div class="menu-badge">
+                <a href="#owned" class="label label-default">{{ stats.ownedCount }}</a>
+              </div>
+            </li>
+            <li class="menu-item">
+              Discovered
+              <div class="menu-badge">
+                <a href="#discovered" class="label label-default">{{ stats.discoveredCount }}</a>
+              </div>
+            </li>
+          </ul>
+        </section>
+      </ClientOnly>
+    </template>
+
+    <template #page-content-top>
+      <ClientOnly>
+        <main class="profile-content">
+          <header class="profile-header">
+            <LazyImage :src="avatarUrl" :alt="githubUser" class="avatar avatar-xl" />
+            <div class="profile-header-text">
+              <a class="profile-back" href="/contributors/">Contributors</a>
+              <h1>{{ githubUser }}</h1>
+              <div class="profile-stats">
+                <span>{{ stats.ownedCount }} owned</span>
+                <span>{{ stats.discoveredCount }} discovered</span>
+                <span>{{ stats.totalSubmittedCount }} submitted</span>
+              </div>
+              <div class="profile-actions">
+                <a class="btn btn-primary" :href="profilePath">OpenUPM profile</a>
+                <a class="btn btn-link nav-link external" :href="githubUrl">GitHub</a>
+              </div>
+            </div>
+          </header>
+
+          <div v-if="isLoading" class="placeholder-loader-wrapper">
+            <PlaceholderLoader />
+          </div>
+          <template v-else>
+            <section id="owned" class="package-section">
+              <h2>Owned packages</h2>
+              <div v-if="!ownedPackages.length" class="empty-state">
+                No owned packages.
+              </div>
+              <div v-else class="package-grid">
+                <PackageCard v-for="metadata in ownedPackages" :key="metadata.name" :metadata="metadata" />
+              </div>
+            </section>
+
+            <section id="discovered" class="package-section">
+              <h2>Discovered packages</h2>
+              <div v-if="!discoveredPackages.length" class="empty-state">
+                No discovered packages.
+              </div>
+              <div v-else class="package-grid">
+                <PackageCard v-for="metadata in discoveredPackages" :key="metadata.name" :metadata="metadata" />
+              </div>
+            </section>
+          </template>
+        </main>
+      </ClientOnly>
+    </template>
+  </ParentLayout>
+</template>
+
+<style lang="scss" scoped>
+@use "@/styles/palette" as *;
+
+.profile-content {
+  max-width: $package-grid-4c-width;
+  margin: $navbar-height auto 3rem;
+  padding: 1rem;
+
+  @media (max-width: $MQMobileNarrow) {
+    margin-top: $navbar-height-mobile;
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.6rem 0 1.2rem;
+  border-bottom: 1px solid var(--c-border);
+
+  h1 {
+    margin: 0;
+    font-size: 2rem;
+    line-height: 1.1;
+  }
+
+  @media (max-width: $MQMobileNarrow) {
+    align-items: flex-start;
+
+    h1 {
+      font-size: 1.5rem;
+    }
+  }
+}
+
+.profile-header-text {
+  min-width: 0;
+}
+
+.profile-back {
+  display: inline-block;
+  margin-bottom: 0.2rem;
+  font-size: $font-size-sm;
+}
+
+.profile-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.8rem;
+  margin-top: 0.35rem;
+  color: var(--c-text-light);
+}
+
+.profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.8rem;
+}
+
+.package-section {
+  margin-top: 1.4rem;
+
+  h2 {
+    margin: 0 0 0.7rem;
+    font-size: 1.3rem;
+  }
+}
+
+.package-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax($package-grid-column-width, 1fr));
+  gap: $package-grid-column-hgap;
+}
+
+.empty-state {
+  color: var(--c-text-light);
+  padding: 0.6rem 0;
+}
+
+.placeholder-loader-wrapper {
+  max-width: 25rem;
+  margin-top: 1rem;
+}
+</style>

--- a/apps/docs/docs/contributors/index.md
+++ b/apps/docs/docs/contributors/index.md
@@ -76,8 +76,8 @@ A heartfelt thank you to all our contributors! 🌟 If you'd like to be honored 
 
 ## Top 100 Package Hunters
 
-<GitHubUserList :items="$page.frontmatter.hunters" />
+<GitHubUserList :items="$page.frontmatter.hunters" link-to-profile />
 
 ## Top 100 Package Owners
 
-<GitHubUserList :items="$page.frontmatter.owners" />
+<GitHubUserList :items="$page.frontmatter.owners" link-to-profile />

--- a/packages/@openupm/common/__tests__/urls.spec.ts
+++ b/packages/@openupm/common/__tests__/urls.spec.ts
@@ -1,10 +1,25 @@
 import {
+  getContributorProfilePagePath,
   getMonthlyDownloadsRangeUrl,
   getMonthlyDownloadsUrl,
   isPackageDetailPath,
   isPackageListPath,
   parsePackageNameFromPackageDetailPath,
 } from '../src/urls.js';
+
+describe('getContributorProfilePagePath', () => {
+  it('should build the contributor profile path', () => {
+    const result = getContributorProfilePagePath('GitHubUser');
+
+    expect(result).toEqual('/contributors/githubuser/');
+  });
+
+  it('should encode contributor names and trim surrounding whitespace', () => {
+    const result = getContributorProfilePagePath(' user name ');
+
+    expect(result).toEqual('/contributors/user%20name/');
+  });
+});
 
 describe('isPackageDetailPath', () => {
   it('should return true for path included lowecase letters', () => {

--- a/packages/@openupm/common/src/urls.ts
+++ b/packages/@openupm/common/src/urls.ts
@@ -83,6 +83,17 @@ export const getPackageListPagePath = function (topic?: string): string {
   return '/packages/';
 };
 
+/**
+ * Get contributor profile page path for GitHub user.
+ * @param githubUser GitHub username
+ * @returns contributor profile page path
+ */
+export const getContributorProfilePagePath = function (
+  githubUser: string,
+): string {
+  return `/contributors/${encodeURIComponent(githubUser.trim().toLowerCase())}/`;
+};
+
 // OpenUPM GitHub repo url.
 export const OpenUPMGitHubRepoUrl = 'https://github.com/openupm/openupm';
 

--- a/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
@@ -1,0 +1,53 @@
+import { PackageMetadataLocal } from '@openupm/types';
+
+import {
+  buildContributorProfile,
+  collectContributorProfileGithubUsers,
+} from '../src/contributors.js';
+
+describe('contributor profile generation', () => {
+  it('includes hunters, owners, and GitHub parent owners without duplicates', () => {
+    const githubUsers = collectContributorProfileGithubUsers(
+      [
+        { githubUser: 'Alice', score: 2 },
+        { githubUser: 'bob', score: 1 },
+      ],
+      [
+        { githubUser: 'alice', score: 1 },
+        { githubUser: 'ParentOrg', score: 1 },
+      ],
+    );
+
+    expect(githubUsers).toEqual(['Alice', 'bob', 'ParentOrg']);
+  });
+
+  it('counts owned packages from owners and parent owners and discovered packages from hunters', () => {
+    const metadata = [
+      {
+        name: 'com.example.owner',
+        owner: 'Alice',
+        parentOwner: null,
+        hunter: 'carol',
+      },
+      {
+        name: 'com.example.parent',
+        owner: 'fork-owner',
+        parentOwner: 'alice',
+        hunter: 'dave',
+      },
+      {
+        name: 'com.example.discovered',
+        owner: 'bob',
+        parentOwner: null,
+        hunter: 'ALICE',
+      },
+    ] as PackageMetadataLocal[];
+
+    expect(buildContributorProfile('Alice', metadata)).toEqual({
+      githubUser: 'Alice',
+      ownedCount: 2,
+      discoveredCount: 1,
+      totalSubmittedCount: 3,
+    });
+  });
+});

--- a/packages/vuepress-plugin-openupm/src/contributors.ts
+++ b/packages/vuepress-plugin-openupm/src/contributors.ts
@@ -1,0 +1,64 @@
+import { GithubUserWithScore, PackageMetadataLocal } from '@openupm/types';
+
+export type ContributorProfile = {
+  githubUser: string;
+  ownedCount: number;
+  discoveredCount: number;
+  totalSubmittedCount: number;
+};
+
+const normalizeGithubUser = (githubUser: string): string =>
+  githubUser.trim().toLowerCase();
+
+const matchesGithubUser = (
+  actual: string | null | undefined,
+  expected: string,
+): boolean =>
+  actual ? normalizeGithubUser(actual) === expected : false;
+
+const ownsPackage = (
+  metadata: PackageMetadataLocal,
+  normalizedGithubUser: string,
+): boolean =>
+  matchesGithubUser(metadata.owner, normalizedGithubUser) ||
+  matchesGithubUser(metadata.parentOwner, normalizedGithubUser);
+
+const discoveredPackage = (
+  metadata: PackageMetadataLocal,
+  normalizedGithubUser: string,
+): boolean => matchesGithubUser(metadata.hunter, normalizedGithubUser);
+
+export const collectContributorProfileGithubUsers = function (
+  hunters: GithubUserWithScore[],
+  owners: GithubUserWithScore[],
+): string[] {
+  const profiles = new Map<string, string>();
+  for (const contributor of [...hunters, ...owners]) {
+    const githubUser = contributor.githubUser.trim();
+    if (!githubUser) continue;
+    const key = normalizeGithubUser(githubUser);
+    if (!profiles.has(key)) profiles.set(key, githubUser);
+  }
+  return [...profiles.values()].sort((a, b) =>
+    a.toLowerCase().localeCompare(b.toLowerCase()),
+  );
+};
+
+export const buildContributorProfile = function (
+  githubUser: string,
+  metadataLocalList: PackageMetadataLocal[],
+): ContributorProfile {
+  const normalizedGithubUser = normalizeGithubUser(githubUser);
+  const ownedCount = metadataLocalList.filter((metadata) =>
+    ownsPackage(metadata, normalizedGithubUser),
+  ).length;
+  const discoveredCount = metadataLocalList.filter((metadata) =>
+    discoveredPackage(metadata, normalizedGithubUser),
+  ).length;
+  return {
+    githubUser,
+    ownedCount,
+    discoveredCount,
+    totalSubmittedCount: ownedCount + discoveredCount,
+  };
+};

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -27,10 +27,15 @@ import {
   getLocalePackageDescription,
 } from '@openupm/common/build/utils.js';
 import {
+  getContributorProfilePagePath,
   getPackageDetailPagePath,
   getPackageListPagePath,
 } from '@openupm/common/build/urls.js';
 
+import {
+  buildContributorProfile,
+  collectContributorProfileGithubUsers,
+} from './contributors.js';
 import {
   buildPackageAliasRedirects,
   mergePackageAliasRedirects,
@@ -44,6 +49,7 @@ type Contributor = GithubUserWithScore & {
 
 type PluginData = {
   blockedScopes: string[];
+  contributorProfileGithubUsers: string[];
   hunters: Contributor[];
   metadataLocalList: PackageMetadataLocal[];
   metadataGroupByNamespace: Record<string, PackageMetadataLocal[]>;
@@ -107,6 +113,10 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
   };
   const hunters = prepareContributors(huntersAndOwners.hunters);
   const owners = prepareContributors(huntersAndOwners.owners);
+  const contributorProfileGithubUsers = collectContributorProfileGithubUsers(
+    huntersAndOwners.hunters,
+    huntersAndOwners.owners,
+  );
   // Blocked scopes
   const blockedScopes = await loadBlockedScopes();
   // Spdx
@@ -121,6 +131,7 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
     });
   return {
     blockedScopes,
+    contributorProfileGithubUsers,
     hunters,
     metadataLocalList,
     metadataGroupByNamespace,
@@ -129,6 +140,36 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
     topicsWithAll,
   };
 })();
+
+/**
+ * Create contributor profile pages
+ * @param app vuepress app
+ */
+const createContributorProfilePages = async function (
+  app: App,
+): Promise<Page[]> {
+  const pages: Page[] = [];
+  const { contributorProfileGithubUsers, metadataLocalList } = PLUGIN_DATA;
+  for (const githubUser of contributorProfileGithubUsers) {
+    const profile = buildContributorProfile(githubUser, metadataLocalList);
+    const frontmatter = {
+      layout: 'ContributorProfileLayout',
+      // Hack: use an empty element to show sidebar
+      sidebar: [{ text: '', children: [] }],
+      title: `${githubUser} | OpenUPM Contributor`,
+      description: `OpenUPM packages owned and discovered by ${githubUser}.`,
+      contributorProfile: profile,
+    };
+    const pageOptions = {
+      path: getContributorProfilePagePath(githubUser),
+      frontmatter,
+      content: '',
+    };
+    const page = await createPage(app, pageOptions);
+    pages.push(page);
+  }
+  return pages;
+};
 
 /**
  * Create package detail pages
@@ -212,6 +253,7 @@ export default (): VuePressPlugin => ({
   async onInitialized(app: App): Promise<void> {
     addPages(app, await createDetailPages(app));
     addPages(app, await createListPages(app));
+    addPages(app, await createContributorProfilePages(app));
   },
   extendsPage: async (page: Page): Promise<void> => {
     if (page.path.endsWith('/contributors/')) {


### PR DESCRIPTION
## Summary

- Generate first-party contributor profile pages at `/contributors/<github-user>/` from existing package hunter, owner, and GitHub parent-owner metadata.
- Add a contributor profile layout with owned and discovered package sections, profile stats, cached avatar, and a prominent GitHub link.
- Route contributor chips and top package hunter/owner entries to OpenUPM profile pages while keeping GitHub available from the profile header.

## Validation

- `npm test -- --filter=@openupm/common`
- `npm test -- --filter=vuepress-plugin-openupm`
- `npm run build -- --filter=@openupm/common --filter=vuepress-plugin-openupm`
- `npm run test -- contributorProfile.spec.ts` from `apps/docs`
- `npm run lint` from `apps/docs`
- `npm run lint -- --filter=@openupm/common --filter=vuepress-plugin-openupm`
- `npm run docs:build:limit` from `apps/docs`