### PR TITLE
Add UnityNuGet package pages

### DIFF
--- a/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
+++ b/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
@@ -70,8 +70,11 @@ describe("NuGet package detail UI", () => {
   it("fetches registry packument, package ads, and shows an unavailable state", () => {
     const source = readFileSync(nugetLayoutPath, "utf8");
 
-    expect(source).toContain("getPackumentUrl(packageName.value)");
-    expect(source).toContain("getPackageAdPlacementUrl(packageName.value)");
+    expect(source).toContain("const requestedPackageName = packageName.value");
+    expect(source).toContain("getPackumentUrl(requestedPackageName)");
+    expect(source).toContain("getPackageAdPlacementUrl(requestedPackageName)");
+    expect(source).toContain("isCurrentRequest");
+    expect(source).toContain("requestId === latestRequestId");
     expect(source).toContain("<UnityAssetAdPlacement");
     expect(source).toContain("AdsenseDisplayForPackageDetail");
     expect(source).toContain("state.isUnavailable = true");

--- a/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
+++ b/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
@@ -67,6 +67,19 @@ describe("NuGet package detail UI", () => {
     });
   });
 
+  it("drops unsafe repository URL schemes from packument metadata", () => {
+    expect(
+      getNuGetRepositoryUrl({
+        repository: { url: "javascript:alert(document.domain)" },
+      }),
+    ).toBe("");
+    expect(
+      getNuGetRepositoryUrl({
+        repository: { url: "https://github.com/JamesNK/Newtonsoft.Json" },
+      }),
+    ).toBe("https://github.com/JamesNK/Newtonsoft.Json");
+  });
+
   it("fetches registry packument, package ads, and shows an unavailable state", () => {
     const source = readFileSync(nugetLayoutPath, "utf8");
 

--- a/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
+++ b/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getLatestNuGetVersion,
+  getNuGetDependencies,
+  getNuGetPackageVersions,
+  getNuGetRepositoryUrl,
+  getNuGetVersionInfo,
+} from "../../docs/.vuepress/nugetPackageDetail";
+import { Packument } from "@openupm/types";
+
+const nugetLayoutPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/layouts/NuGetPackageDetailLayout.vue",
+    import.meta.url,
+  ),
+);
+
+const packageDependenciesViewPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/PackageDependenciesView.vue",
+    import.meta.url,
+  ),
+);
+
+describe("NuGet package detail UI", () => {
+  const packument = {
+    name: "org.nuget.newtonsoft.json",
+    versions: {
+      "13.0.3": {
+        name: "org.nuget.newtonsoft.json",
+        version: "13.0.3",
+        unity: "2019.1",
+        description: "Json.NET",
+        displayName: "Json.NET (NuGet)",
+        dependencies: { "org.nuget.system.buffers": "4.5.1" },
+        readmeFilename: "",
+        author: "James Newton-King",
+        repository: { url: "https://github.com/JamesNK/Newtonsoft.Json" },
+      },
+    },
+    time: { "13.0.3": "2023-03-08T07:42:54.647Z" },
+    "dist-tags": { latest: "13.0.3" },
+    readme: "",
+  } as Packument;
+
+  it("derives identity, latest version, dependencies, and version data from a packument", () => {
+    const latestVersion = getLatestNuGetVersion(packument, "13.0.1");
+    const versionInfo = getNuGetVersionInfo(packument, latestVersion);
+
+    expect(latestVersion).toBe("13.0.3");
+    expect(versionInfo.displayName).toBe("Json.NET (NuGet)");
+    expect(versionInfo.author).toBe("James Newton-King");
+    expect(getNuGetRepositoryUrl(versionInfo)).toBe(
+      "https://github.com/JamesNK/Newtonsoft.Json",
+    );
+    expect(getNuGetDependencies(versionInfo)).toEqual([
+      { name: "org.nuget.system.buffers", version: "4.5.1" },
+    ]);
+    expect(getNuGetPackageVersions(packument, latestVersion)[0]).toMatchObject({
+      latest: true,
+      unity: "2019.1",
+      version: "13.0.3",
+    });
+  });
+
+  it("fetches registry packument, package ads, and shows an unavailable state", () => {
+    const source = readFileSync(nugetLayoutPath, "utf8");
+
+    expect(source).toContain("getPackumentUrl(packageName.value)");
+    expect(source).toContain("getPackageAdPlacementUrl(packageName.value)");
+    expect(source).toContain("<UnityAssetAdPlacement");
+    expect(source).toContain("AdsenseDisplayForPackageDetail");
+    expect(source).toContain("state.isUnavailable = true");
+    expect(source).toContain("UnityNuGet package data is unavailable");
+  });
+
+  it("does not include native OpenUPM-only sections", () => {
+    const source = readFileSync(nugetLayoutPath, "utf8");
+
+    expect(source).not.toContain("PackagePipelinesView");
+    expect(source).not.toContain("PackageReadmeView");
+    expect(source).not.toContain("PackageRelatedView");
+    expect(source).not.toContain("PackageMetadataView");
+  });
+
+  it("uses the standard breadcrumb and install-only right meta column", () => {
+    const source = readFileSync(nugetLayoutPath, "utf8");
+
+    expect(source).toContain('<nav aria-label="Breadcrumb">');
+    expect(source).toContain('<ul class="breadcrumb package-breadcrumb">');
+    expect(source).toContain('class="column column-meta col-4');
+    expect(source).toContain("<PackageSetup");
+    expect(source).toContain(':packument="state.packument"');
+    expect(source).not.toContain('<p class="label label-primary">UnityNuGet</p>');
+  });
+});
+
+describe("package dependency icons", () => {
+  it("shows tooltip-up tooltips for dependency kind icons", () => {
+    const source = readFileSync(packageDependenciesViewPath, "utf8");
+
+    expect(source).toContain("UnityNuGet uplink dependency");
+    expect(source).toContain("Git dependency with package page");
+    expect(source).toContain("OpenUPM package dependency");
+    expect(source).toContain("Unity package documentation");
+    expect(source).toContain("Missing package dependency");
+    expect(source).toContain("'tooltip', 'tooltip-up'");
+    expect(source).toContain(':data-tooltip="entry.iconTooltip"');
+  });
+
+  it("links generated NuGet pages before applying OpenUPM existence checks", () => {
+    const source = readFileSync(packageDependenciesViewPath, "utf8");
+
+    expect(source).toContain("const isNuGet = name.startsWith(\"org.nuget.\")");
+    expect(source).toContain("const openUpmPath = isNuGet || openUpmPackageExists");
+    expect(source).toContain("getPackageDetailPagePath(name)");
+  });
+
+  it("links Unity dependencies to Unity documentation when OpenUPM has no package page", () => {
+    const source = readFileSync(packageDependenciesViewPath, "utf8");
+
+    expect(source).toContain("isPackageExist(name)");
+    expect(source).toContain("name.startsWith(\"com.unity.\")");
+    expect(source).toContain("https://docs.unity3d.com/Packages/");
+    expect(source).toContain("name.startsWith(\"com.unity.modules.\")");
+    expect(source).toContain("https://docs.unity3d.com/Manual/${name}.html");
+    expect(source).toContain("getUnityPackageDocumentationVersion(version)");
+    expect(source).toContain("^(\\d+\\.\\d+)(?:\\.|$)");
+    expect(source).toContain("fab fa-unity");
+    expect(source).toContain("unity-deps-documentation");
+  });
+
+  it("shows Google package detail ads in the left sidebar and right meta column", () => {
+    const source = readFileSync(nugetLayoutPath, "utf8");
+
+    expect(source).toContain("<template #sidebar-top>");
+    expect(source).toContain('<div class="nuget-sidebar-ad">');
+    expect(source).toContain('<section class="col-12 adsense-section">');
+    expect(
+      source.match(/<AdsenseDisplayForPackageDetail \/>/g) || [],
+    ).toHaveLength(2);
+  });
+});

--- a/apps/docs/__tests__/vue/search.spec.ts
+++ b/apps/docs/__tests__/vue/search.spec.ts
@@ -29,6 +29,10 @@ describe("normalizeSearchQuery", () => {
       "org.nuget.newtonsoft.json",
     );
   });
+
+  it("preserves non-ASCII query tokens", () => {
+    normalizeSearchQuery("（日本語 café）").should.equal("日本語 café");
+  });
 });
 
 describe("isUnityNuGetPackageName", () => {

--- a/apps/docs/__tests__/vue/search.spec.ts
+++ b/apps/docs/__tests__/vue/search.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { SearchIndex } from "@vuepress/plugin-search";
 import {
   getPackageSearchResultDisplayName,
@@ -8,9 +11,16 @@ import {
   usePackageSearchSuggestions,
 } from "@/search";
 import { getSearchExtraFields } from "@/searchExtraFields";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import chai from "chai";
 chai.should();
+
+const packageListLayoutPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/layouts/PackageListLayout.vue",
+    import.meta.url,
+  ),
+);
 
 describe("normalizeSearchQuery", () => {
   it("removes leading and trailing punctuation without stripping package separators", () => {
@@ -263,5 +273,17 @@ describe("getSearchExtraFields", () => {
     } as never);
 
     fields.should.deep.equal([]);
+  });
+});
+
+describe("PackageListLayout search result counts", () => {
+  it("counts native package cards and UnityNuGet page results together", () => {
+    const source = readFileSync(packageListLayoutPath, "utf8");
+
+    expect(source).toContain("const resultCount = computed");
+    expect(source).toContain(
+      "metadataEntries.value.length + packagePageSearchSuggestions.value.length",
+    );
+    expect(source).toContain("{{ resultCount }}");
   });
 });

--- a/apps/docs/__tests__/vue/search.spec.ts
+++ b/apps/docs/__tests__/vue/search.spec.ts
@@ -1,8 +1,68 @@
 import { SearchIndex } from "@vuepress/plugin-search";
-import { usePackageSearchSuggestions } from "@/search";
+import {
+  getPackageSearchResultDisplayName,
+  getPackageNameFromSearchSuggestionLink,
+  getPackageSearchResultTitle,
+  normalizeSearchQuery,
+  usePackageSearchSuggestions,
+} from "@/search";
+import { getSearchExtraFields } from "@/searchExtraFields";
 import { describe, it } from "vitest";
 import chai from "chai";
 chai.should();
+
+describe("normalizeSearchQuery", () => {
+  it("removes leading and trailing punctuation without stripping package separators", () => {
+    normalizeSearchQuery(" org.nuget; ").should.equal("org.nuget");
+    normalizeSearchQuery("(org.nuget.newtonsoft.json)").should.equal(
+      "org.nuget.newtonsoft.json",
+    );
+  });
+});
+
+describe("getPackageSearchResultTitle", () => {
+  it("formats native package titles without SEO suffixes", () => {
+    getPackageSearchResultTitle(
+      "Display Name | com.example.package | Unity Package Manager (UPM)",
+      "com.example.package",
+    ).should.equal("Display Name | com.example.package");
+  });
+
+  it("formats NuGet package titles with the generated package name", () => {
+    getPackageSearchResultTitle(
+      "System.Text.Json | org.nuget.system.text.json | UnityNuGet Package | Unity Package Manager (UPM)",
+      "org.nuget.system.text.json",
+    ).should.equal("System.Text.Json | org.nuget.system.text.json");
+  });
+
+  it("does not duplicate package names when no display name exists", () => {
+    getPackageSearchResultTitle(
+      "com.example.package | Unity Package Manager (UPM)",
+      "com.example.package",
+    ).should.equal("com.example.package");
+  });
+});
+
+describe("getPackageSearchResultDisplayName", () => {
+  it("returns the display name from an SEO page title", () => {
+    getPackageSearchResultDisplayName(
+      "System.Text.Json | org.nuget.system.text.json | UnityNuGet Package | Unity Package Manager (UPM)",
+      "org.nuget.system.text.json",
+    ).should.equal("System.Text.Json");
+  });
+});
+
+describe("getPackageNameFromSearchSuggestionLink", () => {
+  it("parses package names from package detail links with anchors", () => {
+    getPackageNameFromSearchSuggestionLink(
+      "/packages/org.nuget.system.text.json/#versions",
+    ).should.equal("org.nuget.system.text.json");
+  });
+
+  it("returns null for non-package links", () => {
+    chai.expect(getPackageNameFromSearchSuggestionLink("/docs/")).to.equal(null);
+  });
+});
 
 describe("usePackageSearchSuggestions", () => {
   it("should return an empty array for an empty query", () => {
@@ -39,7 +99,11 @@ describe("usePackageSearchSuggestions", () => {
     const query = "package1";
     const suggestions = usePackageSearchSuggestions(searchIndex, query);
     suggestions.should.be.an("array").that.has.lengthOf(1);
-    suggestions[0].should.deep.equal({ name: "com.example.package1" });
+    suggestions[0].should.deep.equal({
+      displayName: "package1",
+      name: "com.example.package1",
+      title: "package1 | com.example.package1",
+    });
   });
 
   it("should return an array of package search suggestions for multiple query tokens", () => {
@@ -69,8 +133,16 @@ describe("usePackageSearchSuggestions", () => {
     const query = "fetch rest";
     const suggestions = usePackageSearchSuggestions(searchIndex, query);
     suggestions.should.be.an("array").that.has.lengthOf(2);
-    suggestions[0].should.deep.equal({ name: "com.example.package1" });
-    suggestions[1].should.deep.equal({ name: "com.example.package2" });
+    suggestions[0].should.deep.equal({
+      displayName: "fetch rest",
+      name: "com.example.package1",
+      title: "fetch rest | com.example.package1",
+    });
+    suggestions[1].should.deep.equal({
+      displayName: "rest fetch",
+      name: "com.example.package2",
+      title: "rest fetch | com.example.package2",
+    });
   });
 
   it("should return an array of package search suggestions for multiple query tokens that contains plural words", () => {
@@ -93,8 +165,16 @@ describe("usePackageSearchSuggestions", () => {
     const query = "fetches";
     const suggestions = usePackageSearchSuggestions(searchIndex, query);
     suggestions.should.be.an("array").that.has.lengthOf(2);
-    suggestions[0].should.deep.equal({ name: "com.example.package1" });
-    suggestions[1].should.deep.equal({ name: "com.example.package2" });
+    suggestions[0].should.deep.equal({
+      displayName: "fetches",
+      name: "com.example.package1",
+      title: "fetches | com.example.package1",
+    });
+    suggestions[1].should.deep.equal({
+      displayName: "fetch",
+      name: "com.example.package2",
+      title: "fetch | com.example.package2",
+    });
   });
 
   it("should return an empty array of package search suggestions for multiple query tokens that don't get matched", () => {
@@ -124,5 +204,55 @@ describe("usePackageSearchSuggestions", () => {
     const query = "fetch rest";
     const suggestions = usePackageSearchSuggestions(searchIndex, query);
     suggestions.should.be.an("array").that.is.empty;
+  });
+
+  it("should match package names with trailing punctuation", () => {
+    const searchIndex = [
+      {
+        path: "/packages/org.nuget.newtonsoft.json/",
+        pathLocale: "/",
+        title: "Newtonsoft.Json | UnityNuGet Package",
+        extraFields: ["org.nuget.newtonsoft.json", "Newtonsoft.Json"],
+        headers: [],
+      },
+    ];
+    const suggestions = usePackageSearchSuggestions(searchIndex, "org.nuget;");
+    suggestions.should.deep.equal([
+      {
+        displayName: "Newtonsoft.Json",
+        name: "org.nuget.newtonsoft.json",
+        title: "Newtonsoft.Json | org.nuget.newtonsoft.json",
+      },
+    ]);
+  });
+});
+
+describe("getSearchExtraFields", () => {
+  it("indexes NuGet package names and original IDs", () => {
+    const fields = getSearchExtraFields({
+      frontmatter: {
+        packageKind: "unitynuget",
+        name: "org.nuget.newtonsoft.json",
+        nugetId: "Newtonsoft.Json",
+        description:
+          "Newtonsoft.Json is available as org.nuget.newtonsoft.json through the OpenUPM registry UnityNuGet uplink.",
+      },
+    } as never);
+
+    fields.should.deep.equal([
+      "org.nuget.newtonsoft.json",
+      "Newtonsoft.Json",
+      "Newtonsoft.Json is available as org.nuget.newtonsoft.json through the OpenUPM registry UnityNuGet uplink.",
+    ]);
+  });
+
+  it("does not add extra fields to native package pages", () => {
+    const fields = getSearchExtraFields({
+      frontmatter: {
+        name: "com.example.package",
+      },
+    } as never);
+
+    fields.should.deep.equal([]);
   });
 });

--- a/apps/docs/__tests__/vue/search.spec.ts
+++ b/apps/docs/__tests__/vue/search.spec.ts
@@ -3,6 +3,7 @@ import {
   getPackageSearchResultDisplayName,
   getPackageNameFromSearchSuggestionLink,
   getPackageSearchResultTitle,
+  isUnityNuGetPackageName,
   normalizeSearchQuery,
   usePackageSearchSuggestions,
 } from "@/search";
@@ -17,6 +18,14 @@ describe("normalizeSearchQuery", () => {
     normalizeSearchQuery("(org.nuget.newtonsoft.json)").should.equal(
       "org.nuget.newtonsoft.json",
     );
+  });
+});
+
+describe("isUnityNuGetPackageName", () => {
+  it("only accepts generated UnityNuGet package names", () => {
+    isUnityNuGetPackageName("org.nuget.system.text.json").should.equal(true);
+    isUnityNuGetPackageName("org.kumas.nuget-importer").should.equal(false);
+    isUnityNuGetPackageName("add").should.equal(false);
   });
 });
 

--- a/apps/docs/__tests__/vue/utils.spec.ts
+++ b/apps/docs/__tests__/vue/utils.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import chai from "chai";
+import { createPinia, setActivePinia } from "pinia";
 chai.should();
 
 import { DailyDownload } from "@openupm/types";
@@ -7,10 +8,39 @@ import {
   decodeGitHubBase64Content,
   fillMissingDates,
   generateHueFromStringInRange,
+  isPackageExist,
   stripLeadingBom,
 } from "@/utils";
+import { useDefaultStore } from "@/store";
 
 describe("@/utils.ts", function () {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe("isPackageExist", () => {
+    it("uses generated local package metadata before remote API metadata", () => {
+      const store = useDefaultStore();
+      store.packageMetadataLocalList = [
+        { name: "com.example.local-only" },
+      ] as typeof store.packageMetadataLocalList;
+      store.packageMetadataRemoteDict = {};
+
+      isPackageExist("com.example.local-only").should.equal(true);
+      isPackageExist("com.example.missing").should.equal(false);
+    });
+
+    it("keeps remote API metadata as a fallback", () => {
+      const store = useDefaultStore();
+      store.packageMetadataLocalList = [];
+      store.packageMetadataRemoteDict = {
+        "com.example.remote-only": {},
+      } as typeof store.packageMetadataRemoteDict;
+
+      isPackageExist("com.example.remote-only").should.equal(true);
+    });
+  });
+
   describe("fillMissingDates", () => {
     it("should fill in missing dates with 0 downloads", () => {
       const startDate = new Date("2021-01-01");

--- a/apps/docs/docs/.vuepress/client.ts
+++ b/apps/docs/docs/.vuepress/client.ts
@@ -13,6 +13,7 @@ import { GlobalFilters } from "@/vue-plugins/global-filters";
 import Layout from "@/layouts/Layout.vue";
 import WideLayout from "@/layouts/WideLayout.vue";
 import PackageDetailLayout from "@/layouts/PackageDetailLayout.vue";
+import NuGetPackageDetailLayout from "@/layouts/NuGetPackageDetailLayout.vue";
 import PackageListLayout from "@/layouts/PackageListLayout.vue";
 import PackageAddLayout from "@/layouts/PackageAddLayout.vue";
 import HomeLayout from "@/layouts/HomeLayout.vue";
@@ -81,6 +82,7 @@ export default defineClientConfig({
     Layout,
     WideLayout,
     PackageDetailLayout,
+    NuGetPackageDetailLayout,
     PackageListLayout,
     PackageAddLayout,
     HomeLayout,

--- a/apps/docs/docs/.vuepress/components/MySearchBox.ts
+++ b/apps/docs/docs/.vuepress/components/MySearchBox.ts
@@ -16,6 +16,11 @@ import {
   useSuggestionsFocus,
   SearchSuggestion,
 } from "@node_modules/@vuepress/plugin-search/lib/client/composables";
+import {
+  getPackageNameFromSearchSuggestionLink,
+  getPackageSearchResultTitle,
+  normalizeSearchQuery,
+} from "@/search";
 
 export default defineComponent({
   name: "MySearchBox",
@@ -36,16 +41,28 @@ export default defineComponent({
     const input = ref<HTMLInputElement | null>(null);
     const isActive = ref(false);
     const query = ref("");
+    const normalizedQuery = computed(() => normalizeSearchQuery(query.value));
     const locale = computed(() => locales.value[routeLocale.value] ?? {});
 
     const originalSuggestions = useSearchSuggestions({
       searchIndex,
       routeLocale,
-      query,
+      query: normalizedQuery,
       maxSuggestions,
     });
 
     const suggestions = computed(() => {
+      const displaySuggestions = originalSuggestions.value.map((suggestion) => {
+        const packageName = getPackageNameFromSearchSuggestionLink(
+          suggestion.link,
+        );
+        if (!packageName) return suggestion;
+
+        return {
+          ...suggestion,
+          title: getPackageSearchResultTitle(suggestion.title, packageName),
+        };
+      });
       if (query.value) {
         return (
           [
@@ -54,9 +71,9 @@ export default defineComponent({
               title: "Search the package list...",
             },
           ] as SearchSuggestion[]
-        ).concat(originalSuggestions.value);
+        ).concat(displaySuggestions);
       }
-      return originalSuggestions.value;
+      return displaySuggestions;
     });
 
     const { focusIndex, focusNext, focusPrev } =

--- a/apps/docs/docs/.vuepress/components/PackageDependenciesView.vue
+++ b/apps/docs/docs/.vuepress/components/PackageDependenciesView.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n';
 
 import { getPackageDetailPagePath } from "@openupm/common/build/urls.js";
 import { PackageDependency } from '@openupm/types';
+import { isPackageExist } from '@/utils';
 
 const { t } = useI18n();
 
@@ -18,42 +19,78 @@ const props = defineProps({
   }
 });
 
+const getUnityPackageDocumentationVersion = (version: string): string => {
+  const match = /^(\d+\.\d+)(?:\.|$)/.exec(version);
+  return match ? match[1] : version;
+};
+
+const getUnityPackageDocumentationUrl = (name: string, version: string): string => {
+  if (name.startsWith("com.unity.modules.")) {
+    return `https://docs.unity3d.com/Manual/${name}.html`;
+  }
+  const documentationVersion = getUnityPackageDocumentationVersion(version);
+  return `https://docs.unity3d.com/Packages/${name}@${encodeURIComponent(documentationVersion)}/`;
+};
+
 const dependencyList = computed(() => {
   if (!props.dependencies) return [];
   else
     return props.dependencies.map(({ name, version }: PackageDependency) => {
       const nameWithVersion = `${name}@${version}`;
       const isNuGet = name.startsWith("org.nuget.");
+      const isUnityPackage = name.startsWith("com.unity.");
       const isGit = version.startsWith("git");
-      const path = getPackageDetailPagePath(name);
+      const openUpmPackageExists = isPackageExist(name);
+      const openUpmPath = isNuGet || openUpmPackageExists
+        ? getPackageDetailPagePath(name)
+        : null;
+      const unityDocumentationUrl = !openUpmPath && isUnityPackage
+        ? getUnityPackageDocumentationUrl(name, version)
+        : null;
       let helpText = null;
       let icon = null;
+      let iconTooltip = null;
       // TODO: verify org.nuget.* packages
       if (isNuGet) {
         helpText = t('git-deps-nuget');
         icon = "fa fa-arrow-up";
+        iconTooltip = "UnityNuGet uplink dependency";
       } else if (isGit) {
-        if (path) {
+        if (openUpmPath) {
           helpText = t("git-deps-replaced");
           icon = "fab fa-git text-warning";
+          iconTooltip = "Git dependency with package page";
         } else {
           helpText = t("git-deps-missing");
           icon = "fab fa-git text-error";
+          iconTooltip = "Git dependency without package page";
         }
-      } else if (path) {
+      } else if (openUpmPath) {
         icon = "fa fa-box-open";
+        iconTooltip = "OpenUPM package dependency";
+      } else if (unityDocumentationUrl) {
+        icon = "fab fa-unity";
+        iconTooltip = "Unity package documentation";
+        helpText = t("unity-deps-documentation");
       } else {
         helpText = t("deps-missing");
         icon = "fas fa-exclamation-triangle text-error";
+        iconTooltip = "Missing package dependency";
       }
       return {
         icon,
+        iconTooltip,
         name,
         nameWithVersion,
         helpText,
-        link: path
+        link: openUpmPath
           ? {
-            link: path,
+            link: openUpmPath,
+            text: nameWithVersion
+          }
+          : unityDocumentationUrl
+            ? {
+            link: unityDocumentationUrl,
             text: nameWithVersion
           }
           : null,
@@ -82,7 +119,9 @@ const dependencyList = computed(() => {
       </thead>
       <tbody>
         <tr v-for="entry in dependencyList" :key="entry.name">
-          <td class="td-icon"><i :class="entry.icon"></i></td>
+          <td class="td-icon">
+            <i :class="[entry.icon, 'tooltip', 'tooltip-up']" :data-tooltip="entry.iconTooltip"></i>
+          </td>
           <td class="td-name">
             <AutoLink v-if="entry.link" :item="entry.link" class="dep-text" />
             <span v-else>{{ entry.nameWithVersion }}</span>

--- a/apps/docs/docs/.vuepress/config.ts
+++ b/apps/docs/docs/.vuepress/config.ts
@@ -14,6 +14,7 @@ import { mediumZoomPlugin } from "@vuepress/plugin-medium-zoom";
 
 import OpenupmPlugin from "vuepress-plugin-openupm";
 import { blogRssPlugin } from "./blogRssPlugin";
+import { getSearchExtraFields } from "./searchExtraFields";
 
 const __dirname = getDirname(import.meta.url);
 
@@ -119,7 +120,9 @@ const config: any = mergeWith(
       registerComponentsPlugin({
         componentsDir: path.resolve(__dirname, "./components"),
       }),
-      searchPlugin({}),
+      searchPlugin({
+        getExtraFields: getSearchExtraFields,
+      }),
       OpenupmPlugin(),
       seoPlugin({
         hostname: themeConfig.domain,

--- a/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
@@ -49,6 +49,8 @@ const initState = (): State => ({
 });
 
 const state = reactive(initState());
+let packumentRequestId = 0;
+let adPlacementRequestId = 0;
 
 const packageName = computed(() => frontmatter.value.name);
 const latestVersion = computed(() =>
@@ -79,30 +81,51 @@ const resetState = (): void => {
   Object.assign(state, initState());
 };
 
+const isCurrentRequest = (
+  requestId: number,
+  latestRequestId: number,
+  requestedPackageName: string,
+): boolean =>
+  requestId === latestRequestId && requestedPackageName === packageName.value;
+
 const fetchPackument = async (): Promise<void> => {
+  const requestId = ++packumentRequestId;
+  const requestedPackageName = packageName.value;
   state.isLoading = true;
   state.isUnavailable = false;
   try {
-    const resp = await axios.get(getPackumentUrl(packageName.value), {
+    const resp = await axios.get(getPackumentUrl(requestedPackageName), {
       headers: { Accept: "application/json" },
     });
+    if (!isCurrentRequest(requestId, packumentRequestId, requestedPackageName))
+      return;
     state.packument = resp.data;
   } catch (error) {
+    if (!isCurrentRequest(requestId, packumentRequestId, requestedPackageName))
+      return;
     console.error(error);
     state.isUnavailable = true;
     state.packument = {};
   } finally {
-    state.isLoading = false;
+    if (isCurrentRequest(requestId, packumentRequestId, requestedPackageName)) {
+      state.isLoading = false;
+    }
   }
 };
 
 const fetchAdPlacementData = async (): Promise<void> => {
+  const requestId = ++adPlacementRequestId;
+  const requestedPackageName = packageName.value;
   try {
-    const resp = await axios.get(getPackageAdPlacementUrl(packageName.value), {
+    const resp = await axios.get(getPackageAdPlacementUrl(requestedPackageName), {
       headers: { Accept: "application/json" },
     });
+    if (!isCurrentRequest(requestId, adPlacementRequestId, requestedPackageName))
+      return;
     state.adPlacementDataList = resp.data as AdPlacementData[];
   } catch (error) {
+    if (!isCurrentRequest(requestId, adPlacementRequestId, requestedPackageName))
+      return;
     console.error(error);
     state.adPlacementDataList = [];
   }

--- a/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
@@ -1,0 +1,302 @@
+<script setup lang="ts">
+import axios from "axios";
+import { computed, onMounted, reactive, watch } from "vue";
+import { useRoute } from "vue-router";
+import { usePageFrontmatter } from "@vuepress/client";
+
+import ParentLayout from "@/layouts/WideLayout.vue";
+import AdsenseDisplayForPackageDetail from "@/components/AdsenseDisplayForPackageDetail.vue";
+import PackageDependenciesView from "@/components/PackageDependenciesView.vue";
+import PackageSetup from "@/components/PackageSetup.vue";
+import PackageVersionsView from "@/components/PackageVersionsView.vue";
+import UnityAssetAdPlacement from "@/components/UnityAssetAdPlacement.vue";
+import {
+  getLatestNuGetVersion,
+  getNuGetDependencies,
+  getNuGetPackageMetadata,
+  getNuGetPackageVersions,
+  getNuGetRepositoryUrl,
+  getNuGetVersionInfo,
+  NuGetPackageFrontmatter,
+} from "@/nugetPackageDetail";
+import { AdPlacementData, Packument } from "@openupm/types";
+import {
+  getPackageAdPlacementUrl,
+  getPackumentUrl,
+  isPackageDetailPath,
+} from "@openupm/common/build/urls.js";
+
+const route = useRoute();
+const frontmatter = usePageFrontmatter<NuGetPackageFrontmatter>();
+
+const packagesLink = {
+  text: "Packages",
+  link: "/packages/",
+};
+
+type State = {
+  adPlacementDataList: AdPlacementData[];
+  packument: Partial<Packument>;
+  isLoading: boolean;
+  isUnavailable: boolean;
+};
+
+const initState = (): State => ({
+  adPlacementDataList: [],
+  packument: {},
+  isLoading: true,
+  isUnavailable: false,
+});
+
+const state = reactive(initState());
+
+const packageName = computed(() => frontmatter.value.name);
+const latestVersion = computed(() =>
+  getLatestNuGetVersion(state.packument, frontmatter.value.unityNuGetVersion),
+);
+const latestVersionInfo = computed(() =>
+  getNuGetVersionInfo(state.packument, latestVersion.value),
+);
+const dependencies = computed(() =>
+  getNuGetDependencies(latestVersionInfo.value),
+);
+const versions = computed(() =>
+  getNuGetPackageVersions(state.packument, latestVersion.value),
+);
+const repositoryUrl = computed(() =>
+  getNuGetRepositoryUrl(latestVersionInfo.value),
+);
+const packageMetadata = computed(() =>
+  getNuGetPackageMetadata(packageName.value, repositoryUrl.value),
+);
+const displayName = computed(
+  () => latestVersionInfo.value.displayName || frontmatter.value.nugetId,
+);
+const description = computed(() => latestVersionInfo.value.description || "");
+const author = computed(() => latestVersionInfo.value.author || "");
+
+const resetState = (): void => {
+  Object.assign(state, initState());
+};
+
+const fetchPackument = async (): Promise<void> => {
+  state.isLoading = true;
+  state.isUnavailable = false;
+  try {
+    const resp = await axios.get(getPackumentUrl(packageName.value), {
+      headers: { Accept: "application/json" },
+    });
+    state.packument = resp.data;
+  } catch (error) {
+    console.error(error);
+    state.isUnavailable = true;
+    state.packument = {};
+  } finally {
+    state.isLoading = false;
+  }
+};
+
+const fetchAdPlacementData = async (): Promise<void> => {
+  try {
+    const resp = await axios.get(getPackageAdPlacementUrl(packageName.value), {
+      headers: { Accept: "application/json" },
+    });
+    state.adPlacementDataList = resp.data as AdPlacementData[];
+  } catch (error) {
+    console.error(error);
+    state.adPlacementDataList = [];
+  }
+};
+
+const fetchAllData = async (): Promise<void> => {
+  fetchAdPlacementData();
+  await fetchPackument();
+};
+
+onMounted(() => {
+  fetchAllData();
+});
+
+watch(
+  () => route.path,
+  (newPath) => {
+    if (isPackageDetailPath(newPath)) {
+      resetState();
+      fetchAllData();
+    }
+  },
+);
+</script>
+
+<template>
+  <ParentLayout class="nuget-package-detail">
+    <template #sidebar-top>
+      <ClientOnly>
+        <div class="nuget-sidebar-ad">
+          <AdsenseDisplayForPackageDetail />
+        </div>
+      </ClientOnly>
+    </template>
+    <template #page-content-top>
+      <ClientOnly>
+        <div class="columns columns-contentview">
+          <div class="column col-8 col-xl-8 col-lg-8 col-md-12 col-sm-12">
+            <nav aria-label="Breadcrumb">
+              <ul class="breadcrumb package-breadcrumb">
+                <li class="breadcrumb-item">
+                  <AutoLink :item="packagesLink" />
+                </li>
+                <li class="breadcrumb-item">
+                  <a href="#">{{ packageName }}</a>
+                </li>
+              </ul>
+            </nav>
+
+            <div v-if="state.isUnavailable" class="custom-container warning">
+              <p class="custom-container-title">UnityNuGet package data is unavailable</p>
+              <p>
+                This page is generated from the UnityNuGet package list, but live package data is loaded from the
+                OpenUPM registry uplink and cache. Try again after the registry cache refreshes.
+              </p>
+            </div>
+
+            <section class="package-identity">
+              <h1>{{ displayName }}</h1>
+              <p class="package-name">{{ packageName }}</p>
+              <p v-if="description" class="package-description">{{ description }}</p>
+              <dl class="identity-list">
+                <div>
+                  <dt>NuGet ID</dt>
+                  <dd>{{ frontmatter.nugetId }}</dd>
+                </div>
+                <div>
+                  <dt>Latest version</dt>
+                  <dd>{{ latestVersion || "Unavailable" }}</dd>
+                </div>
+                <div v-if="author">
+                  <dt>Author</dt>
+                  <dd>{{ author }}</dd>
+                </div>
+                <div v-if="repositoryUrl">
+                  <dt>Repository</dt>
+                  <dd><a :href="repositoryUrl">{{ repositoryUrl }}</a></dd>
+                </div>
+              </dl>
+            </section>
+            <PackageDependenciesView
+              :dependencies="dependencies"
+              :is-loading="state.isLoading"
+            />
+            <PackageVersionsView :versions="versions" :is-loading="state.isLoading" />
+          </div>
+          <div class="column column-meta col-4 col-xl-4 col-lg-4 col-md-12 col-sm-12">
+            <div class="meta-section container">
+              <div class="columns">
+                <PackageSetup
+                  :is-loading="state.isLoading"
+                  :metadata="packageMetadata"
+                  :version="latestVersion"
+                  :packument="state.packument"
+                  :scopes="['org.nuget']"
+                />
+                <section class="col-12 ad-placement-section">
+                  <template v-for="(item, index) in state.adPlacementDataList" :key="index">
+                    <UnityAssetAdPlacement :data="item" class="mb-2" />
+                  </template>
+                </section>
+                <section class="col-12 adsense-section">
+                  <AdsenseDisplayForPackageDetail />
+                </section>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ClientOnly>
+    </template>
+  </ParentLayout>
+</template>
+
+<style lang="scss">
+@use '@/styles/palette' as *;
+
+.nuget-package-detail {
+  .theme-default-content {
+    .content__default {
+      h1 {
+        display: none;
+      }
+    }
+
+    .column-meta {
+      max-width: 17rem;
+    }
+  }
+
+  .package-breadcrumb {
+    margin-bottom: 0.8rem;
+  }
+
+  .package-identity {
+    margin-bottom: 1rem;
+
+    h1 {
+      margin: 0.2rem 0 0.1rem;
+      padding-top: 0;
+    }
+
+    .package-name {
+      color: var(--c-text-light);
+      font-family: var(--font-family-code);
+      overflow-wrap: anywhere;
+    }
+
+    .package-description {
+      max-width: 42rem;
+    }
+  }
+
+  .identity-list {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 0.25rem 1rem;
+    margin: 1rem 0;
+
+    div {
+      display: contents;
+    }
+
+    dt {
+      color: var(--c-text-light);
+      font-weight: 600;
+    }
+
+    dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+  }
+}
+
+.nuget-package-detail .meta-section {
+  font-size: $font-size-md;
+  padding-left: 0.5rem;
+}
+
+.nuget-package-detail .nuget-sidebar-ad {
+  margin: 0.2rem 0.4rem 0.4rem;
+}
+
+@media (max-width: $MQMobile) {
+  .nuget-package-detail {
+    .identity-list {
+      grid-template-columns: 1fr;
+    }
+
+    .theme-default-content {
+      .column-meta {
+        max-width: 100%;
+      }
+    }
+  }
+}
+</style>

--- a/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
@@ -17,7 +17,7 @@ import { AdPlacementData, PackageMetadata, TOPIC_ALL_SLUG, Topic } from "@openup
 import { getPackageMetadata } from "@openupm/common/build/utils.js";
 import { getPackageDetailPagePath, getPackageListPagePath, isPackageListPath, getTopicAdPlacementUrl } from "@openupm/common/build/urls.js";
 import { topicsWithAll } from '@temp/topics.js';
-import { usePackageSearchSuggestions } from "@/search";
+import { isUnityNuGetPackageName, usePackageSearchSuggestions } from "@/search";
 import UnityAssetAdPlacement from '@/components/UnityAssetAdPlacementForPackageList.vue';
 import DonationSidebarAd from '@/components/DonationSidebarAd.vue';
 import UnityAssetStoreSale from '@/components/UnityAssetStoreSale.vue';
@@ -114,6 +114,7 @@ const packagePageSearchSuggestions = computed(() => {
     store.packageMetadataLocalList.map((metadata) => metadata.name),
   );
   return usePackageSearchSuggestions(searchIndex.value, searchTerm.value)
+    .filter((suggestion) => isUnityNuGetPackageName(suggestion.name))
     .filter((suggestion) => !nativePackageNames.has(suggestion.name))
     .slice(0, 20)
     .map((suggestion) => ({

--- a/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
@@ -15,7 +15,7 @@ import { SortType } from "@/constant";
 import { useDefaultStore } from '@/store';
 import { AdPlacementData, PackageMetadata, TOPIC_ALL_SLUG, Topic } from "@openupm/types";
 import { getPackageMetadata } from "@openupm/common/build/utils.js";
-import { getPackageListPagePath, isPackageListPath, getTopicAdPlacementUrl } from "@openupm/common/build/urls.js";
+import { getPackageDetailPagePath, getPackageListPagePath, isPackageListPath, getTopicAdPlacementUrl } from "@openupm/common/build/urls.js";
 import { topicsWithAll } from '@temp/topics.js';
 import { usePackageSearchSuggestions } from "@/search";
 import UnityAssetAdPlacement from '@/components/UnityAssetAdPlacementForPackageList.vue';
@@ -105,6 +105,21 @@ const metadataEntries = computed(() => {
   else if (sortType.value == SortType.downloads)
     items = orderBy(items, ["dl30d"], ["desc"]);
   return items;
+});
+
+const packagePageSearchSuggestions = computed(() => {
+  if (!searchTerm.value) return [];
+
+  const nativePackageNames = new Set(
+    store.packageMetadataLocalList.map((metadata) => metadata.name),
+  );
+  return usePackageSearchSuggestions(searchIndex.value, searchTerm.value)
+    .filter((suggestion) => !nativePackageNames.has(suggestion.name))
+    .slice(0, 20)
+    .map((suggestion) => ({
+      ...suggestion,
+      link: getPackageDetailPagePath(suggestion.name),
+    }));
 });
 
 // Store ad placement data for the current topic.
@@ -350,10 +365,30 @@ watch(() => topicSlug.value, () => {
               </div>
               <div v-else>
                 <client-only>
-                  <div v-if="!metadataEntries.length" class="no-data">
+                  <section
+                    v-if="packagePageSearchSuggestions.length"
+                    class="package-page-results"
+                  >
+                    <h2>{{ $t("unitynuget-packages") }}</h2>
+                    <ul>
+                      <li
+                        v-for="suggestion in packagePageSearchSuggestions"
+                        :key="suggestion.name"
+                      >
+                        <RouterLink :to="suggestion.link">
+                          <strong>{{ suggestion.displayName }}</strong>
+                          <small>{{ suggestion.name }}</small>
+                        </RouterLink>
+                      </li>
+                    </ul>
+                  </section>
+                  <div v-if="!metadataEntries.length && !packagePageSearchSuggestions.length" class="no-data">
                     {{ noDataAvailableText }}
                   </div>
-                  <div v-else ref="gridWrapperElement" class="grid-wrapper">
+                  <div v-if="metadataEntries.length" ref="gridWrapperElement" class="grid-wrapper">
+                    <h2 v-if="searchTerm" class="package-results-heading">
+                      {{ $t("openupm-packages") }}
+                    </h2>
                     <Grid class="grid" :length="listItems.length" :page-size="gridPageSize"
                       :page-provider="gridPageProvider" :get-key="getGridKey">
                       <template #probe>
@@ -442,6 +477,60 @@ watch(() => topicSlug.value, () => {
 @use '@/styles/palette' as *;
 
 .package-section {
+  .package-results-heading,
+  .package-page-results h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+  }
+
+  .package-results-heading {
+    margin: 0.85rem 0.4rem 0;
+  }
+
+  .package-page-results {
+    margin: 1rem 0.4rem;
+    max-width: 54rem;
+
+    ul {
+      display: grid;
+      gap: 0.5rem;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      list-style: none;
+      margin: 0;
+      padding: 0;
+
+      @media (max-width: $MQMobile) {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    a {
+      border: 1px solid $border-color;
+      border-radius: 0.25rem;
+      display: grid;
+      gap: 0.15rem;
+      min-width: 0;
+      padding: 0.45rem 0.6rem;
+    }
+
+    strong {
+      color: var(--c-text);
+      font-weight: 600;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    small {
+      color: $gray-color;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
 
   .grid-wrapper {
     height: calc(100vh - $navbar-height);

--- a/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
@@ -123,6 +123,11 @@ const packagePageSearchSuggestions = computed(() => {
     }));
 });
 
+const resultCount = computed(
+  () =>
+    metadataEntries.value.length + packagePageSearchSuggestions.value.length,
+);
+
 // Store ad placement data for the current topic.
 const adPlacementDataList = reactive([
 ] as AdPlacementData[]);
@@ -315,7 +320,7 @@ watch(() => topicSlug.value, () => {
             <li class="menu-item">
               {{ $capitalize($t("results")) }}
               <div class="menu-badge">
-                <label class="label label-default">{{ metadataEntries.length }}</label>
+                <label class="label label-default">{{ resultCount }}</label>
               </div>
             </li>
             <template v-if="searchTerm">

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -119,7 +119,10 @@ package-name-already-exists-error: The package name already exists in OpenUPM re
 package-name-blocked: The package name is blocked by scope {scope}.
 package-name-manual-verification: Major tech company package names require manual review during merge.
 package-name: Package name
+package-page-results: Package page results
 package-updates: Package Updates
+openupm-packages: OpenUPM Packages
+unitynuget-packages: UnityNuGet Packages
 packages: packages
 pending: Pending
 popularity: Popularity

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -48,6 +48,7 @@ get: Get
 git-deps-missing: Please install the Git dependency manually.
 git-deps-nuget: The package may exist in uplinked UnityNuGet registry.
 git-deps-replaced: The Git dependency can be replaced by a version available on OpenUPM.
+unity-deps-documentation: This dependency is documented by Unity.
 git-tag: Git tag
 git-tag-ignore: Git tag ignore pattern
 git-tag-ignore-desc: 'The regular expression to exclude Git tags.'

--- a/apps/docs/docs/.vuepress/nugetPackageDetail.ts
+++ b/apps/docs/docs/.vuepress/nugetPackageDetail.ts
@@ -62,7 +62,15 @@ export const getNuGetPackageVersions = (
 export const getNuGetRepositoryUrl = (
   versionInfo: NuGetPackumentVersion,
 ): string => {
-  return versionInfo.repository?.url || "";
+  const url = versionInfo.repository?.url || "";
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:")
+      return parsedUrl.href;
+  } catch {
+    return "";
+  }
+  return "";
 };
 
 export const getNuGetPackageMetadata = (

--- a/apps/docs/docs/.vuepress/nugetPackageDetail.ts
+++ b/apps/docs/docs/.vuepress/nugetPackageDetail.ts
@@ -1,0 +1,103 @@
+import { map } from "lodash-es";
+
+import {
+  PackageDependency,
+  PackageMetadata,
+  PackageVersionViewEntry,
+  Packument,
+  PackumentVersion,
+} from "@openupm/types";
+import { timeAgoFormat } from "@/utils";
+
+export type NuGetPackageFrontmatter = {
+  name: string;
+  nugetId: string;
+  unityNuGetVersion: string;
+};
+
+export type NuGetPackumentVersion = Partial<PackumentVersion> & {
+  author?: string;
+  repository?: { url?: string };
+};
+
+export const getLatestNuGetVersion = (
+  packument: Partial<Packument>,
+  fallbackVersion = "",
+): string => {
+  return packument["dist-tags"]?.latest || fallbackVersion;
+};
+
+export const getNuGetVersionInfo = (
+  packument: Partial<Packument>,
+  version: string,
+): NuGetPackumentVersion => {
+  return (version && packument.versions?.[version]) || {};
+};
+
+export const getNuGetDependencies = (
+  versionInfo: NuGetPackumentVersion,
+): PackageDependency[] => {
+  return map(versionInfo.dependencies || {}, (version, name) => ({
+    name,
+    version,
+  }));
+};
+
+export const getNuGetPackageVersions = (
+  packument: Partial<Packument>,
+  latestVersion: string,
+): PackageVersionViewEntry[] => {
+  const versions = packument.versions || {};
+  const times = packument.time || {};
+  return Object.keys(versions)
+    .reverse()
+    .map((version) => ({
+      latest: version === latestVersion,
+      timeSince: timeAgoFormat(times[version]),
+      unity: versions[version].unity,
+      version,
+    }));
+};
+
+export const getNuGetRepositoryUrl = (
+  versionInfo: NuGetPackumentVersion,
+): string => {
+  return versionInfo.repository?.url || "";
+};
+
+export const getNuGetPackageMetadata = (
+  name: string,
+  repoUrl: string,
+): PackageMetadata => {
+  return {
+    name,
+    aliases: [],
+    repoUrl,
+    displayName: "",
+    description: "",
+    licenseSpdxId: null,
+    licenseName: "",
+    topics: [],
+    owner: "",
+    ownerUrl: null,
+    repo: "",
+    parentRepoUrl: null,
+    parentRepo: null,
+    parentOwner: null,
+    parentOwnerUrl: null,
+    hunter: "",
+    hunterUrl: null,
+    createdAt: 0,
+    readmeBranch: "",
+    trackingMode: "git",
+    ver: null,
+    time: 0,
+    stars: 0,
+    pstars: 0,
+    unity: "",
+    imageFilename: null,
+    dl30d: 0,
+    repoUnavailable: false,
+    repoArchived: false,
+  };
+};

--- a/apps/docs/docs/.vuepress/search.ts
+++ b/apps/docs/docs/.vuepress/search.ts
@@ -12,6 +12,9 @@ export interface PackageSearchSuggestion {
   title: string;
 }
 
+export const isUnityNuGetPackageName = (packageName: string): boolean =>
+  packageName.startsWith("org.nuget.");
+
 export const getPackageSearchResultDisplayName = (
   pageTitle: string,
   packageName: string,

--- a/apps/docs/docs/.vuepress/search.ts
+++ b/apps/docs/docs/.vuepress/search.ts
@@ -48,7 +48,9 @@ export const normalizeSearchQuery = (query: string): string =>
   query
     .trim()
     .split(/\s+/)
-    .map((token) => token.replace(/^[^\w@.-]+|[^\w@.-]+$/g, ""))
+    .map((token) =>
+      token.replace(/^[^\p{L}\p{N}_@.-]+|[^\p{L}\p{N}_@.-]+$/gu, ""),
+    )
     .filter(Boolean)
     .join(" ");
 

--- a/apps/docs/docs/.vuepress/search.ts
+++ b/apps/docs/docs/.vuepress/search.ts
@@ -7,8 +7,47 @@ import {
 import { SearchIndex, SearchIndexItem } from "@vuepress/plugin-search";
 
 export interface PackageSearchSuggestion {
+  displayName: string;
   name: string;
+  title: string;
 }
+
+export const getPackageSearchResultDisplayName = (
+  pageTitle: string,
+  packageName: string,
+): string => {
+  const titleParts = pageTitle.split(" | ");
+  return titleParts[0]?.trim() || packageName;
+};
+
+export const getPackageSearchResultTitle = (
+  pageTitle: string,
+  packageName: string,
+): string => {
+  const displayName = getPackageSearchResultDisplayName(
+    pageTitle,
+    packageName,
+  );
+
+  if (!displayName) return packageName;
+  if (displayName === packageName) return packageName;
+  return `${displayName} | ${packageName}`;
+};
+
+export const getPackageNameFromSearchSuggestionLink = (
+  link: string,
+): string | null => {
+  const path = link.split(/[?#]/, 1)[0];
+  return parsePackageNameFromPackageDetailPath(path);
+};
+
+export const normalizeSearchQuery = (query: string): string =>
+  query
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.replace(/^[^\w@.-]+|[^\w@.-]+$/g, ""))
+    .filter(Boolean)
+    .join(" ");
 
 export const usePackageSearchSuggestions = (
   searchIndex: SearchIndex,
@@ -22,7 +61,7 @@ export const usePackageSearchSuggestions = (
     ),
   );
   // if query is empty, return empty suggestions
-  const searchStr = cleanToken(query.trim().toLowerCase());
+  const searchStr = cleanToken(normalizeSearchQuery(query).toLowerCase());
   if (!searchStr) return [];
   // search tokens
   const suggestions: PackageSearchSuggestion[] = [];
@@ -41,7 +80,12 @@ export const usePackageSearchSuggestions = (
       );
       if (packageName)
         suggestions.push({
-          name: parsePackageNameFromPackageDetailPath(searchIndexItem.path)!,
+          displayName: getPackageSearchResultDisplayName(
+            searchIndexItem.title,
+            packageName,
+          ),
+          name: packageName,
+          title: getPackageSearchResultTitle(searchIndexItem.title, packageName),
         });
       else
         console.warn(

--- a/apps/docs/docs/.vuepress/searchExtraFields.ts
+++ b/apps/docs/docs/.vuepress/searchExtraFields.ts
@@ -1,0 +1,29 @@
+import { Page } from "vuepress";
+
+export const getSearchExtraFields = (page: Page): string[] => {
+  const frontmatter = page.frontmatter;
+  if (frontmatter.packageKind !== "unitynuget") return [];
+
+  return uniqueStrings([
+    frontmatter.name,
+    frontmatter.nugetId,
+    frontmatter.description,
+  ]);
+};
+
+const uniqueStrings = (values: unknown[]): string[] => {
+  const fields: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+
+    const field = value.trim();
+    if (!field || seen.has(field)) continue;
+
+    fields.push(field);
+    seen.add(field);
+  }
+
+  return fields;
+};

--- a/apps/docs/docs/.vuepress/utils.ts
+++ b/apps/docs/docs/.vuepress/utils.ts
@@ -14,7 +14,10 @@ import { ComposerTranslation } from "vue-i18n";
  */
 export const isPackageExist = function (name: string): boolean {
   const store = useDefaultStore();
-  return name in store.packageMetadataRemoteDict;
+  return (
+    store.packageMetadataLocalList.some((metadata) => metadata.name === name) ||
+    name in store.packageMetadataRemoteDict
+  );
 };
 
 // Return time since string for the given date

--- a/apps/docs/docs/nuget/index.md
+++ b/apps/docs/docs/nuget/index.md
@@ -28,8 +28,8 @@ To improve convenience, the OpenUPM registry [uplinks](https://verdaccio.org/doc
 
 The integration comes with a few limitations:
 
-- NuGet packages are neither searchable nor browsable on the OpenUPM website.
-- Search results are served by the registry uplink and may depend on UnityNuGet availability and cache freshness. If UnityNuGet is temporarily unavailable, already cached package metadata and tarballs continue to resolve through OpenUPM, but new uncached search results may be delayed until the uplink recovers.
+- NuGet packages have generated website pages based on the UnityNuGet curated package list, but they are not shown in the normal OpenUPM package list.
+- Package page details and search results are served by the registry uplink and may depend on UnityNuGet availability and cache freshness. If UnityNuGet is temporarily unavailable, already cached package metadata and tarballs continue to resolve through OpenUPM, but new uncached package details and search results may be delayed until the uplink recovers.
 
 To demonstrate the uplinks feature, we have created a staging package at [https://github.com/openupm/com.example.nuget-consumer](https://github.com/openupm/com.example.nuget-consumer) which includes:
 

--- a/packages/vuepress-plugin-openupm/__tests__/unitynuget.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/unitynuget.test.ts
@@ -67,6 +67,9 @@ describe('UnityNuGet registry inventory', () => {
     const source = readFileSync(pluginIndexPath, 'utf8');
 
     expect(source).toContain("layout: 'NuGetPackageDetailLayout'");
+    expect(source).toContain(
+      '${entry.nugetId} | ${entry.packageName} | UnityNuGet Package | Unity Package Manager (UPM)',
+    );
     expect(source).toContain("content: ''");
     expect(source).not.toContain('UnityNuGet package.\\n');
   });

--- a/packages/vuepress-plugin-openupm/__tests__/unitynuget.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/unitynuget.test.ts
@@ -1,0 +1,73 @@
+import {
+  loadUnityNuGetRegistryInventory,
+  nugetIdToOpenUpmPackageName,
+  parseUnityNuGetRegistryInventory,
+} from '../src/unitynuget/registry.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const pluginIndexPath = fileURLToPath(new URL('../src/index.ts', import.meta.url));
+
+describe('UnityNuGet registry inventory', () => {
+  it('normalizes NuGet IDs to org.nuget package names', () => {
+    expect(nugetIdToOpenUpmPackageName('Newtonsoft.Json')).toBe(
+      'org.nuget.newtonsoft.json',
+    );
+  });
+
+  it('parses listed packages and excludes unlisted packages', () => {
+    expect(
+      parseUnityNuGetRegistryInventory({
+        'Newtonsoft.Json': { listed: true, version: '13.0.4' },
+        'System.Numerics.Vectors': { listed: false, version: '4.4.0' },
+        MissingVersion: { listed: true },
+      }),
+    ).toEqual([
+      {
+        nugetId: 'Newtonsoft.Json',
+        packageName: 'org.nuget.newtonsoft.json',
+        version: '13.0.4',
+      },
+    ]);
+  });
+
+  it('uses the checked-in snapshot when live fetch fails', async () => {
+    const warnings: string[] = [];
+    await expect(
+      loadUnityNuGetRegistryInventory({
+        fetchRegistry: async () => {
+          throw new Error('network unavailable');
+        },
+        snapshot: {
+          Akka: { listed: true, version: '1.4.1' },
+        },
+        warn: (message) => warnings.push(message),
+      }),
+    ).resolves.toEqual([
+      {
+        nugetId: 'Akka',
+        packageName: 'org.nuget.akka',
+        version: '1.4.1',
+      },
+    ]);
+    expect(warnings[0]).toContain('UnityNuGet live registry unavailable');
+  });
+
+  it('fails when live and snapshot inventories are both unavailable', async () => {
+    await expect(
+      loadUnityNuGetRegistryInventory({
+        fetchRegistry: async () => [],
+        snapshot: {},
+        warn: () => undefined,
+      }),
+    ).rejects.toThrow('checked-in snapshot is empty');
+  });
+
+  it('generates NuGet pages without Markdown content headings', () => {
+    const source = readFileSync(pluginIndexPath, 'utf8');
+
+    expect(source).toContain("layout: 'NuGetPackageDetailLayout'");
+    expect(source).toContain("content: ''");
+    expect(source).not.toContain('UnityNuGet package.\\n');
+  });
+});

--- a/packages/vuepress-plugin-openupm/__tests__/unitynuget.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/unitynuget.test.ts
@@ -1,7 +1,9 @@
 import {
+  fetchUnityNuGetRegistryInventory,
   loadUnityNuGetRegistryInventory,
   nugetIdToOpenUpmPackageName,
   parseUnityNuGetRegistryInventory,
+  UNITYNUGET_REGISTRY_URL,
 } from '../src/unitynuget/registry.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -51,6 +53,34 @@ describe('UnityNuGet registry inventory', () => {
       },
     ]);
     expect(warnings[0]).toContain('UnityNuGet live registry unavailable');
+  });
+
+  it('passes an abort signal when fetching the live registry', async () => {
+    const fetchCalls: Array<{ url: string; signal?: AbortSignal }> = [];
+
+    await expect(
+      fetchUnityNuGetRegistryInventory(async (url, init) => {
+        fetchCalls.push({ url, signal: init?.signal });
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({
+            Akka: { listed: true, version: '1.4.1' },
+          }),
+        };
+      }),
+    ).resolves.toEqual([
+      {
+        nugetId: 'Akka',
+        packageName: 'org.nuget.akka',
+        version: '1.4.1',
+      },
+    ]);
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe(UNITYNUGET_REGISTRY_URL);
+    expect(fetchCalls[0].signal).toBeInstanceOf(AbortSignal);
   });
 
   it('fails when live and snapshot inventories are both unavailable', async () => {

--- a/packages/vuepress-plugin-openupm/package.json
+++ b/packages/vuepress-plugin-openupm/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint . --ext .ts --ext .mts",
     "test": "cross-env NODE_ENV=test vitest run --config vitest.config.js",
     "prettier": "prettier --config .prettierrc --write .",
-    "test:watch": "cross-env NODE_ENV=test vitest --config vitest.config.js"
+    "test:watch": "cross-env NODE_ENV=test vitest --config vitest.config.js",
+    "unitynuget:snapshot": "node scripts/refresh-unitynuget-snapshot.mjs"
   },
   "dependencies": {
     "vue": "^3.4.19",

--- a/packages/vuepress-plugin-openupm/scripts/refresh-unitynuget-snapshot.mjs
+++ b/packages/vuepress-plugin-openupm/scripts/refresh-unitynuget-snapshot.mjs
@@ -1,0 +1,30 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+const registryUrl =
+  'https://raw.githubusercontent.com/xoofx/UnityNuGet/master/registry.json';
+const outputPath = resolve('src/unitynuget/registry-snapshot.ts');
+
+const response = await fetch(registryUrl);
+if (!response.ok) {
+  throw new Error(
+    `Failed to fetch UnityNuGet registry: ${response.status} ${response.statusText}`,
+  );
+}
+
+const registry = await response.json();
+const sortedRegistry = Object.fromEntries(
+  Object.entries(registry).sort(([a], [b]) =>
+    a.toLowerCase().localeCompare(b.toLowerCase()),
+  ),
+);
+
+const source = `export const UNITYNUGET_REGISTRY_SNAPSHOT: Record<
+  string,
+  { listed?: boolean; version?: string; [key: string]: unknown }
+> = ${JSON.stringify(sortedRegistry, null, 2)};
+`;
+
+await mkdir(dirname(outputPath), { recursive: true });
+await writeFile(outputPath, source, 'utf8');
+console.log(`Wrote ${outputPath}`);

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -229,7 +229,7 @@ const createUnityNuGetDetailPages = async function (app: App): Promise<Page[]> {
       layout: 'NuGetPackageDetailLayout',
       // Hack: use an empty element to show sidebar
       sidebar: [{ text: '', children: [] }],
-      title: `${entry.nugetId} | UnityNuGet Package | Unity Package Manager (UPM)`,
+      title: `${entry.nugetId} | ${entry.packageName} | UnityNuGet Package | Unity Package Manager (UPM)`,
       description: `${entry.nugetId} is available as ${entry.packageName} through the OpenUPM registry UnityNuGet uplink.`,
       packageKind: 'unitynuget',
       name: entry.packageName,

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -40,6 +40,10 @@ import {
   buildPackageAliasRedirects,
   mergePackageAliasRedirects,
 } from './redirects.js';
+import {
+  loadUnityNuGetRegistryInventory,
+  UnityNuGetInventoryEntry,
+} from './unitynuget/registry.js';
 import { writePublicGen } from './utils/write-file.js';
 
 type Contributor = GithubUserWithScore & {
@@ -56,6 +60,7 @@ type PluginData = {
   owners: Contributor[];
   sdpxList: License[];
   topicsWithAll: Topic[];
+  unityNuGetInventory: UnityNuGetInventoryEntry[];
 };
 
 type VuePressPlugin = {
@@ -129,6 +134,7 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
     .map(function (key) {
       return { id: key, name: spdx[key].name } as License;
     });
+  const unityNuGetInventory = await loadUnityNuGetRegistryInventory();
   return {
     blockedScopes,
     contributorProfileGithubUsers,
@@ -138,6 +144,7 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
     owners,
     sdpxList,
     topicsWithAll,
+    unityNuGetInventory,
   };
 })();
 
@@ -212,6 +219,34 @@ const createDetailPages = async function (app: App): Promise<Page[]> {
 };
 
 /**
+ * Create UnityNuGet package detail pages.
+ * @param app vuepress app
+ */
+const createUnityNuGetDetailPages = async function (app: App): Promise<Page[]> {
+  const pages: Page[] = [];
+  for (const entry of PLUGIN_DATA.unityNuGetInventory) {
+    const frontmatter = {
+      layout: 'NuGetPackageDetailLayout',
+      // Hack: use an empty element to show sidebar
+      sidebar: [{ text: '', children: [] }],
+      title: `${entry.nugetId} | UnityNuGet Package | Unity Package Manager (UPM)`,
+      description: `${entry.nugetId} is available as ${entry.packageName} through the OpenUPM registry UnityNuGet uplink.`,
+      packageKind: 'unitynuget',
+      name: entry.packageName,
+      nugetId: entry.nugetId,
+      unityNuGetVersion: entry.version,
+    };
+    const page = await createPage(app, {
+      path: getPackageDetailPagePath(entry.packageName),
+      frontmatter,
+      content: '',
+    });
+    pages.push(page);
+  }
+  return pages;
+};
+
+/**
  * Create package list pages
  * @param app vuepress app
  */
@@ -251,6 +286,7 @@ export default (): VuePressPlugin => ({
   name: 'vuepress-plugin-openupm',
   async onInitialized(app: App): Promise<void> {
     addPages(app, await createDetailPages(app));
+    addPages(app, await createUnityNuGetDetailPages(app));
     addPages(app, await createListPages(app));
     addPages(app, await createContributorProfilePages(app));
   },

--- a/packages/vuepress-plugin-openupm/src/unitynuget/registry-snapshot.ts
+++ b/packages/vuepress-plugin-openupm/src/unitynuget/registry-snapshot.ts
@@ -1,0 +1,2224 @@
+export const UNITYNUGET_REGISTRY_SNAPSHOT: Record<
+  string,
+  { listed?: boolean; version?: string; [key: string]: unknown }
+> = {
+  "AdysTech.CredentialManager": {
+    "listed": true,
+    "version": "2.3.0"
+  },
+  "Akka": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Analyzers": {
+    "listed": true,
+    "version": "0.1.1",
+    "analyzer": true
+  },
+  "Akka.Cluster": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Cluster.Hosting": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "Akka.Cluster.Sharding": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Cluster.Tools": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Coordination": {
+    "listed": true,
+    "version": "1.4.4"
+  },
+  "Akka.DependencyInjection": {
+    "listed": true,
+    "version": "1.4.15"
+  },
+  "Akka.Discovery": {
+    "listed": true,
+    "version": "1.4.29"
+  },
+  "Akka.DistributedData": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.DistributedData.LightningDB": {
+    "listed": true,
+    "version": "1.5.0"
+  },
+  "Akka.Hosting": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "Akka.Persistence": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Persistence.Hosting": {
+    "listed": true,
+    "version": "0.3.3"
+  },
+  "Akka.Remote": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Remote.Hosting": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "Akka.Streams": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Antlr4.Runtime.Standard": {
+    "listed": true,
+    "version": "4.9.1"
+  },
+  "Apache.Arrow": {
+    "listed": true,
+    "version": "10.0.0"
+  },
+  "Apache.Arrow.Compression": {
+    "listed": true,
+    "version": "12.0.0"
+  },
+  "Apache.Arrow.Scalars": {
+    "listed": true,
+    "version": "23.0.0"
+  },
+  "Args": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "Asmodat.Standard.SSH.NET": {
+    "listed": true,
+    "version": "[1.0.0,1.0.0.1]"
+  },
+  "AsyncAwaitBestPractices": {
+    "listed": true,
+    "version": "4.0.1"
+  },
+  "AsyncAwaitBestPractices.MVVM": {
+    "listed": true,
+    "version": "5.0.2"
+  },
+  "AsyncIO": {
+    "listed": true,
+    "version": "0.1.69"
+  },
+  "AsyncKeyedLock": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "AutoMapper": {
+    "listed": true,
+    "version": "7.0.1"
+  },
+  "AutoMapper.Extensions.Microsoft.DependencyInjection": {
+    "listed": true,
+    "version": "3.0.1"
+  },
+  "AutomaticGraphLayout": {
+    "listed": true,
+    "version": "1.1.4.3"
+  },
+  "AWSSDK.Core": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "AWSSDK.S3": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "AWSSDK.SecurityToken": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "Ben.Demystifier": {
+    "listed": true,
+    "version": "0.0.43"
+  },
+  "BinaryEx": {
+    "listed": true,
+    "version": "0.3.0"
+  },
+  "BouncyCastle.Cryptography": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Boxed.Mapping": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "BugSplatDotNetStandard": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Castle.Core": {
+    "listed": true,
+    "version": "5.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "CircularBuffer": {
+    "listed": true,
+    "version": "1.0.2"
+  },
+  "CliWrap": {
+    "listed": true,
+    "version": "1.5.2"
+  },
+  "ClosedXML": {
+    "listed": true,
+    "version": "0.104.2"
+  },
+  "ClosedXML.Parser": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Constants.CollectionPool": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.Constants.DefaultRandom": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Constants.NoOp": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Constants.ValueEquivalentStrings": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.CommonMathOps": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IComparable.ClampToRange": {
+    "listed": true,
+    "version": "1.3.0"
+  },
+  "CLSS.ExtensionMethods.IComparable.InRange": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IDictionary.GetOrAdd": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IDictionary.MoveKey": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IDictionary.RemoveAndProcess": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IDictionary.SwapKeys": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IEnumerable.ForEach": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IEnumerable.Looping": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IEnumerable.MinMaxBy": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IEnumerator.LoopNext": {
+    "listed": true,
+    "version": "1.0.1"
+  },
+  "CLSS.ExtensionMethods.IList.ExclusiveSample": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.FillBy": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.FirstLastIndex": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.GetLoopingElementAt": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.GetRandom": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.GetWeightedRandom": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.RemoveAndProcess": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.Shuffle": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.SwapIndices": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.Object.As": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.Object.Is": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.Object.ToStringFormattedBy": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.Pipe": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.Reference.Action.Once": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.String.AsEnum": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.AgnosticObjectPool": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.Types.EventLatch": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.MemoizedFunc": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.Reference": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.SortedAction": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.ValueRange": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.WeightedSampler": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "codecracker.CSharp": {
+    "listed": true,
+    "version": "1.1.0",
+    "analyzer": true
+  },
+  "com.IvanMurzak.ReflectorNet": {
+    "listed": true,
+    "version": "0.1.12"
+  },
+  "CommandLineParser": {
+    "listed": true,
+    "version": "2.4.0"
+  },
+  "CommunityToolkit.HighPerformance": {
+    "listed": true,
+    "version": "7.0.1"
+  },
+  "CommunityToolkit.Mvvm": {
+    "listed": true,
+    "version": "7.0.1"
+  },
+  "ComradeVanti.CSharpTools.Opt": {
+    "listed": true,
+    "version": "1.0.2"
+  },
+  "ComradeVanti.CSharpTools.Res": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CoreAudio": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "Coroutine.NET": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CSharpFunctionalExtensions": {
+    "listed": true,
+    "version": "2.40.3"
+  },
+  "CsvHelper": {
+    "listed": true,
+    "version": "32.0.0"
+  },
+  "Dapplo.Log": {
+    "listed": true,
+    "version": "1.3.17"
+  },
+  "Dapplo.Windows.Common": {
+    "listed": true,
+    "version": "1.0.26"
+  },
+  "Dapplo.Windows.Input": {
+    "listed": true,
+    "version": "1.0.26"
+  },
+  "Dapplo.Windows.Messages": {
+    "listed": true,
+    "version": "1.0.26"
+  },
+  "Dapplo.Windows.User32": {
+    "listed": true,
+    "version": "1.0.26"
+  },
+  "Dev.ComradeVanti.Nothing": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "DnsClient": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "DocumentFormat.OpenXml": {
+    "listed": true,
+    "version": "2.10.0"
+  },
+  "DocumentFormat.OpenXml.Framework": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "DotNetty.Buffers": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Codecs": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Common": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Handlers": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Transport": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "Duende.IdentityModel": {
+    "listed": true,
+    "version": "7.0.0"
+  },
+  "Duende.IdentityModel.OidcClient": {
+    "listed": true,
+    "version": "6.0.0"
+  },
+  "Eflatun.Expansions": {
+    "listed": true,
+    "version": "0.0.1"
+  },
+  "Elasticsearch.Net": {
+    "listed": true,
+    "version": "6.3.0"
+  },
+  "EnvironmentAbstractions": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "EnvironmentAbstractions.TestHelpers": {
+    "listed": true,
+    "version": "2.1.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "ErrorProne.NET.CoreAnalyzers": {
+    "listed": true,
+    "version": "0.1.2",
+    "analyzer": true
+  },
+  "ErrorProne.NET.Structs": {
+    "listed": true,
+    "version": "0.1.2",
+    "analyzer": true
+  },
+  "ExcelDataReader": {
+    "listed": true,
+    "version": "3.0.0",
+    "analyzer": true
+  },
+  "ExcelDataReader.DataSet": {
+    "listed": true,
+    "version": "3.0.0",
+    "analyzer": true
+  },
+  "ExcelNumberFormat": {
+    "listed": false,
+    "version": "1.0.6"
+  },
+  "Faker.Net": {
+    "listed": true,
+    "version": "1.3.56"
+  },
+  "FastEnum": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "FastMember": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "FastMember.Signed": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "FirebaseAdmin": {
+    "listed": true,
+    "version": "1.7.0"
+  },
+  "FlipBinding.CSharp": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "FluentAssertions": {
+    "listed": true,
+    "version": "5.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "FluentResults": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "FluentValidation": {
+    "listed": true,
+    "version": "7.3.0"
+  },
+  "FluentValidation.DependencyInjectionExtensions": {
+    "listed": true,
+    "version": "8.2.2"
+  },
+  "GeneticSharp": {
+    "listed": true,
+    "version": "[2.0.0,3.0.0)"
+  },
+  "GeoTimeZone": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Google.Api.CommonProtos": {
+    "listed": true,
+    "version": "1.7.0"
+  },
+  "Google.Api.Gax": {
+    "listed": true,
+    "version": "2.7.0"
+  },
+  "Google.Api.Gax.Grpc": {
+    "listed": true,
+    "version": "2.7.0"
+  },
+  "Google.Api.Gax.Grpc.GrpcCore": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Google.Api.Gax.Rest": {
+    "listed": false,
+    "version": "2.7.0"
+  },
+  "Google.Apis": {
+    "listed": true,
+    "version": "1.35.0"
+  },
+  "Google.Apis.AndroidPublisher.v3": {
+    "listed": true,
+    "version": "1.66.0.3324"
+  },
+  "Google.Apis.Auth": {
+    "listed": true,
+    "version": "1.35.0"
+  },
+  "Google.Apis.Core": {
+    "listed": true,
+    "version": "1.35.0"
+  },
+  "Google.Apis.Drive.v3": {
+    "listed": true,
+    "version": "1.35.1.1312"
+  },
+  "Google.Apis.Script.v1": {
+    "listed": true,
+    "version": "1.35.1.1314"
+  },
+  "Google.Apis.Sheets.v4": {
+    "listed": true,
+    "version": "1.70.0.3819"
+  },
+  "Google.Cloud.Firestore": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Google.Cloud.Firestore.Admin.V1": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Google.Cloud.Firestore.V1": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Google.Cloud.Location": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Google.FlatBuffers": {
+    "listed": true,
+    "version": "22.9.24"
+  },
+  "Google.LongRunning": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Google.Protobuf": {
+    "listed": true,
+    "version": "3.8.0"
+  },
+  "GraphQL.Client": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "GraphQL.Client.Abstractions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "GraphQL.Client.Abstractions.Websocket": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "GraphQL.Client.Serializer.Newtonsoft": {
+    "listed": true,
+    "version": "3.1.9"
+  },
+  "GraphQL.Client.Serializer.SystemTextJson": {
+    "listed": true,
+    "version": "3.1.9"
+  },
+  "GraphQL.Common": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "GraphQL.Primitives": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Grpc.Auth": {
+    "listed": true,
+    "version": "1.20.0"
+  },
+  "Grpc.Core": {
+    "listed": true,
+    "version": "1.20.0"
+  },
+  "Grpc.Core.Api": {
+    "listed": true,
+    "version": "1.20.0"
+  },
+  "Grpc.Net.Client": {
+    "listed": true,
+    "version": "2.36.0"
+  },
+  "Grpc.Net.Client.Web": {
+    "listed": true,
+    "version": "2.36.0"
+  },
+  "Grpc.Net.ClientFactory": {
+    "listed": true,
+    "version": "2.37.0"
+  },
+  "Grpc.Net.Common": {
+    "listed": true,
+    "version": "2.36.0"
+  },
+  "H.InputSimulator": {
+    "listed": true,
+    "version": "1.0.8",
+    "defineConstraints": [
+      "UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN"
+    ]
+  },
+  "HarmonyX": {
+    "listed": true,
+    "version": "2.0.2",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "HtmlAgilityPack": {
+    "listed": true,
+    "version": "1.5.3"
+  },
+  "Humanizer.Core": {
+    "listed": true,
+    "version": "2.3.2"
+  },
+  "Hyperion": {
+    "listed": true,
+    "version": "0.9.9"
+  },
+  "ICSharpCode.Decompiler": {
+    "listed": true,
+    "version": "6.0.0.5836",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "IdentityModel": {
+    "listed": true,
+    "version": "2.13.0",
+    "includeUnlisted": true
+  },
+  "IdentityModel.OidcClient": {
+    "listed": true,
+    "version": "2.3.0",
+    "includeUnlisted": true
+  },
+  "IDisposableAnalyzers": {
+    "listed": true,
+    "version": "[1.0.0,4.0.4]",
+    "analyzer": true
+  },
+  "IndexRange": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Injecter": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Irony": {
+    "listed": true,
+    "version": "1.5.0"
+  },
+  "Jdenticon-net": {
+    "listed": true,
+    "version": "2.2.0"
+  },
+  "JsonSubTypes": {
+    "listed": true,
+    "version": "1.4.0"
+  },
+  "Jurassic": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "JWT": {
+    "listed": true,
+    "version": "5.2.0"
+  },
+  "K4os.Compression.LZ4": {
+    "listed": true,
+    "version": "1.0.2"
+  },
+  "K4os.Compression.LZ4.Streams": {
+    "listed": true,
+    "version": "1.0.2"
+  },
+  "K4os.Hash.xxHash": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Kdl.NetStandard.x64": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "KeepAChangeLogParser": {
+    "listed": true,
+    "version": "1.2.7"
+  },
+  "LightningDB": {
+    "listed": true,
+    "version": "0.11.0"
+  },
+  "LiteDB": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "LiteDB.Async": {
+    "listed": true,
+    "version": "0.0.1"
+  },
+  "LiteDb.Extensions.Caching": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "log4net": {
+    "listed": true,
+    "version": "2.0.10"
+  },
+  "MasterMemory": {
+    "listed": true,
+    "version": "3.0.1"
+  },
+  "MasterMemory.Annotations": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "MathNet.Numerics": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "McMaster.Extensions.CommandLineUtils": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "MedallionShell": {
+    "listed": true,
+    "version": "1.6.0"
+  },
+  "MemoryPools": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "MemoryPools.Collections": {
+    "listed": true,
+    "version": "1.0.0.1"
+  },
+  "MessagePack": {
+    "listed": true,
+    "version": "1.7.0"
+  },
+  "MessagePack.Annotations": {
+    "listed": true,
+    "version": "2.0.323"
+  },
+  "MessagePackAnalyzer": {
+    "listed": true,
+    "version": "2.5.187",
+    "analyzer": true
+  },
+  "MessagePipe": {
+    "listed": true,
+    "version": "0.0.1"
+  },
+  "Meziantou.Analyzer": {
+    "listed": true,
+    "version": "1.0.349",
+    "analyzer": true
+  },
+  "Microsoft.AspNetCore.Connections.Abstractions": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "Microsoft.AspNetCore.Http.Connections.Client": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.AspNetCore.Http.Connections.Common": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.AspNetCore.Http.Features": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.AspNetCore.SignalR.Client": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.AspNetCore.SignalR.Client.Core": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.AspNetCore.SignalR.Common": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.AspNetCore.SignalR.Protocols.Json": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Microsoft.Azure.Kinect.Sensor": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "Microsoft.Bcl.AsyncInterfaces": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.Bcl.Cryptography": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Microsoft.Bcl.HashCode": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Microsoft.Bcl.Memory": {
+    "listed": true,
+    "version": "9.0.0"
+  },
+  "Microsoft.Bcl.TimeProvider": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Microsoft.CodeAnalysis.Analyzers": {
+    "listed": true,
+    "version": "3.0.0",
+    "analyzer": true
+  },
+  "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+    "listed": true,
+    "version": "2.9.0",
+    "analyzer": true
+  },
+  "Microsoft.CodeAnalysis.Common": {
+    "listed": true,
+    "version": "3.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "Microsoft.CodeAnalysis.CSharp": {
+    "listed": true,
+    "version": "3.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "Microsoft.CodeAnalysis.CSharp.Scripting": {
+    "listed": true,
+    "version": "3.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "Microsoft.CodeAnalysis.NetAnalyzers": {
+    "listed": true,
+    "version": "5.0.3",
+    "analyzer": true
+  },
+  "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
+    "listed": true,
+    "version": "2.9.0",
+    "analyzer": true
+  },
+  "Microsoft.CodeAnalysis.Scripting": {
+    "listed": true,
+    "version": "3.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "Microsoft.CodeAnalysis.Scripting.Common": {
+    "listed": true,
+    "version": "3.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "Microsoft.CSharp": {
+    "ignore": true
+  },
+  "Microsoft.Data.Sqlite.Core": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.DotNet.PlatformAbstractions": {
+    "listed": true,
+    "version": "3.1.0",
+    "analyzer": true
+  },
+  "Microsoft.EntityFrameworkCore": {
+    "listed": true,
+    "version": "[3.1.0,6.0.0)"
+  },
+  "Microsoft.EntityFrameworkCore.Abstractions": {
+    "listed": true,
+    "version": "[3.1.0,6.0.0)"
+  },
+  "Microsoft.EntityFrameworkCore.Analyzers": {
+    "listed": true,
+    "version": "[3.1.0,6.0.0)"
+  },
+  "Microsoft.EntityFrameworkCore.Proxies": {
+    "listed": true,
+    "version": "[3.1.0,6.0.0)"
+  },
+  "Microsoft.EntityFrameworkCore.Relational": {
+    "listed": true,
+    "version": "[3.1.0,6.0.0)"
+  },
+  "Microsoft.EntityFrameworkCore.Sqlite": {
+    "listed": true,
+    "version": "[3.1.0,6.0.0)"
+  },
+  "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+    "listed": true,
+    "version": "[3.1.0,6.0.0)"
+  },
+  "Microsoft.Extensions.AI.Abstractions": {
+    "listed": true,
+    "version": "9.5.0"
+  },
+  "Microsoft.Extensions.AmbientMetadata.Application": {
+    "listed": true,
+    "version": "9.8.0"
+  },
+  "Microsoft.Extensions.Caching.Abstractions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Caching.Memory": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Compliance.Abstractions": {
+    "listed": true,
+    "version": "9.0.0"
+  },
+  "Microsoft.Extensions.Configuration": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.Abstractions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.Binder": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.CommandLine": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.FileExtensions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.Ini": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.Json": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.NewtonsoftJson": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Microsoft.Extensions.Configuration.UserSecrets": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Configuration.Xml": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.DependencyInjection": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.DependencyInjection.Abstractions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+    "listed": true,
+    "version": "9.8.0"
+  },
+  "Microsoft.Extensions.DependencyModel": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Microsoft.Extensions.Diagnostics": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Microsoft.Extensions.Diagnostics.Abstractions": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+    "listed": true,
+    "version": "9.8.0"
+  },
+  "Microsoft.Extensions.Diagnostics.HealthChecks": {
+    "listed": true,
+    "version": "2.2.0"
+  },
+  "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+    "listed": true,
+    "version": "2.2.0"
+  },
+  "Microsoft.Extensions.Diagnostics.Testing": {
+    "listed": true,
+    "version": "9.8.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "Microsoft.Extensions.Features": {
+    "listed": true,
+    "version": "6.0.0"
+  },
+  "Microsoft.Extensions.FileProviders.Abstractions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.FileProviders.Composite": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.FileProviders.Physical": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.FileSystemGlobbing": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Hosting": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "Microsoft.Extensions.Hosting.Abstractions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Http": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "Microsoft.Extensions.Http.Diagnostics": {
+    "listed": true,
+    "version": "9.8.0"
+  },
+  "Microsoft.Extensions.Http.Polly": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "Microsoft.Extensions.Http.Resilience": {
+    "listed": true,
+    "version": "9.8.0"
+  },
+  "Microsoft.Extensions.Localization.Abstractions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Logging": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Logging.Abstractions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Logging.Configuration": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Logging.Console": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Logging.Debug": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Logging.EventLog": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "Microsoft.Extensions.Logging.EventSource": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Logging.Log4Net.AspNetCore": {
+    "listed": true,
+    "version": "2.0.1"
+  },
+  "Microsoft.Extensions.Logging.TraceSource": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.ObjectPool": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Options": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Options.ConfigurationExtensions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Options.DataAnnotations": {
+    "listed": true,
+    "version": "2.2.0"
+  },
+  "Microsoft.Extensions.Primitives": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Microsoft.Extensions.Resilience": {
+    "listed": true,
+    "version": "9.8.0"
+  },
+  "Microsoft.Extensions.Telemetry": {
+    "listed": true,
+    "version": "9.8.0"
+  },
+  "Microsoft.Extensions.Telemetry.Abstractions": {
+    "listed": true,
+    "version": "9.8.0"
+  },
+  "Microsoft.Identity.Abstractions": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "Microsoft.IdentityModel.Abstractions": {
+    "listed": true,
+    "version": "6.18.0"
+  },
+  "Microsoft.IdentityModel.JsonWebTokens": {
+    "listed": true,
+    "version": "5.3.0"
+  },
+  "Microsoft.IdentityModel.Logging": {
+    "listed": true,
+    "version": "5.3.0"
+  },
+  "Microsoft.IdentityModel.Tokens": {
+    "listed": true,
+    "version": "5.3.0"
+  },
+  "Microsoft.IO.RecyclableMemoryStream": {
+    "listed": true,
+    "version": "1.4.0"
+  },
+  "Microsoft.NET.StringTools": {
+    "listed": true,
+    "version": "[1.0.0]"
+  },
+  "Microsoft.NETCore.Platforms": {
+    "ignore": true
+  },
+  "Microsoft.Unity.Analyzers": {
+    "listed": true,
+    "version": "1.7.0",
+    "analyzer": true
+  },
+  "Microsoft.VisualStudio.Threading.Analyzers": {
+    "listed": true,
+    "version": "16.3.13",
+    "analyzer": true
+  },
+  "Microsoft.Win32.Registry": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "MimeTypeMapOfficial": {
+    "listed": true,
+    "version": "1.0.8"
+  },
+  "MiniExcel": {
+    "listed": true,
+    "version": "0.2.0"
+  },
+  "ModelContextProtocol": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "ModelContextProtocol.Core": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "MongoDB.Bson": {
+    "listed": true,
+    "version": "2.11.0"
+  },
+  "MongoDB.Driver": {
+    "listed": true,
+    "version": "2.11.0"
+  },
+  "MongoDB.Driver.Core": {
+    "listed": true,
+    "version": "2.11.0"
+  },
+  "MongoDB.Driver.GridFS": {
+    "listed": true,
+    "version": "2.11.0"
+  },
+  "MongoDB.Libmongocrypt": {
+    "listed": true,
+    "version": "1.12.0"
+  },
+  "Mono.Cecil": {
+    "listed": true,
+    "version": "0.11.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "MonoMod.Backports": {
+    "listed": true,
+    "version": "1.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "MonoMod.Core": {
+    "listed": true,
+    "version": "1.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "MonoMod.ILHelpers": {
+    "listed": true,
+    "version": "1.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "MonoMod.RuntimeDetour": {
+    "listed": true,
+    "version": "18.11.9.9",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "MonoMod.Utils": {
+    "listed": true,
+    "version": "18.11.9.9",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "Moq": {
+    "listed": true,
+    "version": "4.11.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "morelinq": {
+    "listed": true,
+    "version": "2.7.0"
+  },
+  "MQTTnet": {
+    "listed": true,
+    "version": "2.5.1"
+  },
+  "MQTTnet.Extensions.ManagedClient": {
+    "listed": true,
+    "version": "4.0.0.167"
+  },
+  "MumbleSharp": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "NaCl.Net": {
+    "listed": true,
+    "version": "0.1.12"
+  },
+  "NAudio.Core": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "NAudio.Wasapi": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "NAudio.WinMM": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "NeoSmart.Caching.Sqlite": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "NetMQ": {
+    "listed": true,
+    "version": "4.0.0.207"
+  },
+  "NETStandard.Library": {
+    "ignore": true
+  },
+  "NetTopologySuite": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Newtonsoft.Json": {
+    "listed": true,
+    "version": "11.0.1"
+  },
+  "NLog": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "NSubstitute": {
+    "listed": true,
+    "version": "4.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "NSubstitute.Analyzers.CSharp": {
+    "listed": true,
+    "version": "1.0.15",
+    "analyzer": true
+  },
+  "NUnit.Analyzers": {
+    "listed": true,
+    "version": "[2.0.0,3.9.0]",
+    "analyzer": true
+  },
+  "ObservableCollections": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "ObservableCollections.R3": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "OneOf": {
+    "listed": true,
+    "version": "3.0.205"
+  },
+  "OpenSearch.Net": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "OpenTelemetry": {
+    "listed": true,
+    "version": "1.0.1"
+  },
+  "OpenTelemetry.Api": {
+    "listed": true,
+    "version": "1.0.1"
+  },
+  "OpenTelemetry.Api.ProviderBuilderExtensions": {
+    "listed": true,
+    "version": "1.4.0"
+  },
+  "OpenTelemetry.Extensions.Hosting": {
+    "listed": true,
+    "version": "1.4.0"
+  },
+  "OpenTelemetry.Instrumentation.Http": {
+    "listed": true,
+    "version": "1.6.0"
+  },
+  "Parse": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "PcgRandom": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "PlaceframeApiClient": {
+    "listed": true,
+    "version": "0.1.3"
+  },
+  "PlaceframeZedClient": {
+    "listed": true,
+    "version": "0.1.3"
+  },
+  "Polly": {
+    "listed": true,
+    "version": "6.0.1"
+  },
+  "Polly.Contrib.WaitAndRetry": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Polly.Core": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Polly.Extensions": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Polly.Extensions.Http": {
+    "listed": true,
+    "version": "2.0.1"
+  },
+  "Polly.RateLimiting": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Portable.BouncyCastle": {
+    "listed": true,
+    "version": "1.8.1.3"
+  },
+  "Portable.System.DateTimeOnly": {
+    "listed": true,
+    "version": "6.0.0"
+  },
+  "Prism.Container.Abstractions": {
+    "listed": true,
+    "version": "9.0.88"
+  },
+  "Prism.Core": {
+    "listed": true,
+    "version": "7.0.0.362"
+  },
+  "Prism.Events": {
+    "listed": true,
+    "version": "9.0.537"
+  },
+  "ProcessX": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "ProgressStream": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "ProjNET": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "protobuf-net": {
+    "listed": true,
+    "version": "2.3.6"
+  },
+  "protobuf-net.Core": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "protobuf-net.Grpc": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "protobuf-net.Grpc.ClientFactory": {
+    "listed": true,
+    "version": "1.0.177"
+  },
+  "pythonnet": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "QuikGraph": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "R3": {
+    "listed": true,
+    "version": "0.0.3"
+  },
+  "Raffinert.FuzzySharp": {
+    "listed": true,
+    "version": "2.0.3"
+  },
+  "RBush": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "RBush.Signed": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "Reactive.Streams": {
+    "listed": true,
+    "version": "1.0.3"
+  },
+  "ReactiveProperty": {
+    "listed": true,
+    "version": "5.0.0"
+  },
+  "ReactiveProperty.Core": {
+    "listed": true,
+    "version": "7.0.0"
+  },
+  "RestSharp": {
+    "listed": true,
+    "version": "106.0.0"
+  },
+  "RestSharp.Serializers.NewtonsoftJson": {
+    "listed": true,
+    "version": "106.10.0"
+  },
+  "RestSharp.Serializers.SystemTextJson": {
+    "listed": true,
+    "version": "106.10.0"
+  },
+  "Rhino3dm": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "RichardSzalay.MockHttp": {
+    "listed": true,
+    "version": "5.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "Robots": {
+    "listed": true,
+    "version": "1.1.7"
+  },
+  "Roslynator.Analyzers": {
+    "listed": true,
+    "version": "1.2.0",
+    "analyzer": true
+  },
+  "Roslynator.CodeAnalysis.Analyzers": {
+    "listed": true,
+    "version": "1.0.0",
+    "analyzer": true
+  },
+  "Roslynator.CodeFixes": {
+    "listed": true,
+    "version": "4.10.0",
+    "analyzer": true
+  },
+  "Roslynator.Formatting.Analyzers": {
+    "listed": true,
+    "version": "1.0.0",
+    "analyzer": true
+  },
+  "Roslynator.Refactorings": {
+    "listed": true,
+    "version": "4.10.0",
+    "analyzer": true
+  },
+  "RSG.Promise": {
+    "listed": true,
+    "version": "3.0.1"
+  },
+  "runtime.native.System.Data.SqlClient.sni": {
+    "ignore": true
+  },
+  "Scriban": {
+    "listed": true,
+    "version": "1.2.4"
+  },
+  "Scrutor": {
+    "listed": true,
+    "version": "3.0.1"
+  },
+  "Semver": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "Serialization.NET": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Serialize.Linq": {
+    "listed": true,
+    "version": "1.7.0"
+  },
+  "Serilog": {
+    "listed": true,
+    "version": "2.8.0"
+  },
+  "Serilog.Enrichers.AssemblyName": {
+    "listed": true,
+    "version": "1.0.6"
+  },
+  "Serilog.Enrichers.Context": {
+    "listed": true,
+    "version": "4.6.5"
+  },
+  "Serilog.Enrichers.Demystifier": {
+    "listed": true,
+    "version": "0.9.0"
+  },
+  "Serilog.Enrichers.Environment": {
+    "listed": true,
+    "version": "2.2.0"
+  },
+  "Serilog.Enrichers.GlobalLogContext": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Serilog.Enrichers.Memory": {
+    "listed": true,
+    "version": "1.0.4"
+  },
+  "Serilog.Enrichers.Process": {
+    "listed": true,
+    "version": "2.0.2"
+  },
+  "Serilog.Enrichers.Thread": {
+    "listed": true,
+    "version": "3.1.0"
+  },
+  "Serilog.Expressions": {
+    "listed": true,
+    "version": "3.2.1"
+  },
+  "Serilog.Extensions.Hosting": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Serilog.Extensions.Logging": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Serilog.Formatting.Compact": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "Serilog.Formatting.Elasticsearch": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Serilog.Formatting.OpenSearch": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Serilog.Settings.Configuration": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Serilog.Sinks.Async": {
+    "listed": true,
+    "version": "1.4.0"
+  },
+  "Serilog.Sinks.Console": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "Serilog.Sinks.Debug": {
+    "listed": true,
+    "version": "1.0.1"
+  },
+  "Serilog.Sinks.Elasticsearch": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Serilog.Sinks.File": {
+    "listed": true,
+    "version": "4.1.0"
+  },
+  "Serilog.Sinks.Graylog": {
+    "listed": true,
+    "version": "1.1.89"
+  },
+  "Serilog.Sinks.OpenSearch": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Serilog.Sinks.PeriodicBatching": {
+    "listed": true,
+    "version": "2.2.0"
+  },
+  "Serilog.Sinks.Trace": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "SharpCompress": {
+    "listed": true,
+    "version": "0.19.0"
+  },
+  "SharpYaml": {
+    "listed": true,
+    "version": "1.6.4"
+  },
+  "SharpZipLib": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "SixLabors.Fonts": {
+    "listed": true,
+    "version": "[1.0.0,2.0.0)"
+  },
+  "SixLabors.ImageSharp": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "SixLabors.ImageSharp.Drawing": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Snappier": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "SonarAnalyzer.CSharp": {
+    "listed": true,
+    "version": "8.30.0.37606",
+    "analyzer": true
+  },
+  "SourceCraftCommunity.SimplifiedCSharp": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "SourceGear.sqlite3": {
+    "listed": true,
+    "version": "3.50.3"
+  },
+  "Sovran.NET": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "SQLitePCLRaw.bundle_e_sqlite3": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "SQLitePCLRaw.bundle_green": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "SQLitePCLRaw.bundle_sqlite3": {
+    "listed": true,
+    "version": "2.0.4"
+  },
+  "SQLitePCLRaw.config.e_sqlite3": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "SQLitePCLRaw.core": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "SQLitePCLRaw.lib.e_sqlite3": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "SQLitePCLRaw.provider.e_sqlite3": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "SQLitePCLRaw.provider.sqlite3": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "SSH.NET": {
+    "listed": true,
+    "version": "2020.0.0"
+  },
+  "SshNet.Security.Cryptography": {
+    "listed": true,
+    "version": "1.3.0"
+  },
+  "Stateless": {
+    "listed": true,
+    "version": "4.3.0"
+  },
+  "StrongInject": {
+    "listed": true,
+    "version": "1.0.0",
+    "analyzer": true
+  },
+  "StrongInject.Extensions.DependencyInjection": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "StyleCop.Analyzers": {
+    "listed": true,
+    "version": "1.0.0",
+    "analyzer": true,
+    "includePrerelease": true
+  },
+  "StyleCop.Analyzers.Unstable": {
+    "listed": true,
+    "version": "1.1.0.47",
+    "analyzer": true
+  },
+  "SunCalcNet": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "Sylvan.Data.Csv": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "System.Buffers": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.CodeDom": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Collections.Immutable": {
+    "listed": true,
+    "version": "1.4.0"
+  },
+  "System.CommandLine": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "System.ComponentModel.Annotations": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Configuration.ConfigurationManager": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Data.SqlClient": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Diagnostics.DiagnosticSource": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.Diagnostics.EventLog": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.Drawing.Common": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.Formats.Asn1": {
+    "listed": true,
+    "version": "5.0.0"
+  },
+  "System.IdentityModel.Tokens.Jwt": {
+    "listed": true,
+    "version": "5.3.0"
+  },
+  "System.Interactive.Async": {
+    "listed": true,
+    "version": "3.2.0"
+  },
+  "System.IO.Abstractions": {
+    "listed": true,
+    "version": "22.0.9"
+  },
+  "System.IO.FileSystem.AccessControl": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.IO.Hashing": {
+    "listed": false,
+    "version": "6.0.0"
+  },
+  "System.IO.Packaging": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.IO.Pipelines": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.Linq.Async": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "System.Linq.AsyncEnumerable": {
+    "listed": true,
+    "version": "10.0.0"
+  },
+  "System.Management": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.Memory": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.Net.Http.WinHttpHandler": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Net.ServerSentEvents": {
+    "listed": true,
+    "version": "9.0.0"
+  },
+  "System.Numerics.Vectors": {
+    "listed": false,
+    "version": "4.4.0"
+  },
+  "System.Private.ServiceModel": {
+    "listed": false,
+    "version": "4.6.0"
+  },
+  "System.Reactive": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "System.Reflection.DispatchProxy": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Reflection.Emit": {
+    "listed": true,
+    "version": "4.6.0"
+  },
+  "System.Reflection.Emit.ILGeneration": {
+    "listed": true,
+    "version": "4.6.0"
+  },
+  "System.Reflection.Emit.Lightweight": {
+    "listed": true,
+    "version": "4.6.0"
+  },
+  "System.Reflection.Metadata": {
+    "listed": true,
+    "version": "1.5.0"
+  },
+  "System.Reflection.TypeExtensions": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Runtime.CompilerServices.Unsafe": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Runtime.InteropServices.WindowsRuntime": {
+    "listed": false,
+    "version": "4.3.0",
+    "ignore": true
+  },
+  "System.Security.AccessControl": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Security.Cryptography.Cng": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Security.Cryptography.Pkcs": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Security.Cryptography.ProtectedData": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Security.Cryptography.Xml": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Security.Permissions": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Security.Principal.Windows": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.ServiceModel.Primitives": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.ServiceModel.Syndication": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.Text.Encoding.CodePages": {
+    "listed": false,
+    "version": "4.4.0"
+  },
+  "System.Text.Encodings.Web": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "System.Text.Json": {
+    "listed": true,
+    "version": "4.6.0"
+  },
+  "System.Threading.Channels": {
+    "listed": true,
+    "version": "4.5.0"
+  },
+  "System.Threading.RateLimiting": {
+    "listed": true,
+    "version": "7.0.0"
+  },
+  "System.Threading.Tasks.Dataflow": {
+    "listed": true,
+    "version": "4.8.0"
+  },
+  "System.Threading.Tasks.Extensions": {
+    "listed": false,
+    "version": "4.4.0"
+  },
+  "System.Xml.XPath.XmlDocument": {
+    "listed": true,
+    "version": "4.7.0"
+  },
+  "Telnet": {
+    "listed": true,
+    "version": "0.8.6"
+  },
+  "TestableIO.System.IO.Abstractions": {
+    "listed": true,
+    "version": "17.2.26"
+  },
+  "TestableIO.System.IO.Abstractions.TestingHelpers": {
+    "listed": true,
+    "version": "18.0.1",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
+  },
+  "TestableIO.System.IO.Abstractions.Wrappers": {
+    "listed": true,
+    "version": "17.2.26"
+  },
+  "Testably.Abstractions.FileSystem.Interface": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "TimeZoneConverter": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "Tomlyn": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "Tomlyn.Extensions.Configuration": {
+    "listed": true,
+    "version": "1.0.1"
+  },
+  "TxFileManager": {
+    "listed": true,
+    "version": "1.4.0"
+  },
+  "UniRxAnalyzer": {
+    "listed": true,
+    "version": "1.0.4.1",
+    "analyzer": true
+  },
+  "UnitsNet": {
+    "listed": true,
+    "version": "5.28.0"
+  },
+  "UnitsNet.NumberExtensions": {
+    "listed": true,
+    "version": "5.28.0"
+  },
+  "UnitsNet.Serialization.JsonNet": {
+    "listed": true,
+    "version": "5.28.0"
+  },
+  "Utf8StringInterpolation": {
+    "listed": true,
+    "version": "1.3.1"
+  },
+  "Validation": {
+    "listed": true,
+    "version": "2.5.42"
+  },
+  "VideoLibrary": {
+    "listed": true,
+    "version": "3.2.2"
+  },
+  "VoltRpc": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "VoltRpc.Communication.Pipes": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "VoltRpc.Extension.Memory": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "VoltRpc.Extension.Vectors": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "VYaml": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "VYaml.Annotations": {
+    "listed": true,
+    "version": "0.28.0"
+  },
+  "WebDav.Client": {
+    "listed": true,
+    "version": "2.3.0"
+  },
+  "Websocket.Client": {
+    "listed": true,
+    "version": "1.0.1"
+  },
+  "Websocketsharp.core": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "XLParser": {
+    "listed": true,
+    "version": "1.7.0"
+  },
+  "YamlDotNet": {
+    "listed": true,
+    "version": "12.0.0"
+  },
+  "Zirou.Tomlyn.Extensions.Configuration": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "ZLinq": {
+    "listed": true,
+    "version": "0.5.0"
+  },
+  "ZLinq.DropInGenerator": {
+    "listed": true,
+    "version": "0.5.0",
+    "analyzer": true
+  },
+  "ZLogger": {
+    "listed": true,
+    "version": "2.0.1"
+  },
+  "ZstdSharp.Port": {
+    "listed": true,
+    "version": "0.5.0"
+  },
+  "ZString": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "ZXing.Net": {
+    "listed": true,
+    "version": "0.16.4"
+  }
+};

--- a/packages/vuepress-plugin-openupm/src/unitynuget/registry.ts
+++ b/packages/vuepress-plugin-openupm/src/unitynuget/registry.ts
@@ -2,6 +2,7 @@ import { UNITYNUGET_REGISTRY_SNAPSHOT } from './registry-snapshot.js';
 
 export const UNITYNUGET_REGISTRY_URL =
   'https://raw.githubusercontent.com/xoofx/UnityNuGet/master/registry.json';
+export const UNITYNUGET_REGISTRY_FETCH_TIMEOUT_MS = 10_000;
 
 export type UnityNuGetRegistryEntry = {
   listed?: boolean;
@@ -17,7 +18,7 @@ export type UnityNuGetInventoryEntry = {
   version: string;
 };
 
-type FetchLike = (url: string) => Promise<{
+type FetchLike = (url: string, init?: { signal?: AbortSignal }) => Promise<{
   ok: boolean;
   status: number;
   statusText: string;
@@ -47,13 +48,24 @@ export const parseUnityNuGetRegistryInventory = (
 export const fetchUnityNuGetRegistryInventory = async (
   fetcher: FetchLike = fetch,
 ): Promise<UnityNuGetInventoryEntry[]> => {
-  const resp = await fetcher(UNITYNUGET_REGISTRY_URL);
-  if (!resp.ok) {
-    throw new Error(
-      `UnityNuGet registry fetch failed with ${resp.status} ${resp.statusText}`,
-    );
+  const abortController = new AbortController();
+  const timeout = setTimeout(
+    () => abortController.abort(),
+    UNITYNUGET_REGISTRY_FETCH_TIMEOUT_MS,
+  );
+  try {
+    const resp = await fetcher(UNITYNUGET_REGISTRY_URL, {
+      signal: abortController.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(
+        `UnityNuGet registry fetch failed with ${resp.status} ${resp.statusText}`,
+      );
+    }
+    return parseUnityNuGetRegistryInventory(await resp.json());
+  } finally {
+    clearTimeout(timeout);
   }
-  return parseUnityNuGetRegistryInventory(await resp.json());
 };
 
 export const loadUnityNuGetRegistryInventory = async ({

--- a/packages/vuepress-plugin-openupm/src/unitynuget/registry.ts
+++ b/packages/vuepress-plugin-openupm/src/unitynuget/registry.ts
@@ -1,0 +1,81 @@
+import { UNITYNUGET_REGISTRY_SNAPSHOT } from './registry-snapshot.js';
+
+export const UNITYNUGET_REGISTRY_URL =
+  'https://raw.githubusercontent.com/xoofx/UnityNuGet/master/registry.json';
+
+export type UnityNuGetRegistryEntry = {
+  listed?: boolean;
+  version?: string;
+  [key: string]: unknown;
+};
+
+export type UnityNuGetRegistry = Record<string, UnityNuGetRegistryEntry>;
+
+export type UnityNuGetInventoryEntry = {
+  nugetId: string;
+  packageName: string;
+  version: string;
+};
+
+type FetchLike = (url: string) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json: () => Promise<unknown>;
+}>;
+
+export const nugetIdToOpenUpmPackageName = (nugetId: string): string =>
+  `org.nuget.${nugetId.trim().toLowerCase()}`;
+
+export const parseUnityNuGetRegistryInventory = (
+  registry: unknown,
+): UnityNuGetInventoryEntry[] => {
+  if (!registry || typeof registry !== 'object' || Array.isArray(registry)) {
+    return [];
+  }
+  return Object.entries(registry as UnityNuGetRegistry)
+    .filter(([, entry]) => entry?.listed === true)
+    .map(([nugetId, entry]) => ({
+      nugetId,
+      packageName: nugetIdToOpenUpmPackageName(nugetId),
+      version: typeof entry.version === 'string' ? entry.version : '',
+    }))
+    .filter((entry) => entry.nugetId.trim() && entry.version.trim())
+    .sort((a, b) => a.packageName.localeCompare(b.packageName));
+};
+
+export const fetchUnityNuGetRegistryInventory = async (
+  fetcher: FetchLike = fetch,
+): Promise<UnityNuGetInventoryEntry[]> => {
+  const resp = await fetcher(UNITYNUGET_REGISTRY_URL);
+  if (!resp.ok) {
+    throw new Error(
+      `UnityNuGet registry fetch failed with ${resp.status} ${resp.statusText}`,
+    );
+  }
+  return parseUnityNuGetRegistryInventory(await resp.json());
+};
+
+export const loadUnityNuGetRegistryInventory = async ({
+  fetchRegistry = fetchUnityNuGetRegistryInventory,
+  snapshot = UNITYNUGET_REGISTRY_SNAPSHOT,
+  warn = console.warn,
+}: {
+  fetchRegistry?: () => Promise<UnityNuGetInventoryEntry[]>;
+  snapshot?: UnityNuGetRegistry;
+  warn?: (message: string) => void;
+} = {}): Promise<UnityNuGetInventoryEntry[]> => {
+  try {
+    const liveInventory = await fetchRegistry();
+    if (liveInventory.length) return liveInventory;
+    warn('UnityNuGet live registry returned no listed packages; using snapshot.');
+  } catch (error) {
+    warn(`UnityNuGet live registry unavailable; using snapshot. ${error}`);
+  }
+
+  const snapshotInventory = parseUnityNuGetRegistryInventory(snapshot);
+  if (snapshotInventory.length) return snapshotInventory;
+  throw new Error(
+    'UnityNuGet registry inventory is unavailable and the checked-in snapshot is empty.',
+  );
+};


### PR DESCRIPTION
## Summary
- generate static UnityNuGet package detail pages from the curated registry inventory with snapshot fallback
- add a NuGet-specific package detail layout backed by runtime packument fetches
- surface generated NuGet pages through static site search and package-list query results without adding them to native OpenUPM metadata lists
- improve dependency links for OpenUPM, Unity package docs, and UnityNuGet package pages

## Validation
- npm run build -- --filter=vuepress-plugin-openupm
- npm run test -- --filter=vuepress-plugin-openupm
- cd apps/docs && npm run test
- cd apps/docs && npm run lint
- cd apps/docs && npm run docs:build:limit