### PR TITLE
[codex] Refine contributor profile pages

### DIFF
--- a/apps/docs/__tests__/vue/contributorProfile.spec.ts
+++ b/apps/docs/__tests__/vue/contributorProfile.spec.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { PackageMetadataLocal } from "@openupm/types";
+import { describe, expect, it } from "vitest";
+
+import {
+  getContributorDiscoveredPackages,
+  getContributorOwnedPackages,
+  getContributorProfileStats,
+  toPackageMetadata,
+} from "../../docs/.vuepress/components/contributor-profile";
+
+const layoutPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/layouts/ContributorProfileLayout.vue",
+    import.meta.url,
+  ),
+);
+
+const packageMetadataViewPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/PackageMetadataView.vue",
+    import.meta.url,
+  ),
+);
+
+const packageCardPath = fileURLToPath(
+  new URL("../../docs/.vuepress/components/PackageCard.vue", import.meta.url),
+);
+
+const metadata = [
+  {
+    name: "com.example.owner",
+    owner: "Alice",
+    parentOwner: null,
+    hunter: "carol",
+    displayName: "Owner Package",
+    description: "",
+    topics: [],
+  },
+  {
+    name: "com.example.parent",
+    owner: "fork-owner",
+    parentOwner: "alice",
+    hunter: "dave",
+    displayName: "Parent Package",
+    description: "",
+    topics: [],
+  },
+  {
+    name: "com.example.discovered",
+    owner: "bob",
+    parentOwner: null,
+    hunter: "ALICE",
+    displayName: "Discovered Package",
+    description: "",
+    topics: [],
+  },
+  {
+    name: "com.example.both",
+    owner: "Alice",
+    parentOwner: null,
+    hunter: "alice",
+    displayName: "Both Package",
+    description: "",
+    topics: [],
+  },
+  {
+    name: "com.example.local-only",
+    owner: "alice",
+    parentOwner: null,
+    hunter: "eve",
+    displayName: "Local Only Package",
+    description: "",
+    topics: [],
+  },
+] as PackageMetadataLocal[];
+
+describe("contributor profile filtering", () => {
+  it("matches owned packages by owner case-insensitively", () => {
+    expect(getContributorOwnedPackages(metadata, "alice").map((x) => x.name)).toContain(
+      "com.example.owner",
+    );
+  });
+
+  it("matches owned packages by GitHub parent owner case-insensitively", () => {
+    expect(getContributorOwnedPackages(metadata, "Alice").map((x) => x.name)).toContain(
+      "com.example.parent",
+    );
+  });
+
+  it("matches discovered packages by hunter case-insensitively", () => {
+    expect(
+      getContributorDiscoveredPackages(metadata, "alice").map((x) => x.name),
+    ).toContain("com.example.discovered");
+  });
+
+  it("allows the same user to appear in both sections", () => {
+    expect(getContributorOwnedPackages(metadata, "alice").map((x) => x.name)).toContain(
+      "com.example.both",
+    );
+    expect(
+      getContributorDiscoveredPackages(metadata, "alice").map((x) => x.name),
+    ).toContain("com.example.both");
+  });
+
+  it("keeps local-only packages without remote or published metadata", () => {
+    const packageMetadata = toPackageMetadata(metadata[4]);
+
+    expect(packageMetadata.name).toEqual("com.example.local-only");
+    expect(packageMetadata.ver).toBeNull();
+    expect(packageMetadata.repoUnavailable).toBe(false);
+  });
+
+  it("reports empty owned and discovered sections", () => {
+    expect(getContributorOwnedPackages(metadata, "nobody")).toEqual([]);
+    expect(getContributorDiscoveredPackages(metadata, "nobody")).toEqual([]);
+    expect(getContributorProfileStats(metadata, "nobody")).toEqual({
+      ownedCount: 0,
+      discoveredCount: 0,
+      totalSubmittedCount: 0,
+    });
+  });
+
+  it("renders separate owned and discovered sections without version filtering", () => {
+    const source = readFileSync(layoutPath, "utf8");
+
+    expect(source).toContain("Owned packages");
+    expect(source).toContain("Discovered packages");
+    expect(source).toContain("PackageCard");
+    expect(source).not.toContain(".filter((x) => x.ver)");
+  });
+
+  it("links package metadata and package cards to OpenUPM contributor profiles", () => {
+    const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
+    const packageCardSource = readFileSync(packageCardPath, "utf8");
+
+    expect(metadataViewSource).toContain("getContributorProfilePagePath");
+    expect(packageCardSource).toContain("getContributorProfilePagePath");
+  });
+
+  it("keeps non-GitHub parent owner chips on their original upstream profile URL", () => {
+    const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
+
+    expect(metadataViewSource).toContain('toLowerCase()');
+    expect(metadataViewSource).toContain('.includes("github")');
+    expect(metadataViewSource).toContain("external: !isGithubParentOwner");
+    expect(metadataViewSource).toContain(
+      "parentOwnerNavLink && parentOwnerNavLink.external && parentOwnerNavLink.link",
+    );
+    expect(metadataViewSource).toContain(": parentOwnerUrl");
+  });
+});

--- a/apps/docs/__tests__/vue/contributorProfile.spec.ts
+++ b/apps/docs/__tests__/vue/contributorProfile.spec.ts
@@ -5,9 +5,11 @@ import { PackageMetadataLocal } from "@openupm/types";
 import { describe, expect, it } from "vitest";
 
 import {
+  formatPackageSubmittedDate,
   getContributorDiscoveredPackages,
   getContributorOwnedPackages,
   getContributorProfileStats,
+  toContributorProfilePackageEntry,
   toPackageMetadata,
 } from "../../docs/.vuepress/components/contributor-profile";
 
@@ -24,9 +26,17 @@ const packageMetadataViewPath = fileURLToPath(
     import.meta.url,
   ),
 );
-
-const packageCardPath = fileURLToPath(
-  new URL("../../docs/.vuepress/components/PackageCard.vue", import.meta.url),
+const githubAvatarPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/GitHubAvatar.vue",
+    import.meta.url,
+  ),
+);
+const pluginPath = fileURLToPath(
+  new URL(
+    "../../../../packages/vuepress-plugin-openupm/src/index.ts",
+    import.meta.url,
+  ),
 );
 
 const metadata = [
@@ -38,6 +48,7 @@ const metadata = [
     displayName: "Owner Package",
     description: "",
     topics: [],
+    createdAt: 1700000000000,
   },
   {
     name: "com.example.parent",
@@ -47,6 +58,7 @@ const metadata = [
     displayName: "Parent Package",
     description: "",
     topics: [],
+    createdAt: 1701000000000,
   },
   {
     name: "com.example.discovered",
@@ -56,6 +68,7 @@ const metadata = [
     displayName: "Discovered Package",
     description: "",
     topics: [],
+    createdAt: 1702000000000,
   },
   {
     name: "com.example.both",
@@ -65,6 +78,7 @@ const metadata = [
     displayName: "Both Package",
     description: "",
     topics: [],
+    createdAt: 1703000000000,
   },
   {
     name: "com.example.local-only",
@@ -74,6 +88,7 @@ const metadata = [
     displayName: "Local Only Package",
     description: "",
     topics: [],
+    createdAt: 1699000000000,
   },
 ] as PackageMetadataLocal[];
 
@@ -105,6 +120,18 @@ describe("contributor profile filtering", () => {
     ).toContain("com.example.both");
   });
 
+  it("sorts owned and discovered packages by latest submitted first", () => {
+    expect(getContributorOwnedPackages(metadata, "alice").map((x) => x.name)).toEqual([
+      "com.example.both",
+      "com.example.parent",
+      "com.example.owner",
+      "com.example.local-only",
+    ]);
+    expect(
+      getContributorDiscoveredPackages(metadata, "alice").map((x) => x.name),
+    ).toEqual(["com.example.both", "com.example.discovered"]);
+  });
+
   it("keeps local-only packages without remote or published metadata", () => {
     const packageMetadata = toPackageMetadata(metadata[4]);
 
@@ -123,32 +150,105 @@ describe("contributor profile filtering", () => {
     });
   });
 
-  it("renders separate owned and discovered sections without version filtering", () => {
+  it("formats submitted package rows for the table", () => {
+    expect(formatPackageSubmittedDate(1700000000000)).toEqual("2023-11-14");
+    expect(formatPackageSubmittedDate(undefined)).toEqual("-");
+    expect(toContributorProfilePackageEntry(metadata[0])).toEqual({
+      name: "com.example.owner",
+      displayName: "Owner Package",
+      createdAt: 1700000000000,
+      createdAtText: "2023-11-14",
+      path: "/packages/com.example.owner/",
+    });
+  });
+
+  it("renders separate owned and discovered tables without version filtering or package cards", () => {
     const source = readFileSync(layoutPath, "utf8");
 
+    expect(source).toContain('<ul class="breadcrumb profile-breadcrumb">');
+    expect(source).toContain("class=\"breadcrumb-item\"");
+    expect(source).toContain('<AutoLink :item="contributorsLink" />');
     expect(source).toContain("Owned packages");
     expect(source).toContain("Discovered packages");
-    expect(source).toContain("PackageCard");
+    expect(source).toContain("Display name");
+    expect(source).toContain("Package name");
+    expect(source).toContain("Submitted");
+    expect(source).toContain("package-table");
+    expect(source).toContain("GitHub profile");
+    expect(source).not.toContain("OpenUPM profile");
+    expect(source).not.toContain("totalSubmittedCount }} submitted");
+    expect(source).not.toContain("sidebar-top");
+    expect(source).not.toContain("table-striped");
+    expect(source).not.toContain("PackageCard");
     expect(source).not.toContain(".filter((x) => x.ver)");
   });
 
-  it("links package metadata and package cards to OpenUPM contributor profiles", () => {
+  it("uses AutoLink for external profile links with theme external-link behavior", () => {
+    const layoutSource = readFileSync(layoutPath, "utf8");
+
+    expect(layoutSource).toContain(
+      '<AutoLink class="nav-link external github-link" :item="githubLink" />',
+    );
+    expect(layoutSource).toContain("font-size: 0.8rem");
+    expect(layoutSource).toContain("isGitHubProfileHost");
+    expect(layoutSource).toContain('hostname === "github.com"');
+    expect(layoutSource).toContain('hostname.endsWith(".github.com")');
+    expect(layoutSource).toContain('"GitHub profile"');
+    expect(layoutSource).toContain('`${profileHost} profile`');
+    expect(layoutSource).toContain("link: githubUrl.value");
+  });
+
+  it("generates contributor profile pages without a sidebar", () => {
+    const source = readFileSync(pluginPath, "utf8");
+
+    expect(source).toContain("layout: 'ContributorProfileLayout'");
+    expect(source).toContain("sidebar: false");
+  });
+
+  it("links package metadata to OpenUPM contributor profiles", () => {
     const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
-    const packageCardSource = readFileSync(packageCardPath, "utf8");
 
     expect(metadataViewSource).toContain("getContributorProfilePagePath");
-    expect(packageCardSource).toContain("getContributorProfilePagePath");
   });
 
   it("keeps non-GitHub parent owner chips on their original upstream profile URL", () => {
     const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
 
-    expect(metadataViewSource).toContain('toLowerCase()');
-    expect(metadataViewSource).toContain('.includes("github")');
-    expect(metadataViewSource).toContain("external: !isGithubParentOwner");
+    expect(metadataViewSource).toContain("isGithubProfileUrl");
+    expect(metadataViewSource).toContain('hostname === "github.com"');
+    expect(metadataViewSource).toContain('hostname === "www.github.com"');
+    expect(metadataViewSource).toContain("external: Boolean(profileUrl && !isGithubProfile)");
     expect(metadataViewSource).toContain(
       "parentOwnerNavLink && parentOwnerNavLink.external && parentOwnerNavLink.link",
     );
-    expect(metadataViewSource).toContain(": parentOwnerUrl");
+    expect(metadataViewSource).toContain(": profileUrl");
+  });
+
+  it("keeps non-GitHub owner and hunter chips on their original upstream profile URLs", () => {
+    const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
+
+    expect(metadataViewSource).toContain("props.metadata.ownerUrl");
+    expect(metadataViewSource).toContain("props.metadata.hunterUrl");
+    expect(metadataViewSource).toContain(
+      "ownerNavLink && ownerNavLink.external && ownerNavLink.link",
+    );
+    expect(metadataViewSource).toContain(
+      "hunterNavLink && hunterNavLink.external && hunterNavLink.link",
+    );
+  });
+
+  it("routes contributor avatar profile links through RouterLink", () => {
+    const githubAvatarSource = readFileSync(githubAvatarPath, "utf8");
+
+    expect(githubAvatarSource).toContain('<RouterLink v-if="linkToProfile" :to="profilePath">');
+    expect(githubAvatarSource).toContain('<a v-else :href="githubUrl">');
+  });
+
+  it("uses the contributor profile URL and host from generated frontmatter", () => {
+    const layoutSource = readFileSync(layoutPath, "utf8");
+
+    expect(layoutSource).toContain("profileUrl");
+    expect(layoutSource).toContain("profileHost");
+    expect(layoutSource).toContain('`${profileHost} profile`');
   });
 });

--- a/apps/docs/docs/.vuepress/client.ts
+++ b/apps/docs/docs/.vuepress/client.ts
@@ -16,6 +16,7 @@ import PackageDetailLayout from "@/layouts/PackageDetailLayout.vue";
 import PackageListLayout from "@/layouts/PackageListLayout.vue";
 import PackageAddLayout from "@/layouts/PackageAddLayout.vue";
 import HomeLayout from "@/layouts/HomeLayout.vue";
+import ContributorProfileLayout from "@/layouts/ContributorProfileLayout.vue";
 
 export default defineClientConfig({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -83,5 +84,6 @@ export default defineClientConfig({
     PackageListLayout,
     PackageAddLayout,
     HomeLayout,
+    ContributorProfileLayout,
   },
 });

--- a/apps/docs/docs/.vuepress/components/GitHubAvatar.vue
+++ b/apps/docs/docs/.vuepress/components/GitHubAvatar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { PropType } from 'vue';
 
-import { getAvatarImageUrl } from "@openupm/common/build/urls.js";
+import { getAvatarImageUrl, getContributorProfilePagePath } from "@openupm/common/build/urls.js";
 
 interface Profile {
   githubUser: string;
@@ -13,11 +13,17 @@ const props = defineProps({
   profile: {
     type: Object as PropType<Profile>,
     required: true
+  },
+  linkToProfile: {
+    type: Boolean,
+    default: false
   }
 });
 
 const { text, abbr, githubUser } = props.profile;
-const url = `https://github.com/${githubUser}`;
+const url = props.linkToProfile
+  ? getContributorProfilePagePath(githubUser)
+  : `https://github.com/${githubUser}`;
 const imageUrl = getAvatarImageUrl(githubUser, 128);
 </script>
 

--- a/apps/docs/docs/.vuepress/components/GitHubAvatar.vue
+++ b/apps/docs/docs/.vuepress/components/GitHubAvatar.vue
@@ -21,15 +21,17 @@ const props = defineProps({
 });
 
 const { text, abbr, githubUser } = props.profile;
-const url = props.linkToProfile
-  ? getContributorProfilePagePath(githubUser)
-  : `https://github.com/${githubUser}`;
+const profilePath = getContributorProfilePagePath(githubUser);
+const githubUrl = `https://github.com/${githubUser}`;
 const imageUrl = getAvatarImageUrl(githubUser, 128);
 </script>
 
 <template>
   <figure class="avatar avatar-xl tooltip" :data-tooltip="text" :data-initial="abbr">
-    <a :href="url">
+    <RouterLink v-if="linkToProfile" :to="profilePath">
+      <LazyImage v-if="imageUrl" :src="imageUrl" :alt="text" />
+    </RouterLink>
+    <a v-else :href="githubUrl">
       <LazyImage v-if="imageUrl" :src="imageUrl" :alt="text" />
     </a>
   </figure>

--- a/apps/docs/docs/.vuepress/components/GitHubUserList.vue
+++ b/apps/docs/docs/.vuepress/components/GitHubUserList.vue
@@ -14,6 +14,10 @@ const props = defineProps({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     type: Array<any>,
     default: () => []
+  },
+  linkToProfile: {
+    type: Boolean,
+    default: false
   }
 });
 
@@ -31,7 +35,7 @@ const users = computed(() => {
 <template>
   <div class="github-user-container">
     <div v-for="(profile, index) in users" :key="index" class="github-user-item">
-      <GitHubAvatar :profile="profile" />
+      <GitHubAvatar :profile="profile" :link-to-profile="linkToProfile" />
     </div>
   </div>
 </template>

--- a/apps/docs/docs/.vuepress/components/PackageCard.vue
+++ b/apps/docs/docs/.vuepress/components/PackageCard.vue
@@ -3,7 +3,7 @@ import { PropType, computed } from "vue";
 
 import { generateHueFromStringInRange, timeAgoFormat } from '@/utils';
 import { PackageMetadata } from '@openupm/types';
-import { getAvatarImageUrl, getGitHubAvatarUrl, getPackageDetailPagePath } from '@openupm/common/build/urls.js';
+import { getAvatarImageUrl, getContributorProfilePagePath, getGitHubAvatarUrl, getPackageDetailPagePath } from '@openupm/common/build/urls.js';
 import { getLocalePackageDescription, getLocalePackageDisplayName } from "@openupm/common/build/utils.js";
 
 const props = defineProps({
@@ -93,6 +93,10 @@ const packageLink = computed(() => {
   };
 });
 
+const ownerProfileLink = computed(() => {
+  return getContributorProfilePagePath(props.metadata.owner);
+});
+
 const imageErrorMessage = computed(() => {
   return `Failed to load image for ${props.metadata.name}: `;
 });
@@ -121,10 +125,10 @@ const imageErrorMessage = computed(() => {
         </div>
         <div class="card-footer">
           <div class="row1">
-            <span v-if="metadata.owner" class="chip chip-avatar">
+            <RouterLink v-if="metadata.owner" :to="ownerProfileLink" class="chip chip-avatar contributor-chip">
               <LazyImage :src="ownerAvatarUrl" :alt="metadata.owner" class="avatar avatar-sm" />
               {{ metadata.owner }}
-            </span>
+            </RouterLink>
             <span v-if="repositoryStatusChip" class="chip" :class="repositoryStatusChip.className">
               <i v-if="repositoryStatusChip.icon" :class="repositoryStatusChip.icon"></i>{{ repositoryStatusChip.text }}
             </span>
@@ -240,6 +244,11 @@ const imageErrorMessage = computed(() => {
           background-color: var(--c-warning);
           color: var(--c-warning-text, #746000);
         }
+      }
+
+      .contributor-chip {
+        color: inherit;
+        text-decoration: none;
       }
     }
   }

--- a/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
@@ -6,7 +6,7 @@ import { useI18n } from 'vue-i18n';
 
 import { timeAgoFormat } from '@/utils';
 import { getPackageAliasNavLinks } from './package-metadata';
-import { getAvatarImageUrl, getGitHubPackageMetadataUrl, getPackageDetailPageUrl } from '@openupm/common/build/urls.js';
+import { getAvatarImageUrl, getContributorProfilePagePath, getGitHubPackageMetadataUrl, getPackageDetailPageUrl } from '@openupm/common/build/urls.js';
 import { DownloadsRange, PackageInfo, PackageMetadata, Packument } from "@openupm/types";
 
 const { t } = useI18n();
@@ -86,7 +86,7 @@ const hunterAvatarUrl = computed(() => {
 
 const hunterNavLink = computed(() => {
   return {
-    link: props.metadata.hunterUrl,
+    link: getContributorProfilePagePath(props.metadata.hunter),
     text: props.metadata.hunter,
   };
 });
@@ -116,7 +116,7 @@ const ownerAvatarUrl = computed(() => {
 
 const ownerNavLink = computed(() => {
   return {
-    link: props.metadata.ownerUrl,
+    link: getContributorProfilePagePath(props.metadata.owner),
     text: props.metadata.owner,
   };
 });
@@ -128,11 +128,19 @@ const parentOwnerAvatarUrl = computed(() => {
 });
 
 const parentOwnerNavLink = computed(() => {
-  if (props.metadata.parentRepoUrl)
+  if (props.metadata.parentRepoUrl && props.metadata.parentOwner) {
+    const parentOwnerUrl = props.metadata.parentOwnerUrl || "";
+    const isGithubParentOwner = parentOwnerUrl
+      .toLowerCase()
+      .includes("github");
     return {
-      link: props.metadata.parentOwnerUrl,
+      external: !isGithubParentOwner,
+      link: isGithubParentOwner
+        ? getContributorProfilePagePath(props.metadata.parentOwner)
+        : parentOwnerUrl,
       text: props.metadata.parentOwner,
     };
+  }
   return null;
 });
 
@@ -286,28 +294,37 @@ const trackingModeTooltip = computed(() => {
       </section>
       <section class="col-6">
         <div class="metadata-title">{{ $capitalize($t("authors")) }}</div>
-        <a v-if="parentOwnerNavLink && parentOwnerNavLink.link" :href="parentOwnerNavLink.link" class="nav-link external">
+        <a v-if="parentOwnerNavLink && parentOwnerNavLink.external && parentOwnerNavLink.link"
+          :href="parentOwnerNavLink.link" class="nav-link external">
           <span class="chip">
             <LazyImage v-if="parentOwnerAvatarUrl" :src="parentOwnerAvatarUrl" :alt="metadata.parentOwner"
               class="avatar avatar-sm" />
             {{ parentOwnerNavLink.text }}
           </span>
         </a>
-        <a :href="ownerNavLink.link" class="nav-link external">
+        <RouterLink v-else-if="parentOwnerNavLink && parentOwnerNavLink.link" :to="parentOwnerNavLink.link"
+          class="nav-link">
+          <span class="chip">
+            <LazyImage v-if="parentOwnerAvatarUrl" :src="parentOwnerAvatarUrl" :alt="metadata.parentOwner"
+              class="avatar avatar-sm" />
+            {{ parentOwnerNavLink.text }}
+          </span>
+        </RouterLink>
+        <RouterLink :to="ownerNavLink.link" class="nav-link">
           <span class="chip">
             <LazyImage :src="ownerAvatarUrl" :alt="metadata.owner" class="avatar avatar-sm" />
             {{ ownerNavLink.text }}
           </span>
-        </a>
+        </RouterLink>
       </section>
       <section class="col-6">
         <div class="metadata-title">{{ $capitalize($t("discovered-by")) }}</div>
-        <a v-if="hunterNavLink.link" :href="hunterNavLink.link" class="nav-link external">
+        <RouterLink v-if="hunterNavLink.link" :to="hunterNavLink.link" class="nav-link">
           <span class="chip">
             <LazyImage :src="hunterAvatarUrl" :alt="hunterNavLink.text" class="avatar avatar-sm" />
             {{ hunterNavLink.text }}
           </span>
-        </a>
+        </RouterLink>
         <span v-else>{{ metadata.hunter }}</span>
       </section>
       <section class="col-12">

--- a/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageMetadataView.vue
@@ -84,11 +84,40 @@ const hunterAvatarUrl = computed(() => {
     : null;
 });
 
-const hunterNavLink = computed(() => {
+const isGithubProfileUrl = function (url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    return hostname === "github.com" || hostname === "www.github.com";
+  } catch {
+    return false;
+  }
+};
+
+const getContributorNavLink = function (
+  githubUser: string | null | undefined,
+  profileUrl: string | null | undefined,
+): {
+  external: boolean;
+  link: string;
+  text: string;
+} | null {
+  if (!githubUser) return null;
+  const isGithubProfile = isGithubProfileUrl(profileUrl);
   return {
-    link: getContributorProfilePagePath(props.metadata.hunter),
-    text: props.metadata.hunter,
+    external: Boolean(profileUrl && !isGithubProfile),
+    link: isGithubProfile || !profileUrl
+      ? getContributorProfilePagePath(githubUser)
+      : profileUrl,
+    text: githubUser,
   };
+};
+
+const hunterNavLink = computed(() => {
+  return getContributorNavLink(
+    props.metadata.hunter,
+    props.metadata.hunterUrl,
+  );
 });
 
 const aliasNavLinks = computed(() => {
@@ -115,10 +144,10 @@ const ownerAvatarUrl = computed(() => {
 });
 
 const ownerNavLink = computed(() => {
-  return {
-    link: getContributorProfilePagePath(props.metadata.owner),
-    text: props.metadata.owner,
-  };
+  return getContributorNavLink(
+    props.metadata.owner,
+    props.metadata.ownerUrl,
+  );
 });
 
 const parentOwnerAvatarUrl = computed(() => {
@@ -129,17 +158,10 @@ const parentOwnerAvatarUrl = computed(() => {
 
 const parentOwnerNavLink = computed(() => {
   if (props.metadata.parentRepoUrl && props.metadata.parentOwner) {
-    const parentOwnerUrl = props.metadata.parentOwnerUrl || "";
-    const isGithubParentOwner = parentOwnerUrl
-      .toLowerCase()
-      .includes("github");
-    return {
-      external: !isGithubParentOwner,
-      link: isGithubParentOwner
-        ? getContributorProfilePagePath(props.metadata.parentOwner)
-        : parentOwnerUrl,
-      text: props.metadata.parentOwner,
-    };
+    return getContributorNavLink(
+      props.metadata.parentOwner,
+      props.metadata.parentOwnerUrl,
+    );
   }
   return null;
 });
@@ -310,7 +332,14 @@ const trackingModeTooltip = computed(() => {
             {{ parentOwnerNavLink.text }}
           </span>
         </RouterLink>
-        <RouterLink :to="ownerNavLink.link" class="nav-link">
+        <a v-if="ownerNavLink && ownerNavLink.external && ownerNavLink.link" :href="ownerNavLink.link"
+          class="nav-link external">
+          <span class="chip">
+            <LazyImage :src="ownerAvatarUrl" :alt="metadata.owner" class="avatar avatar-sm" />
+            {{ ownerNavLink.text }}
+          </span>
+        </a>
+        <RouterLink v-else-if="ownerNavLink && ownerNavLink.link" :to="ownerNavLink.link" class="nav-link">
           <span class="chip">
             <LazyImage :src="ownerAvatarUrl" :alt="metadata.owner" class="avatar avatar-sm" />
             {{ ownerNavLink.text }}
@@ -319,7 +348,14 @@ const trackingModeTooltip = computed(() => {
       </section>
       <section class="col-6">
         <div class="metadata-title">{{ $capitalize($t("discovered-by")) }}</div>
-        <RouterLink v-if="hunterNavLink.link" :to="hunterNavLink.link" class="nav-link">
+        <a v-if="hunterNavLink && hunterNavLink.external && hunterNavLink.link" :href="hunterNavLink.link"
+          class="nav-link external">
+          <span class="chip">
+            <LazyImage :src="hunterAvatarUrl" :alt="hunterNavLink.text" class="avatar avatar-sm" />
+            {{ hunterNavLink.text }}
+          </span>
+        </a>
+        <RouterLink v-else-if="hunterNavLink && hunterNavLink.link" :to="hunterNavLink.link" class="nav-link">
           <span class="chip">
             <LazyImage :src="hunterAvatarUrl" :alt="hunterNavLink.text" class="avatar avatar-sm" />
             {{ hunterNavLink.text }}

--- a/apps/docs/docs/.vuepress/components/contributor-profile.ts
+++ b/apps/docs/docs/.vuepress/components/contributor-profile.ts
@@ -3,12 +3,24 @@ import {
   PackageMetadataLocal,
   PackageMetadataRemote,
 } from '@openupm/types';
-import { getPackageMetadata } from '@openupm/common/build/utils.js';
+import {
+  getLocalePackageDisplayName,
+  getPackageMetadata,
+} from '@openupm/common/build/utils.js';
+import { getPackageDetailPagePath } from '@openupm/common/build/urls.js';
 
 export type ContributorProfileStats = {
   ownedCount: number;
   discoveredCount: number;
   totalSubmittedCount: number;
+};
+
+export type ContributorProfilePackageEntry = {
+  name: string;
+  displayName: string;
+  createdAt: number;
+  createdAtText: string;
+  path: string;
 };
 
 const emptyMetadataRemote: PackageMetadataRemote = {
@@ -63,12 +75,43 @@ export const toPackageMetadata = function (
   );
 };
 
+export const sortPackagesByLatestSubmitted = function <
+  T extends PackageMetadataLocal,
+>(metadataLocalList: T[]): T[] {
+  return [...metadataLocalList].sort((a, b) => {
+    return (b.createdAt || 0) - (a.createdAt || 0);
+  });
+};
+
+export const formatPackageSubmittedDate = function (
+  createdAt: number | undefined,
+): string {
+  if (!createdAt) return '-';
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return '-';
+  return date.toISOString().slice(0, 10);
+};
+
+export const toContributorProfilePackageEntry = function (
+  metadataLocal: PackageMetadataLocal,
+): ContributorProfilePackageEntry {
+  return {
+    name: metadataLocal.name,
+    displayName: getLocalePackageDisplayName(metadataLocal),
+    createdAt: metadataLocal.createdAt || 0,
+    createdAtText: formatPackageSubmittedDate(metadataLocal.createdAt),
+    path: getPackageDetailPagePath(metadataLocal.name),
+  };
+};
+
 export const getContributorOwnedPackages = function (
   metadataLocalList: PackageMetadataLocal[],
   githubUser: string,
 ): PackageMetadataLocal[] {
-  return metadataLocalList.filter((metadata) =>
-    isOwnedByContributor(metadata, githubUser),
+  return sortPackagesByLatestSubmitted(
+    metadataLocalList.filter((metadata) =>
+      isOwnedByContributor(metadata, githubUser),
+    ),
   );
 };
 
@@ -76,8 +119,10 @@ export const getContributorDiscoveredPackages = function (
   metadataLocalList: PackageMetadataLocal[],
   githubUser: string,
 ): PackageMetadataLocal[] {
-  return metadataLocalList.filter((metadata) =>
-    isDiscoveredByContributor(metadata, githubUser),
+  return sortPackagesByLatestSubmitted(
+    metadataLocalList.filter((metadata) =>
+      isDiscoveredByContributor(metadata, githubUser),
+    ),
   );
 };
 

--- a/apps/docs/docs/.vuepress/components/contributor-profile.ts
+++ b/apps/docs/docs/.vuepress/components/contributor-profile.ts
@@ -1,0 +1,101 @@
+import {
+  PackageMetadata,
+  PackageMetadataLocal,
+  PackageMetadataRemote,
+} from '@openupm/types';
+import { getPackageMetadata } from '@openupm/common/build/utils.js';
+
+export type ContributorProfileStats = {
+  ownedCount: number;
+  discoveredCount: number;
+  totalSubmittedCount: number;
+};
+
+const emptyMetadataRemote: PackageMetadataRemote = {
+  ver: null,
+  time: 0,
+  stars: 0,
+  pstars: 0,
+  unity: '2017.2',
+  imageFilename: null,
+  dl30d: 0,
+  repoUnavailable: false,
+  repoArchived: false,
+};
+
+export const normalizeGithubUser = function (githubUser: string): string {
+  return githubUser.trim().toLowerCase();
+};
+
+export const githubUserMatches = function (
+  actual: string | null | undefined,
+  expected: string,
+): boolean {
+  return actual
+    ? normalizeGithubUser(actual) === normalizeGithubUser(expected)
+    : false;
+};
+
+export const isOwnedByContributor = function (
+  metadata: PackageMetadataLocal,
+  githubUser: string,
+): boolean {
+  return (
+    githubUserMatches(metadata.owner, githubUser) ||
+    githubUserMatches(metadata.parentOwner, githubUser)
+  );
+};
+
+export const isDiscoveredByContributor = function (
+  metadata: PackageMetadataLocal,
+  githubUser: string,
+): boolean {
+  return githubUserMatches(metadata.hunter, githubUser);
+};
+
+export const toPackageMetadata = function (
+  metadataLocal: PackageMetadataLocal,
+  metadataRemote?: PackageMetadataRemote,
+): PackageMetadata {
+  return getPackageMetadata(
+    metadataLocal,
+    metadataRemote || emptyMetadataRemote,
+  );
+};
+
+export const getContributorOwnedPackages = function (
+  metadataLocalList: PackageMetadataLocal[],
+  githubUser: string,
+): PackageMetadataLocal[] {
+  return metadataLocalList.filter((metadata) =>
+    isOwnedByContributor(metadata, githubUser),
+  );
+};
+
+export const getContributorDiscoveredPackages = function (
+  metadataLocalList: PackageMetadataLocal[],
+  githubUser: string,
+): PackageMetadataLocal[] {
+  return metadataLocalList.filter((metadata) =>
+    isDiscoveredByContributor(metadata, githubUser),
+  );
+};
+
+export const getContributorProfileStats = function (
+  metadataLocalList: PackageMetadataLocal[],
+  githubUser: string,
+): ContributorProfileStats {
+  const ownedCount = getContributorOwnedPackages(
+    metadataLocalList,
+    githubUser,
+  ).length;
+  const discoveredCount = getContributorDiscoveredPackages(
+    metadataLocalList,
+    githubUser,
+  ).length;
+  return {
+    ownedCount,
+    discoveredCount,
+    totalSubmittedCount: ownedCount + discoveredCount,
+  };
+};

--- a/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { usePageFrontmatter } from "@vuepress/client";
+
+import ParentLayout from "@/layouts/WideLayout.vue";
+import {
+  getContributorDiscoveredPackages,
+  getContributorOwnedPackages,
+  getContributorProfileStats,
+  toPackageMetadata,
+} from "@/components/contributor-profile";
+import { useDefaultStore } from "@/store";
+import {
+  getAvatarImageUrl,
+  getContributorProfilePagePath,
+} from "@openupm/common/build/urls.js";
+import {
+  PackageMetadata,
+  PackageMetadataLocal,
+  PackageMetadataRemote,
+} from "@openupm/types";
+
+type ContributorProfileFrontmatter = {
+  contributorProfile?: {
+    githubUser: string;
+    ownedCount: number;
+    discoveredCount: number;
+    totalSubmittedCount: number;
+  };
+};
+
+const frontmatter = usePageFrontmatter<ContributorProfileFrontmatter>();
+const store = useDefaultStore();
+
+const githubUser = computed(() => {
+  return frontmatter.value.contributorProfile?.githubUser || "";
+});
+
+const githubUrl = computed(() => {
+  return `https://github.com/${githubUser.value}`;
+});
+
+const profilePath = computed(() => {
+  return getContributorProfilePagePath(githubUser.value);
+});
+
+const avatarUrl = computed(() => {
+  return githubUser.value ? getAvatarImageUrl(githubUser.value, 128) : "";
+});
+
+const metadataLocalList = computed(() => {
+  return store.packageMetadataLocalList as PackageMetadataLocal[];
+});
+
+const stats = computed(() => {
+  if (metadataLocalList.value.length) {
+    return getContributorProfileStats(metadataLocalList.value, githubUser.value);
+  }
+  return (
+    frontmatter.value.contributorProfile || {
+      ownedCount: 0,
+      discoveredCount: 0,
+      totalSubmittedCount: 0,
+    }
+  );
+});
+
+const mapMetadata = (metadataLocal: PackageMetadataLocal): PackageMetadata => {
+  const metadataRemote = store.packageMetadataRemoteDict[
+    metadataLocal.name
+  ] as PackageMetadataRemote | undefined;
+  return toPackageMetadata(metadataLocal, metadataRemote);
+};
+
+const ownedPackages = computed(() => {
+  return getContributorOwnedPackages(
+    metadataLocalList.value,
+    githubUser.value,
+  ).map(mapMetadata);
+});
+
+const discoveredPackages = computed(() => {
+  return getContributorDiscoveredPackages(
+    metadataLocalList.value,
+    githubUser.value,
+  ).map(mapMetadata);
+});
+
+const isLoading = computed(() => {
+  return !metadataLocalList.value.length;
+});
+</script>
+
+<template>
+  <ParentLayout class="contributor-profile">
+    <template #sidebar-top>
+      <ClientOnly>
+        <section class="state-section">
+          <ul class="menu">
+            <li class="menu-item">
+              Submitted
+              <div class="menu-badge">
+                <label class="label label-default">{{ stats.totalSubmittedCount }}</label>
+              </div>
+            </li>
+            <li class="menu-item">
+              Owned
+              <div class="menu-badge">
+                <a href="#owned" class="label label-default">{{ stats.ownedCount }}</a>
+              </div>
+            </li>
+            <li class="menu-item">
+              Discovered
+              <div class="menu-badge">
+                <a href="#discovered" class="label label-default">{{ stats.discoveredCount }}</a>
+              </div>
+            </li>
+          </ul>
+        </section>
+      </ClientOnly>
+    </template>
+
+    <template #page-content-top>
+      <ClientOnly>
+        <main class="profile-content">
+          <header class="profile-header">
+            <LazyImage :src="avatarUrl" :alt="githubUser" class="avatar avatar-xl" />
+            <div class="profile-header-text">
+              <a class="profile-back" href="/contributors/">Contributors</a>
+              <h1>{{ githubUser }}</h1>
+              <div class="profile-stats">
+                <span>{{ stats.ownedCount }} owned</span>
+                <span>{{ stats.discoveredCount }} discovered</span>
+                <span>{{ stats.totalSubmittedCount }} submitted</span>
+              </div>
+              <div class="profile-actions">
+                <a class="btn btn-primary" :href="profilePath">OpenUPM profile</a>
+                <a class="btn btn-link nav-link external" :href="githubUrl">GitHub</a>
+              </div>
+            </div>
+          </header>
+
+          <div v-if="isLoading" class="placeholder-loader-wrapper">
+            <PlaceholderLoader />
+          </div>
+          <template v-else>
+            <section id="owned" class="package-section">
+              <h2>Owned packages</h2>
+              <div v-if="!ownedPackages.length" class="empty-state">
+                No owned packages.
+              </div>
+              <div v-else class="package-grid">
+                <PackageCard v-for="metadata in ownedPackages" :key="metadata.name" :metadata="metadata" />
+              </div>
+            </section>
+
+            <section id="discovered" class="package-section">
+              <h2>Discovered packages</h2>
+              <div v-if="!discoveredPackages.length" class="empty-state">
+                No discovered packages.
+              </div>
+              <div v-else class="package-grid">
+                <PackageCard v-for="metadata in discoveredPackages" :key="metadata.name" :metadata="metadata" />
+              </div>
+            </section>
+          </template>
+        </main>
+      </ClientOnly>
+    </template>
+  </ParentLayout>
+</template>
+
+<style lang="scss" scoped>
+@use "@/styles/palette" as *;
+
+.profile-content {
+  max-width: $package-grid-4c-width;
+  margin: $navbar-height auto 3rem;
+  padding: 1rem;
+
+  @media (max-width: $MQMobileNarrow) {
+    margin-top: $navbar-height-mobile;
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.6rem 0 1.2rem;
+  border-bottom: 1px solid var(--c-border);
+
+  h1 {
+    margin: 0;
+    font-size: 2rem;
+    line-height: 1.1;
+  }
+
+  @media (max-width: $MQMobileNarrow) {
+    align-items: flex-start;
+
+    h1 {
+      font-size: 1.5rem;
+    }
+  }
+}
+
+.profile-header-text {
+  min-width: 0;
+}
+
+.profile-back {
+  display: inline-block;
+  margin-bottom: 0.2rem;
+  font-size: $font-size-sm;
+}
+
+.profile-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.8rem;
+  margin-top: 0.35rem;
+  color: var(--c-text-light);
+}
+
+.profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.8rem;
+}
+
+.package-section {
+  margin-top: 1.4rem;
+
+  h2 {
+    margin: 0 0 0.7rem;
+    font-size: 1.3rem;
+  }
+}
+
+.package-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax($package-grid-column-width, 1fr));
+  gap: $package-grid-column-hgap;
+}
+
+.empty-state {
+  color: var(--c-text-light);
+  padding: 0.6rem 0;
+}
+
+.placeholder-loader-wrapper {
+  max-width: 25rem;
+  margin-top: 1rem;
+}
+</style>

--- a/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
@@ -7,18 +7,13 @@ import {
   getContributorDiscoveredPackages,
   getContributorOwnedPackages,
   getContributorProfileStats,
-  toPackageMetadata,
+  toContributorProfilePackageEntry,
 } from "@/components/contributor-profile";
 import { useDefaultStore } from "@/store";
 import {
   getAvatarImageUrl,
-  getContributorProfilePagePath,
 } from "@openupm/common/build/urls.js";
-import {
-  PackageMetadata,
-  PackageMetadataLocal,
-  PackageMetadataRemote,
-} from "@openupm/types";
+import { PackageMetadataLocal } from "@openupm/types";
 
 type ContributorProfileFrontmatter = {
   contributorProfile?: {
@@ -26,6 +21,8 @@ type ContributorProfileFrontmatter = {
     ownedCount: number;
     discoveredCount: number;
     totalSubmittedCount: number;
+    profileUrl?: string;
+    profileHost?: string;
   };
 };
 
@@ -37,11 +34,31 @@ const githubUser = computed(() => {
 });
 
 const githubUrl = computed(() => {
-  return `https://github.com/${githubUser.value}`;
+  return (
+    frontmatter.value.contributorProfile?.profileUrl ||
+    `https://github.com/${githubUser.value}`
+  );
 });
 
-const profilePath = computed(() => {
-  return getContributorProfilePagePath(githubUser.value);
+const contributorsLink = {
+  text: "Contributors",
+  link: "/contributors/",
+};
+
+const isGitHubProfileHost = function (profileHost: string): boolean {
+  const hostname = profileHost.toLowerCase();
+  return hostname === "github.com" || hostname.endsWith(".github.com");
+};
+
+const githubLink = computed(() => {
+  const profileHost = frontmatter.value.contributorProfile?.profileHost || "github.com";
+  const text = isGitHubProfileHost(profileHost)
+    ? "GitHub profile"
+    : `${profileHost} profile`;
+  return {
+    text,
+    link: githubUrl.value,
+  };
 });
 
 const avatarUrl = computed(() => {
@@ -65,25 +82,18 @@ const stats = computed(() => {
   );
 });
 
-const mapMetadata = (metadataLocal: PackageMetadataLocal): PackageMetadata => {
-  const metadataRemote = store.packageMetadataRemoteDict[
-    metadataLocal.name
-  ] as PackageMetadataRemote | undefined;
-  return toPackageMetadata(metadataLocal, metadataRemote);
-};
-
 const ownedPackages = computed(() => {
   return getContributorOwnedPackages(
     metadataLocalList.value,
     githubUser.value,
-  ).map(mapMetadata);
+  ).map(toContributorProfilePackageEntry);
 });
 
 const discoveredPackages = computed(() => {
   return getContributorDiscoveredPackages(
     metadataLocalList.value,
     githubUser.value,
-  ).map(mapMetadata);
+  ).map(toContributorProfilePackageEntry);
 });
 
 const isLoading = computed(() => {
@@ -93,49 +103,29 @@ const isLoading = computed(() => {
 
 <template>
   <ParentLayout class="contributor-profile">
-    <template #sidebar-top>
-      <ClientOnly>
-        <section class="state-section">
-          <ul class="menu">
-            <li class="menu-item">
-              Submitted
-              <div class="menu-badge">
-                <label class="label label-default">{{ stats.totalSubmittedCount }}</label>
-              </div>
-            </li>
-            <li class="menu-item">
-              Owned
-              <div class="menu-badge">
-                <a href="#owned" class="label label-default">{{ stats.ownedCount }}</a>
-              </div>
-            </li>
-            <li class="menu-item">
-              Discovered
-              <div class="menu-badge">
-                <a href="#discovered" class="label label-default">{{ stats.discoveredCount }}</a>
-              </div>
-            </li>
-          </ul>
-        </section>
-      </ClientOnly>
-    </template>
-
     <template #page-content-top>
       <ClientOnly>
         <main class="profile-content">
+          <nav aria-label="Breadcrumb">
+            <ul class="breadcrumb profile-breadcrumb">
+              <li class="breadcrumb-item">
+                <AutoLink :item="contributorsLink" />
+              </li>
+              <li class="breadcrumb-item">
+                <a href="#">{{ githubUser }}</a>
+              </li>
+            </ul>
+          </nav>
           <header class="profile-header">
             <LazyImage :src="avatarUrl" :alt="githubUser" class="avatar avatar-xl" />
             <div class="profile-header-text">
-              <a class="profile-back" href="/contributors/">Contributors</a>
               <h1>{{ githubUser }}</h1>
               <div class="profile-stats">
                 <span>{{ stats.ownedCount }} owned</span>
                 <span>{{ stats.discoveredCount }} discovered</span>
-                <span>{{ stats.totalSubmittedCount }} submitted</span>
               </div>
               <div class="profile-actions">
-                <a class="btn btn-primary" :href="profilePath">OpenUPM profile</a>
-                <a class="btn btn-link nav-link external" :href="githubUrl">GitHub</a>
+                <AutoLink class="nav-link external github-link" :item="githubLink" />
               </div>
             </div>
           </header>
@@ -149,8 +139,28 @@ const isLoading = computed(() => {
               <div v-if="!ownedPackages.length" class="empty-state">
                 No owned packages.
               </div>
-              <div v-else class="package-grid">
-                <PackageCard v-for="metadata in ownedPackages" :key="metadata.name" :metadata="metadata" />
+              <div v-else class="package-table-wrapper">
+                <table class="table package-table">
+                  <thead>
+                    <tr>
+                      <th>Display name</th>
+                      <th class="package-name-column">Package name</th>
+                      <th class="submitted-column">Submitted</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="metadata in ownedPackages" :key="metadata.name">
+                      <td>
+                        <RouterLink :to="metadata.path">{{ metadata.displayName }}</RouterLink>
+                        <code class="mobile-package-name">{{ metadata.name }}</code>
+                      </td>
+                      <td class="package-name-column">
+                        <code>{{ metadata.name }}</code>
+                      </td>
+                      <td class="submitted-column">{{ metadata.createdAtText }}</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </section>
 
@@ -159,8 +169,28 @@ const isLoading = computed(() => {
               <div v-if="!discoveredPackages.length" class="empty-state">
                 No discovered packages.
               </div>
-              <div v-else class="package-grid">
-                <PackageCard v-for="metadata in discoveredPackages" :key="metadata.name" :metadata="metadata" />
+              <div v-else class="package-table-wrapper">
+                <table class="table package-table">
+                  <thead>
+                    <tr>
+                      <th>Display name</th>
+                      <th class="package-name-column">Package name</th>
+                      <th class="submitted-column">Submitted</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="metadata in discoveredPackages" :key="metadata.name">
+                      <td>
+                        <RouterLink :to="metadata.path">{{ metadata.displayName }}</RouterLink>
+                        <code class="mobile-package-name">{{ metadata.name }}</code>
+                      </td>
+                      <td class="package-name-column">
+                        <code>{{ metadata.name }}</code>
+                      </td>
+                      <td class="submitted-column">{{ metadata.createdAtText }}</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </section>
           </template>
@@ -180,40 +210,32 @@ const isLoading = computed(() => {
 
   @media (max-width: $MQMobileNarrow) {
     margin-top: $navbar-height-mobile;
-    padding: 0.75rem 0.5rem;
+    padding: 0;
   }
+}
+
+.profile-breadcrumb {
+  margin-bottom: 0.8rem;
 }
 
 .profile-header {
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding: 0.6rem 0 1.2rem;
-  border-bottom: 1px solid var(--c-border);
 
   h1 {
     margin: 0;
-    font-size: 2rem;
+    font-size: 0.8rem;
     line-height: 1.1;
   }
 
   @media (max-width: $MQMobileNarrow) {
     align-items: flex-start;
-
-    h1 {
-      font-size: 1.5rem;
-    }
   }
 }
 
 .profile-header-text {
   min-width: 0;
-}
-
-.profile-back {
-  display: inline-block;
-  margin-bottom: 0.2rem;
-  font-size: $font-size-sm;
 }
 
 .profile-stats {
@@ -228,22 +250,55 @@ const isLoading = computed(() => {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
-  margin-top: 0.8rem;
+  margin-top: 0.35rem;
 }
 
 .package-section {
-  margin-top: 1.4rem;
+  margin-top: 1rem;
 
   h2 {
-    margin: 0 0 0.7rem;
+    margin: 0;
     font-size: 1.3rem;
   }
 }
 
-.package-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax($package-grid-column-width, 1fr));
-  gap: $package-grid-column-hgap;
+.package-table-wrapper {
+  overflow-x: auto;
+}
+
+.package-table {
+  width: 100%;
+
+  code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+}
+
+.mobile-package-name {
+  display: none;
+  margin-top: 0.15rem;
+}
+
+.package-name-column {
+  @media (max-width: $MQMobileNarrow) {
+    display: none;
+  }
+}
+
+.submitted-column {
+  width: 7.5rem;
+  white-space: nowrap;
+
+  @media (max-width: $MQMobileNarrow) {
+    width: 6.2rem;
+  }
+}
+
+@media (max-width: $MQMobileNarrow) {
+  .mobile-package-name {
+    display: block;
+  }
 }
 
 .empty-state {

--- a/apps/docs/docs/contributors/index.md
+++ b/apps/docs/docs/contributors/index.md
@@ -76,8 +76,8 @@ A heartfelt thank you to all our contributors! 🌟 If you'd like to be honored 
 
 ## Top 100 Package Hunters
 
-<GitHubUserList :items="$page.frontmatter.hunters" />
+<GitHubUserList :items="$page.frontmatter.hunters" link-to-profile />
 
 ## Top 100 Package Owners
 
-<GitHubUserList :items="$page.frontmatter.owners" />
+<GitHubUserList :items="$page.frontmatter.owners" link-to-profile />

--- a/design.md
+++ b/design.md
@@ -1,0 +1,47 @@
+# OpenUPM Client Design Notes
+
+The OpenUPM client is a fusion of a tweaked Spectre.css foundation and the
+VuePress theme. Prefer Spectre's native class names and markup shapes for
+components, and use VuePress theme variables, layout primitives, and navigation
+patterns where the site chrome or documentation flow is involved.
+
+## Structure
+
+- Use Spectre component markup exactly where practical, for example breadcrumbs
+  use `.breadcrumb` with direct `.breadcrumb-item` children.
+- Keep OpenUPM pages utilitarian and dense. Avoid decorative cards for page
+  sections; reserve cards for repeated items, modals, and framed tools.
+- For long package collections, prefer tables or virtualized lists over package
+  cards. Package cards are appropriate for browsing grids, not long inventories.
+- Use the default VuePress docs/sidebar structure for documentation pages.
+  Application-style pages may opt out when the sidebar competes with the primary
+  workflow.
+
+## Links
+
+- Use the local `AutoLink` component for new internal and external navigation
+  links. It wraps the VuePress theme `AutoLink`, so it preserves router
+  navigation, active-link behavior, external-link icons, `_blank` targets, and
+  safe `rel` defaults.
+- Pass link data as an item object with `text` and `link` rather than hand
+  writing anchors, unless the markup is static content or requires behavior
+  that `AutoLink` does not support.
+- External reference links should be normal nav links unless the action is a
+  primary task. Do not style them as buttons by default.
+
+## Tables
+
+- Avoid striped table rows in dark mode unless the colors have been explicitly
+  tuned for both themes.
+- Keep table spacing consistent with nearby section headings; avoid large gaps,
+  but preserve enough top margin for the heading and table to read as separate
+  elements.
+- Show both friendly display names and full package names when package identity
+  needs to be scan-friendly and exact.
+
+## Color And Theme
+
+- Reuse existing CSS variables such as `--c-border`, `--c-text`, and
+  `--c-text-light` from the VuePress theme so light and dark modes stay aligned.
+- Do not introduce one-off row backgrounds, gradients, or decorative color
+  bands without checking dark mode.

--- a/packages/@openupm/common/__tests__/urls.spec.ts
+++ b/packages/@openupm/common/__tests__/urls.spec.ts
@@ -1,10 +1,25 @@
 import {
+  getContributorProfilePagePath,
   getMonthlyDownloadsRangeUrl,
   getMonthlyDownloadsUrl,
   isPackageDetailPath,
   isPackageListPath,
   parsePackageNameFromPackageDetailPath,
 } from '../src/urls.js';
+
+describe('getContributorProfilePagePath', () => {
+  it('should build the contributor profile path', () => {
+    const result = getContributorProfilePagePath('GitHubUser');
+
+    expect(result).toEqual('/contributors/githubuser/');
+  });
+
+  it('should encode contributor names and trim surrounding whitespace', () => {
+    const result = getContributorProfilePagePath(' user name ');
+
+    expect(result).toEqual('/contributors/user%20name/');
+  });
+});
 
 describe('isPackageDetailPath', () => {
   it('should return true for path included lowecase letters', () => {

--- a/packages/@openupm/common/src/urls.ts
+++ b/packages/@openupm/common/src/urls.ts
@@ -83,6 +83,17 @@ export const getPackageListPagePath = function (topic?: string): string {
   return '/packages/';
 };
 
+/**
+ * Get contributor profile page path for GitHub user.
+ * @param githubUser GitHub username
+ * @returns contributor profile page path
+ */
+export const getContributorProfilePagePath = function (
+  githubUser: string,
+): string {
+  return `/contributors/${encodeURIComponent(githubUser.trim().toLowerCase())}/`;
+};
+
 // OpenUPM GitHub repo url.
 export const OpenUPMGitHubRepoUrl = 'https://github.com/openupm/openupm';
 

--- a/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
@@ -1,0 +1,53 @@
+import { PackageMetadataLocal } from '@openupm/types';
+
+import {
+  buildContributorProfile,
+  collectContributorProfileGithubUsers,
+} from '../src/contributors.js';
+
+describe('contributor profile generation', () => {
+  it('includes hunters, owners, and GitHub parent owners without duplicates', () => {
+    const githubUsers = collectContributorProfileGithubUsers(
+      [
+        { githubUser: 'Alice', score: 2 },
+        { githubUser: 'bob', score: 1 },
+      ],
+      [
+        { githubUser: 'alice', score: 1 },
+        { githubUser: 'ParentOrg', score: 1 },
+      ],
+    );
+
+    expect(githubUsers).toEqual(['Alice', 'bob', 'ParentOrg']);
+  });
+
+  it('counts owned packages from owners and parent owners and discovered packages from hunters', () => {
+    const metadata = [
+      {
+        name: 'com.example.owner',
+        owner: 'Alice',
+        parentOwner: null,
+        hunter: 'carol',
+      },
+      {
+        name: 'com.example.parent',
+        owner: 'fork-owner',
+        parentOwner: 'alice',
+        hunter: 'dave',
+      },
+      {
+        name: 'com.example.discovered',
+        owner: 'bob',
+        parentOwner: null,
+        hunter: 'ALICE',
+      },
+    ] as PackageMetadataLocal[];
+
+    expect(buildContributorProfile('Alice', metadata)).toEqual({
+      githubUser: 'Alice',
+      ownedCount: 2,
+      discoveredCount: 1,
+      totalSubmittedCount: 3,
+    });
+  });
+});

--- a/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
@@ -26,20 +26,29 @@ describe('contributor profile generation', () => {
       {
         name: 'com.example.owner',
         owner: 'Alice',
+        ownerUrl: 'https://github.com/Alice',
         parentOwner: null,
+        parentOwnerUrl: null,
         hunter: 'carol',
+        hunterUrl: 'https://github.com/carol',
       },
       {
         name: 'com.example.parent',
         owner: 'fork-owner',
+        ownerUrl: 'https://github.com/fork-owner',
         parentOwner: 'alice',
+        parentOwnerUrl: 'https://github.com/alice',
         hunter: 'dave',
+        hunterUrl: 'https://github.com/dave',
       },
       {
         name: 'com.example.discovered',
         owner: 'bob',
+        ownerUrl: 'https://github.com/bob',
         parentOwner: null,
+        parentOwnerUrl: null,
         hunter: 'ALICE',
+        hunterUrl: 'https://github.com/ALICE',
       },
     ] as PackageMetadataLocal[];
 
@@ -48,6 +57,27 @@ describe('contributor profile generation', () => {
       ownedCount: 2,
       discoveredCount: 1,
       totalSubmittedCount: 3,
+      profileUrl: 'https://github.com/Alice',
+      profileHost: 'github.com',
+    });
+  });
+
+  it('uses the contributor upstream profile URL and host from matching metadata', () => {
+    const metadata = [
+      {
+        name: 'com.example.gitlab',
+        owner: 'Alice',
+        ownerUrl: 'https://gitlab.com/Alice',
+        parentOwner: null,
+        parentOwnerUrl: null,
+        hunter: 'bob',
+        hunterUrl: 'https://github.com/bob',
+      },
+    ] as PackageMetadataLocal[];
+
+    expect(buildContributorProfile('Alice', metadata)).toMatchObject({
+      profileUrl: 'https://gitlab.com/Alice',
+      profileHost: 'gitlab.com',
     });
   });
 });

--- a/packages/vuepress-plugin-openupm/src/contributors.ts
+++ b/packages/vuepress-plugin-openupm/src/contributors.ts
@@ -1,0 +1,64 @@
+import { GithubUserWithScore, PackageMetadataLocal } from '@openupm/types';
+
+export type ContributorProfile = {
+  githubUser: string;
+  ownedCount: number;
+  discoveredCount: number;
+  totalSubmittedCount: number;
+};
+
+const normalizeGithubUser = (githubUser: string): string =>
+  githubUser.trim().toLowerCase();
+
+const matchesGithubUser = (
+  actual: string | null | undefined,
+  expected: string,
+): boolean =>
+  actual ? normalizeGithubUser(actual) === expected : false;
+
+const ownsPackage = (
+  metadata: PackageMetadataLocal,
+  normalizedGithubUser: string,
+): boolean =>
+  matchesGithubUser(metadata.owner, normalizedGithubUser) ||
+  matchesGithubUser(metadata.parentOwner, normalizedGithubUser);
+
+const discoveredPackage = (
+  metadata: PackageMetadataLocal,
+  normalizedGithubUser: string,
+): boolean => matchesGithubUser(metadata.hunter, normalizedGithubUser);
+
+export const collectContributorProfileGithubUsers = function (
+  hunters: GithubUserWithScore[],
+  owners: GithubUserWithScore[],
+): string[] {
+  const profiles = new Map<string, string>();
+  for (const contributor of [...hunters, ...owners]) {
+    const githubUser = contributor.githubUser.trim();
+    if (!githubUser) continue;
+    const key = normalizeGithubUser(githubUser);
+    if (!profiles.has(key)) profiles.set(key, githubUser);
+  }
+  return [...profiles.values()].sort((a, b) =>
+    a.toLowerCase().localeCompare(b.toLowerCase()),
+  );
+};
+
+export const buildContributorProfile = function (
+  githubUser: string,
+  metadataLocalList: PackageMetadataLocal[],
+): ContributorProfile {
+  const normalizedGithubUser = normalizeGithubUser(githubUser);
+  const ownedCount = metadataLocalList.filter((metadata) =>
+    ownsPackage(metadata, normalizedGithubUser),
+  ).length;
+  const discoveredCount = metadataLocalList.filter((metadata) =>
+    discoveredPackage(metadata, normalizedGithubUser),
+  ).length;
+  return {
+    githubUser,
+    ownedCount,
+    discoveredCount,
+    totalSubmittedCount: ownedCount + discoveredCount,
+  };
+};

--- a/packages/vuepress-plugin-openupm/src/contributors.ts
+++ b/packages/vuepress-plugin-openupm/src/contributors.ts
@@ -5,6 +5,8 @@ export type ContributorProfile = {
   ownedCount: number;
   discoveredCount: number;
   totalSubmittedCount: number;
+  profileUrl: string;
+  profileHost: string;
 };
 
 const normalizeGithubUser = (githubUser: string): string =>
@@ -27,6 +29,34 @@ const discoveredPackage = (
   metadata: PackageMetadataLocal,
   normalizedGithubUser: string,
 ): boolean => matchesGithubUser(metadata.hunter, normalizedGithubUser);
+
+const getUrlHost = function (url: string | null | undefined): string {
+  if (!url) return 'github.com';
+  try {
+    return new URL(url).hostname || 'github.com';
+  } catch {
+    return 'github.com';
+  }
+};
+
+const getContributorProfileUrl = function (
+  githubUser: string,
+  metadataLocalList: PackageMetadataLocal[],
+): string {
+  const normalizedGithubUser = normalizeGithubUser(githubUser);
+  for (const metadata of metadataLocalList) {
+    if (matchesGithubUser(metadata.owner, normalizedGithubUser)) {
+      return metadata.ownerUrl || `https://github.com/${githubUser}`;
+    }
+    if (matchesGithubUser(metadata.parentOwner, normalizedGithubUser)) {
+      return metadata.parentOwnerUrl || `https://github.com/${githubUser}`;
+    }
+    if (matchesGithubUser(metadata.hunter, normalizedGithubUser)) {
+      return metadata.hunterUrl || `https://github.com/${githubUser}`;
+    }
+  }
+  return `https://github.com/${githubUser}`;
+};
 
 export const collectContributorProfileGithubUsers = function (
   hunters: GithubUserWithScore[],
@@ -55,10 +85,13 @@ export const buildContributorProfile = function (
   const discoveredCount = metadataLocalList.filter((metadata) =>
     discoveredPackage(metadata, normalizedGithubUser),
   ).length;
+  const profileUrl = getContributorProfileUrl(githubUser, metadataLocalList);
   return {
     githubUser,
     ownedCount,
     discoveredCount,
     totalSubmittedCount: ownedCount + discoveredCount,
+    profileUrl,
+    profileHost: getUrlHost(profileUrl),
   };
 };

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -154,8 +154,7 @@ const createContributorProfilePages = async function (
     const profile = buildContributorProfile(githubUser, metadataLocalList);
     const frontmatter = {
       layout: 'ContributorProfileLayout',
-      // Hack: use an empty element to show sidebar
-      sidebar: [{ text: '', children: [] }],
+      sidebar: false,
       title: `${githubUser} | OpenUPM Contributor`,
       description: `OpenUPM packages owned and discovered by ${githubUser}.`,
       contributorProfile: profile,

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -27,10 +27,15 @@ import {
   getLocalePackageDescription,
 } from '@openupm/common/build/utils.js';
 import {
+  getContributorProfilePagePath,
   getPackageDetailPagePath,
   getPackageListPagePath,
 } from '@openupm/common/build/urls.js';
 
+import {
+  buildContributorProfile,
+  collectContributorProfileGithubUsers,
+} from './contributors.js';
 import {
   buildPackageAliasRedirects,
   mergePackageAliasRedirects,
@@ -44,6 +49,7 @@ type Contributor = GithubUserWithScore & {
 
 type PluginData = {
   blockedScopes: string[];
+  contributorProfileGithubUsers: string[];
   hunters: Contributor[];
   metadataLocalList: PackageMetadataLocal[];
   metadataGroupByNamespace: Record<string, PackageMetadataLocal[]>;
@@ -107,6 +113,10 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
   };
   const hunters = prepareContributors(huntersAndOwners.hunters);
   const owners = prepareContributors(huntersAndOwners.owners);
+  const contributorProfileGithubUsers = collectContributorProfileGithubUsers(
+    huntersAndOwners.hunters,
+    huntersAndOwners.owners,
+  );
   // Blocked scopes
   const blockedScopes = await loadBlockedScopes();
   // Spdx
@@ -121,6 +131,7 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
     });
   return {
     blockedScopes,
+    contributorProfileGithubUsers,
     hunters,
     metadataLocalList,
     metadataGroupByNamespace,
@@ -129,6 +140,36 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
     topicsWithAll,
   };
 })();
+
+/**
+ * Create contributor profile pages
+ * @param app vuepress app
+ */
+const createContributorProfilePages = async function (
+  app: App,
+): Promise<Page[]> {
+  const pages: Page[] = [];
+  const { contributorProfileGithubUsers, metadataLocalList } = PLUGIN_DATA;
+  for (const githubUser of contributorProfileGithubUsers) {
+    const profile = buildContributorProfile(githubUser, metadataLocalList);
+    const frontmatter = {
+      layout: 'ContributorProfileLayout',
+      // Hack: use an empty element to show sidebar
+      sidebar: [{ text: '', children: [] }],
+      title: `${githubUser} | OpenUPM Contributor`,
+      description: `OpenUPM packages owned and discovered by ${githubUser}.`,
+      contributorProfile: profile,
+    };
+    const pageOptions = {
+      path: getContributorProfilePagePath(githubUser),
+      frontmatter,
+      content: '',
+    };
+    const page = await createPage(app, pageOptions);
+    pages.push(page);
+  }
+  return pages;
+};
 
 /**
  * Create package detail pages
@@ -212,6 +253,7 @@ export default (): VuePressPlugin => ({
   async onInitialized(app: App): Promise<void> {
     addPages(app, await createDetailPages(app));
     addPages(app, await createListPages(app));
+    addPages(app, await createContributorProfilePages(app));
   },
   extendsPage: async (page: Page): Promise<void> => {
     if (page.path.endsWith('/contributors/')) {


### PR DESCRIPTION
## Summary

- reintroduces contributor profile pages with a simpler, table-based package view
- removes the profile sidebar and keeps the page focused on breadcrumb, avatar, stats, and GitHub profile link
- adds a reusable NavLink component for safe external link defaults
- adds generic client design notes for the Spectre.css and VuePress theme blend

## Validation

- npm run test -- contributorProfile.spec.ts
- npm run lint
- npm run lint -- --filter=vuepress-plugin-openupm
- npm run build -- --filter=vuepress-plugin-openupm
- npm run docs:build:limit
