### PR TITLE
[codex] Link backers to contributor profiles

### DIFF
--- a/apps/docs/__tests__/vue/contributorProfile.spec.ts
+++ b/apps/docs/__tests__/vue/contributorProfile.spec.ts
@@ -211,6 +211,17 @@ describe("contributor profile filtering", () => {
     expect(metadataViewSource).toContain("getContributorProfilePagePath");
   });
 
+  it("lets contributor list data override avatar links", () => {
+    const githubAvatarSource = readFileSync(githubAvatarPath, "utf8");
+    const pluginSource = readFileSync(pluginPath, "utf8");
+
+    expect(githubAvatarSource).toContain("url?: string");
+    expect(githubAvatarSource).toContain("props.profile.url ||");
+    expect(githubAvatarSource).toContain('rel="noopener noreferrer"');
+    expect(pluginSource).toContain("addContributorProfileUrls");
+    expect(pluginSource).toContain("page.frontmatter.backers");
+  });
+
   it("keeps non-GitHub parent owner chips on their original upstream profile URL", () => {
     const metadataViewSource = readFileSync(packageMetadataViewPath, "utf8");
 
@@ -240,8 +251,8 @@ describe("contributor profile filtering", () => {
   it("routes contributor avatar profile links through RouterLink", () => {
     const githubAvatarSource = readFileSync(githubAvatarPath, "utf8");
 
-    expect(githubAvatarSource).toContain('<RouterLink v-if="linkToProfile" :to="profilePath">');
-    expect(githubAvatarSource).toContain('<a v-else :href="githubUrl">');
+    expect(githubAvatarSource).toContain('<RouterLink v-if="isInternalLink" :to="linkUrl">');
+    expect(githubAvatarSource).toContain('<a v-else :href="linkUrl" rel="noopener noreferrer">');
   });
 
   it("uses the contributor profile URL and host from generated frontmatter", () => {

--- a/apps/docs/docs/.vuepress/components/GitHubAvatar.vue
+++ b/apps/docs/docs/.vuepress/components/GitHubAvatar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { PropType } from 'vue';
+import { computed, PropType } from 'vue';
 
 import { getAvatarImageUrl, getContributorProfilePagePath } from "@openupm/common/build/urls.js";
 
@@ -7,6 +7,7 @@ interface Profile {
   githubUser: string;
   text?: string;
   abbr?: string;
+  url?: string;
 }
 
 const props = defineProps({
@@ -24,14 +25,18 @@ const { text, abbr, githubUser } = props.profile;
 const profilePath = getContributorProfilePagePath(githubUser);
 const githubUrl = `https://github.com/${githubUser}`;
 const imageUrl = getAvatarImageUrl(githubUser, 128);
+const linkUrl = computed(() => {
+  return props.profile.url || (props.linkToProfile ? profilePath : githubUrl);
+});
+const isInternalLink = computed(() => linkUrl.value.startsWith('/'));
 </script>
 
 <template>
   <figure class="avatar avatar-xl tooltip" :data-tooltip="text" :data-initial="abbr">
-    <RouterLink v-if="linkToProfile" :to="profilePath">
+    <RouterLink v-if="isInternalLink" :to="linkUrl">
       <LazyImage v-if="imageUrl" :src="imageUrl" :alt="text" />
     </RouterLink>
-    <a v-else :href="githubUrl">
+    <a v-else :href="linkUrl" rel="noopener noreferrer">
       <LazyImage v-if="imageUrl" :src="imageUrl" :alt="text" />
     </a>
   </figure>

--- a/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
@@ -1,8 +1,10 @@
 import { PackageMetadataLocal } from '@openupm/types';
 
 import {
+  addContributorProfileUrls,
   buildContributorProfile,
   collectContributorProfileGithubUsers,
+  getContributorPageOrGithubUrl,
 } from '../src/contributors.js';
 
 describe('contributor profile generation', () => {
@@ -79,5 +81,39 @@ describe('contributor profile generation', () => {
       profileUrl: 'https://gitlab.com/Alice',
       profileHost: 'gitlab.com',
     });
+  });
+
+  it('resolves contributor page URLs only when a profile exists', () => {
+    const contributorProfileGithubUsers = ['Alice'];
+
+    expect(
+      getContributorPageOrGithubUrl('alice', contributorProfileGithubUsers),
+    ).toEqual('/contributors/alice/');
+    expect(
+      getContributorPageOrGithubUrl('bob', contributorProfileGithubUsers),
+    ).toEqual('https://github.com/bob');
+  });
+
+  it('adds backer URLs that prefer existing contributor profile pages', () => {
+    expect(
+      addContributorProfileUrls(
+        [
+          { text: 'Alice Backer', githubUser: 'alice' },
+          { text: 'Bob Backer', githubUser: 'bob' },
+        ],
+        ['Alice'],
+      ),
+    ).toEqual([
+      {
+        text: 'Alice Backer',
+        githubUser: 'alice',
+        url: '/contributors/alice/',
+      },
+      {
+        text: 'Bob Backer',
+        githubUser: 'bob',
+        url: 'https://github.com/bob',
+      },
+    ]);
   });
 });

--- a/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
@@ -100,6 +100,11 @@ describe('contributor profile generation', () => {
         [
           { text: 'Alice Backer', githubUser: 'alice' },
           { text: 'Bob Backer', githubUser: 'bob' },
+          {
+            text: 'Custom Backer',
+            githubUser: 'carol',
+            url: 'https://example.com/carol',
+          },
         ],
         ['Alice'],
       ),
@@ -113,6 +118,11 @@ describe('contributor profile generation', () => {
         text: 'Bob Backer',
         githubUser: 'bob',
         url: 'https://github.com/bob',
+      },
+      {
+        text: 'Custom Backer',
+        githubUser: 'carol',
+        url: 'https://example.com/carol',
       },
     ]);
   });

--- a/packages/vuepress-plugin-openupm/src/contributors.ts
+++ b/packages/vuepress-plugin-openupm/src/contributors.ts
@@ -108,6 +108,7 @@ export const addContributorProfileUrls = function <T extends GithubUserLink>(
   contributorProfileGithubUsers: string[],
 ): T[] {
   return contributors.map((contributor) => {
+    if (contributor.url) return contributor;
     if (!contributor.githubUser) return contributor;
     const url = getContributorPageOrGithubUrl(
       contributor.githubUser,

--- a/packages/vuepress-plugin-openupm/src/contributors.ts
+++ b/packages/vuepress-plugin-openupm/src/contributors.ts
@@ -1,4 +1,5 @@
 import { GithubUserWithScore, PackageMetadataLocal } from '@openupm/types';
+import { getContributorProfilePagePath } from '@openupm/common/build/urls.js';
 
 export type ContributorProfile = {
   githubUser: string;
@@ -9,7 +10,12 @@ export type ContributorProfile = {
   profileHost: string;
 };
 
-const normalizeGithubUser = (githubUser: string): string =>
+export type GithubUserLink = {
+  githubUser?: string | null;
+  url?: string;
+};
+
+export const normalizeGithubUser = (githubUser: string): string =>
   githubUser.trim().toLowerCase();
 
 const matchesGithubUser = (
@@ -72,6 +78,44 @@ export const collectContributorProfileGithubUsers = function (
   return [...profiles.values()].sort((a, b) =>
     a.toLowerCase().localeCompare(b.toLowerCase()),
   );
+};
+
+const hasContributorProfile = function (
+  contributorProfileGithubUsers: string[],
+  githubUser: string,
+): boolean {
+  const normalizedGithubUser = normalizeGithubUser(githubUser);
+  return contributorProfileGithubUsers.some(
+    (profileGithubUser) =>
+      normalizeGithubUser(profileGithubUser) === normalizedGithubUser,
+  );
+};
+
+export const getContributorPageOrGithubUrl = function (
+  githubUser: string,
+  contributorProfileGithubUsers: string[],
+): string {
+  const trimmedGithubUser = githubUser.trim();
+  if (!trimmedGithubUser) return '';
+  if (hasContributorProfile(contributorProfileGithubUsers, trimmedGithubUser)) {
+    return getContributorProfilePagePath(trimmedGithubUser);
+  }
+  return `https://github.com/${trimmedGithubUser}`;
+};
+
+export const addContributorProfileUrls = function <T extends GithubUserLink>(
+  contributors: T[],
+  contributorProfileGithubUsers: string[],
+): T[] {
+  return contributors.map((contributor) => {
+    if (!contributor.githubUser) return contributor;
+    const url = getContributorPageOrGithubUrl(
+      contributor.githubUser,
+      contributorProfileGithubUsers,
+    );
+    if (!url) return contributor;
+    return { ...contributor, url };
+  });
 };
 
 export const buildContributorProfile = function (

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from '@openupm/common/build/urls.js';
 
 import {
+  addContributorProfileUrls,
   buildContributorProfile,
   collectContributorProfileGithubUsers,
 } from './contributors.js';
@@ -256,9 +257,15 @@ export default (): VuePressPlugin => ({
   },
   extendsPage: async (page: Page): Promise<void> => {
     if (page.path.endsWith('/contributors/')) {
-      const { hunters, owners } = PLUGIN_DATA;
+      const { contributorProfileGithubUsers, hunters, owners } = PLUGIN_DATA;
       page.frontmatter.hunters = hunters.slice(0, 100);
       page.frontmatter.owners = owners.slice(0, 100);
+      if (Array.isArray(page.frontmatter.backers)) {
+        page.frontmatter.backers = addContributorProfileUrls(
+          page.frontmatter.backers,
+          contributorProfileGithubUsers,
+        );
+      }
     }
   },
   onPrepared: async (app: App): Promise<void> => {


### PR DESCRIPTION
## Summary
- add contributor-aware URL generation for contributors page backers
- route backer avatars to OpenUPM contributor profiles when a generated profile exists
- keep GitHub fallback links with noopener/noreferrer for backers without a profile

## Validation
- npm test -- --filter=vuepress-plugin-openupm
- npm run test -- contributorProfile.spec.ts
- npm run lint -- --filter=vuepress-plugin-openupm
- npm run lint in apps/docs
- npm run build -- --filter=vuepress-plugin-openupm
- npm run docs:build:limit