### PR TITLE
[codex] Add contributor profile badges

### DIFF
--- a/apps/docs/__tests__/vue/contributorProfile.spec.ts
+++ b/apps/docs/__tests__/vue/contributorProfile.spec.ts
@@ -19,6 +19,21 @@ const layoutPath = fileURLToPath(
     import.meta.url,
   ),
 );
+const badgeWallPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/ContributorBadgeWall.vue",
+    import.meta.url,
+  ),
+);
+const badgeReviewPagePath = fileURLToPath(
+  new URL("../../docs/docs/contributor-badges/index.md", import.meta.url),
+);
+const contributorsPagePath = fileURLToPath(
+  new URL("../../docs/contributors/index.md", import.meta.url),
+);
+const styleCheatsheetPath = fileURLToPath(
+  new URL("../../docs/docs/dev/style-cheatsheet.md", import.meta.url),
+);
 
 const packageMetadataViewPath = fileURLToPath(
   new URL(
@@ -27,16 +42,19 @@ const packageMetadataViewPath = fileURLToPath(
   ),
 );
 const githubAvatarPath = fileURLToPath(
-  new URL(
-    "../../docs/.vuepress/components/GitHubAvatar.vue",
-    import.meta.url,
-  ),
+  new URL("../../docs/.vuepress/components/GitHubAvatar.vue", import.meta.url),
 );
 const pluginPath = fileURLToPath(
   new URL(
     "../../../../packages/vuepress-plugin-openupm/src/index.ts",
     import.meta.url,
   ),
+);
+const docsConfigPath = fileURLToPath(
+  new URL("../../docs/.vuepress/config-us.ts", import.meta.url),
+);
+const designNotesPath = fileURLToPath(
+  new URL("../../../../design.md", import.meta.url),
 );
 
 const metadata = [
@@ -94,15 +112,15 @@ const metadata = [
 
 describe("contributor profile filtering", () => {
   it("matches owned packages by owner case-insensitively", () => {
-    expect(getContributorOwnedPackages(metadata, "alice").map((x) => x.name)).toContain(
-      "com.example.owner",
-    );
+    expect(
+      getContributorOwnedPackages(metadata, "alice").map((x) => x.name),
+    ).toContain("com.example.owner");
   });
 
   it("matches owned packages by GitHub parent owner case-insensitively", () => {
-    expect(getContributorOwnedPackages(metadata, "Alice").map((x) => x.name)).toContain(
-      "com.example.parent",
-    );
+    expect(
+      getContributorOwnedPackages(metadata, "Alice").map((x) => x.name),
+    ).toContain("com.example.parent");
   });
 
   it("matches discovered packages by hunter case-insensitively", () => {
@@ -112,16 +130,18 @@ describe("contributor profile filtering", () => {
   });
 
   it("allows the same user to appear in both sections", () => {
-    expect(getContributorOwnedPackages(metadata, "alice").map((x) => x.name)).toContain(
-      "com.example.both",
-    );
+    expect(
+      getContributorOwnedPackages(metadata, "alice").map((x) => x.name),
+    ).toContain("com.example.both");
     expect(
       getContributorDiscoveredPackages(metadata, "alice").map((x) => x.name),
     ).toContain("com.example.both");
   });
 
   it("sorts owned and discovered packages by latest submitted first", () => {
-    expect(getContributorOwnedPackages(metadata, "alice").map((x) => x.name)).toEqual([
+    expect(
+      getContributorOwnedPackages(metadata, "alice").map((x) => x.name),
+    ).toEqual([
       "com.example.both",
       "com.example.parent",
       "com.example.owner",
@@ -166,7 +186,7 @@ describe("contributor profile filtering", () => {
     const source = readFileSync(layoutPath, "utf8");
 
     expect(source).toContain('<ul class="breadcrumb profile-breadcrumb">');
-    expect(source).toContain("class=\"breadcrumb-item\"");
+    expect(source).toContain('class="breadcrumb-item"');
     expect(source).toContain('<AutoLink :item="contributorsLink" />');
     expect(source).toContain("Owned packages");
     expect(source).toContain("Discovered packages");
@@ -175,6 +195,7 @@ describe("contributor profile filtering", () => {
     expect(source).toContain("Submitted");
     expect(source).toContain("package-table");
     expect(source).toContain("GitHub profile");
+    expect(source).toContain("align-items: center;");
     expect(source).not.toContain("OpenUPM profile");
     expect(source).not.toContain("totalSubmittedCount }} submitted");
     expect(source).not.toContain("sidebar-top");
@@ -183,18 +204,143 @@ describe("contributor profile filtering", () => {
     expect(source).not.toContain(".filter((x) => x.ver)");
   });
 
+  it("renders contributor badges from generated frontmatter", () => {
+    const layoutSource = readFileSync(layoutPath, "utf8");
+    const badgeWallSource = readFileSync(badgeWallPath, "utf8");
+    const badgeIconSource = readFileSync(
+      fileURLToPath(
+        new URL(
+          "../../docs/.vuepress/components/ContributorBadgeIcon.vue",
+          import.meta.url,
+        ),
+      ),
+      "utf8",
+    );
+    const profileActionsIndex = layoutSource.indexOf('class="profile-actions"');
+    const headerCloseIndex = layoutSource.indexOf("</header>");
+    const badgeWallIndex = layoutSource.indexOf("<ContributorBadgeWall");
+
+    expect(layoutSource).toContain("badges?: ContributorBadge[]");
+    expect(profileActionsIndex).toBeGreaterThan(-1);
+    expect(badgeWallIndex).toBeGreaterThan(profileActionsIndex);
+    expect(badgeWallIndex).toBeGreaterThan(headerCloseIndex);
+    expect(layoutSource).toContain('<ContributorBadgeWall :badges="badges" />');
+    expect(badgeWallSource).toContain('class="profile-badges"');
+    expect(badgeWallSource).toContain("Contributor badge wall");
+    expect(badgeWallSource).toContain("ContributorBadgeIcon");
+    expect(badgeIconSource).toContain('viewBox="0 0 70 70"');
+    expect(badgeIconSource).toContain('width="70"');
+    expect(badgeIconSource).toContain('height="70"');
+    expect(badgeIconSource).toContain("icon === 'trophy'");
+    expect(badgeIconSource).toContain("icon === 'coin'");
+    expect(badgeIconSource).toContain("icon === 'year-search'");
+    expect(badgeIconSource).toContain("icon === 'year-box'");
+    expect(badgeIconSource).toContain("badge-year-metric");
+    expect(badgeIconSource).toContain("badge-year-mark");
+    expect(badgeWallSource).toContain("getBadgeIconLabel");
+    expect(badgeWallSource).toContain("`${badge.tier}`");
+    expect(badgeWallSource).toContain("`${badge.year}`");
+    expect(badgeWallSource).toContain("getBadgeStyle");
+    expect(badgeWallSource).toContain('"--badge-accent"');
+    expect(badgeIconSource).toContain("badge-trophy-metric");
+    expect(badgeIconSource).toContain('dominant-baseline="middle"');
+    expect(badgeWallSource).toContain("getBadgeAriaLabel");
+    expect(badgeWallSource).toContain('badge.category === "rank"');
+    expect(badgeWallSource).toContain("`Top ${badge.tier}`");
+    expect(badgeWallSource).toContain("`${badge.tier}+`");
+    expect(badgeWallSource).toContain('role="tooltip"');
+    expect(badgeWallSource).toContain("profile-badge-tooltip");
+    expect(badgeIconSource).toContain("badge-disc");
+    expect(badgeIconSource).toContain("badge-ring");
+    expect(badgeIconSource).toContain("badge-mark");
+    expect(badgeWallSource).toContain("profile-badge-title");
+    expect(badgeWallSource).toContain("profile-badge-description");
+    expect(badgeWallSource).not.toContain("fa-box-open");
+    expect(badgeWallSource).not.toContain("fa-trophy");
+  });
+
+  it("provides a contributor badge review page with all badge rules", () => {
+    const source = readFileSync(badgeReviewPagePath, "utf8");
+    const configSource = readFileSync(docsConfigPath, "utf8");
+
+    expect(source).toContain("badgeExamples:");
+    expect(source).not.toContain("sidebar: false");
+    expect(source).toContain("package-hunter-1");
+    expect(source).toContain("package-hunter-100");
+    expect(source).toContain("package-owner-1");
+    expect(source).toContain("package-owner-100");
+    expect(source).toContain("package-hunter-2021");
+    expect(source).toContain("package-hunter-2026");
+    expect(source).not.toContain("package-hunter-2027");
+    expect(source).toContain("package-owner-2021");
+    expect(source).toContain("package-owner-2026");
+    expect(source).not.toContain("package-owner-2027");
+    expect(source).toContain("icon: year-search");
+    expect(source).toContain("icon: year-box");
+    expect(source).toContain('accent: "#5b6889"');
+    expect(source).toContain('accent: "#765776"');
+    expect(source).toContain("top-package-hunter-10");
+    expect(source).toContain("top-package-hunter-100");
+    expect(source).toContain("top-package-owner-10");
+    expect(source).toContain("top-package-owner-100");
+    expect(source).toContain("early-contributor");
+    expect(source).toContain("current-backer");
+    expect(source).toContain("former-backer");
+    expect(source).toContain("tone: hunter");
+    expect(source).toContain("tone: owner");
+    expect(source).toContain("icon: coin");
+    expect(source).toContain("tone: muted");
+    expect(source).toContain("<ContributorBadgeWall");
+
+    expect(readFileSync(contributorsPagePath, "utf8")).toContain(
+      "[Contributor badge reference](/docs/contributor-badges/)",
+    );
+    expect(configSource).toContain(
+      'children: ["/support/", "/contributors/", "/docs/contributor-badges/"]',
+    );
+  });
+
+  it("documents reusable contributor badge icon styles in the design docs", () => {
+    const source = readFileSync(styleCheatsheetPath, "utf8");
+    const designNotesSource = readFileSync(designNotesPath, "utf8");
+
+    expect(source).toContain("### Badge Icons");
+    expect(source).toContain("ContributorBadgeIcon");
+    expect(source).toContain('<ContributorBadgeIcon icon="search" />');
+    expect(source).toContain('<ContributorBadgeIcon icon="box" label="25+" />');
+    expect(source).toContain(
+      '<ContributorBadgeIcon icon="trophy" label="10" />',
+    );
+    expect(source).toContain(
+      '<ContributorBadgeIcon icon="year-search" label="2026" />',
+    );
+    expect(source).toContain("keep the full `Top 10` wording");
+    expect(source).toContain("feature the four-digit year");
+    expect(source).toContain("Render at `70x70`");
+    expect(source).toContain("Set tone through `currentColor`");
+    expect(source).toContain("`hunter`: `#2f7d78`");
+    expect(source).toContain("`muted`: `#7a7f87`");
+    expect(designNotesSource).toContain("## Contributor Badge Icons");
+    expect(designNotesSource).toContain("Use `ContributorBadgeIcon`");
+    expect(designNotesSource).toContain("70x70 SVG widget");
+    expect(designNotesSource).toContain("current and former backers");
+    expect(designNotesSource).toContain("put only the number in the icon");
+    expect(designNotesSource).toContain("For year badges");
+    expect(designNotesSource).toContain("`year-search`");
+    expect(designNotesSource).toContain("`year-box`");
+  });
+
   it("uses AutoLink for external profile links with theme external-link behavior", () => {
     const layoutSource = readFileSync(layoutPath, "utf8");
 
-    expect(layoutSource).toContain(
-      '<AutoLink class="nav-link external github-link" :item="githubLink" />',
-    );
+    expect(layoutSource).toContain('class="nav-link external github-link"');
+    expect(layoutSource).toContain(':item="githubLink"');
     expect(layoutSource).toContain("font-size: 0.8rem");
     expect(layoutSource).toContain("isGitHubProfileHost");
     expect(layoutSource).toContain('hostname === "github.com"');
     expect(layoutSource).toContain('hostname.endsWith(".github.com")');
     expect(layoutSource).toContain('"GitHub profile"');
-    expect(layoutSource).toContain('`${profileHost} profile`');
+    expect(layoutSource).toContain("`${profileHost} profile`");
     expect(layoutSource).toContain("link: githubUrl.value");
   });
 
@@ -203,6 +349,10 @@ describe("contributor profile filtering", () => {
 
     expect(source).toContain("layout: 'ContributorProfileLayout'");
     expect(source).toContain("sidebar: false");
+    expect(source).toContain("backers");
+    expect(source).toContain(
+      "buildContributorProfile(githubUser, metadataLocalList",
+    );
   });
 
   it("links package metadata to OpenUPM contributor profiles", () => {
@@ -228,7 +378,9 @@ describe("contributor profile filtering", () => {
     expect(metadataViewSource).toContain("isGithubProfileUrl");
     expect(metadataViewSource).toContain('hostname === "github.com"');
     expect(metadataViewSource).toContain('hostname === "www.github.com"');
-    expect(metadataViewSource).toContain("external: Boolean(profileUrl && !isGithubProfile)");
+    expect(metadataViewSource).toContain(
+      "external: Boolean(profileUrl && !isGithubProfile)",
+    );
     expect(metadataViewSource).toContain(
       "parentOwnerNavLink && parentOwnerNavLink.external && parentOwnerNavLink.link",
     );
@@ -251,8 +403,12 @@ describe("contributor profile filtering", () => {
   it("routes contributor avatar profile links through RouterLink", () => {
     const githubAvatarSource = readFileSync(githubAvatarPath, "utf8");
 
-    expect(githubAvatarSource).toContain('<RouterLink v-if="isInternalLink" :to="linkUrl">');
-    expect(githubAvatarSource).toContain('<a v-else :href="linkUrl" rel="noopener noreferrer">');
+    expect(githubAvatarSource).toContain(
+      '<RouterLink v-if="isInternalLink" :to="linkUrl">',
+    );
+    expect(githubAvatarSource).toContain(
+      '<a v-else :href="linkUrl" rel="noopener noreferrer">',
+    );
   });
 
   it("uses the contributor profile URL and host from generated frontmatter", () => {
@@ -260,6 +416,6 @@ describe("contributor profile filtering", () => {
 
     expect(layoutSource).toContain("profileUrl");
     expect(layoutSource).toContain("profileHost");
-    expect(layoutSource).toContain('`${profileHost} profile`');
+    expect(layoutSource).toContain("`${profileHost} profile`");
   });
 });

--- a/apps/docs/docs/.vuepress/components/ContributorBadgeIcon.vue
+++ b/apps/docs/docs/.vuepress/components/ContributorBadgeIcon.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+defineProps<{
+  icon: string;
+  label?: string;
+}>();
+</script>
+
+<template>
+  <svg
+    class="profile-badge-icon"
+    viewBox="0 0 70 70"
+    width="70"
+    height="70"
+    role="img"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <circle class="badge-disc" cx="35" cy="35" r="31" />
+    <circle class="badge-ring" cx="35" cy="35" r="26" />
+    <path class="badge-shine" d="M19 24c4-8 12-13 22-13 5 0 10 1 14 4" />
+    <g v-if="icon === 'year-search'" class="badge-year-mark">
+      <circle cx="45" cy="20" r="5" />
+      <path d="m49 24 5 5" />
+      <path d="M45 17v6" />
+      <path d="M42 20h6" />
+    </g>
+    <g v-else-if="icon === 'year-box'" class="badge-year-mark">
+      <path d="M40 20 48 15l8 5-8 5-8-5Z" />
+      <path d="M40 20v9l8 5 8-5v-9" />
+      <path d="M48 25v9" />
+    </g>
+    <g v-else-if="icon === 'search'" class="badge-mark">
+      <circle cx="31" cy="30" r="9" />
+      <path d="m38 37 10 10" />
+      <path d="M31 26v8" />
+      <path d="M27 30h8" />
+    </g>
+    <g v-else-if="icon === 'box'" class="badge-mark">
+      <path d="M22 28 35 20l13 8-13 8-13-8Z" />
+      <path d="M22 28v15l13 8 13-8V28" />
+      <path d="M35 36v15" />
+    </g>
+    <g v-else-if="icon === 'trophy'" class="badge-mark">
+      <path d="M27 22h16v8c0 8-4 14-8 14s-8-6-8-14v-8Z" />
+      <path d="M27 27h-7c0 8 3 12 9 13" />
+      <path d="M43 27h7c0 8-3 12-9 13" />
+      <path d="M35 44v7" />
+      <path d="M27 52h16" />
+    </g>
+    <g v-else-if="icon === 'spark'" class="badge-mark">
+      <path d="M35 50V31" />
+      <path d="M35 35c-8-1-13-6-14-14 8 1 13 6 14 14Z" />
+      <path d="M36 39c8-1 13-6 14-14-8 1-13 6-14 14Z" />
+      <path d="M24 52h22" />
+    </g>
+    <g v-else-if="icon === 'coin'" class="badge-mark">
+      <circle cx="35" cy="35" r="15" />
+      <path d="M35 25v20" />
+      <path d="M41 30c-2-3-11-3-12 1-1 6 12 4 12 9 0 5-10 5-13 1" />
+    </g>
+    <g v-else class="badge-mark">
+      <path d="M35 18 40 30l13 1-10 8 3 13-11-7-11 7 3-13-10-8 13-1 5-12Z" />
+    </g>
+    <text
+      v-if="icon.startsWith('year-') && label"
+      class="badge-year-metric"
+      x="35"
+      y="43"
+      text-anchor="middle"
+    >
+      {{ label }}
+    </text>
+    <text
+      v-else-if="icon === 'trophy' && label"
+      class="badge-trophy-metric"
+      x="35"
+      y="35"
+      text-anchor="middle"
+      dominant-baseline="middle"
+    >
+      {{ label }}
+    </text>
+    <text
+      v-else-if="label"
+      class="badge-metric"
+      x="35"
+      y="62"
+      text-anchor="middle"
+    >
+      {{ label }}
+    </text>
+  </svg>
+</template>
+
+<style lang="scss" scoped>
+.profile-badge-icon {
+  display: block;
+  width: 70px;
+  height: 70px;
+  overflow: visible;
+  filter: drop-shadow(0 2px 3px rgb(0 0 0 / 12%));
+}
+
+.badge-disc {
+  fill: var(--c-bg);
+  stroke: currentColor;
+  stroke-width: 3;
+}
+
+.badge-ring {
+  fill: color-mix(in srgb, currentColor 13%, transparent);
+  stroke: color-mix(in srgb, currentColor 42%, var(--c-bg));
+  stroke-width: 1.5;
+  stroke-dasharray: 3 4;
+}
+
+.badge-shine {
+  fill: none;
+  stroke: color-mix(in srgb, currentColor 45%, var(--c-bg));
+  stroke-linecap: round;
+  stroke-width: 2;
+}
+
+.badge-mark {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 3.2;
+}
+
+.badge-mark circle {
+  fill: none;
+}
+
+.badge-year-mark {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.6;
+}
+
+.badge-metric {
+  fill: currentColor;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.badge-trophy-metric {
+  fill: currentColor;
+  font-size: 0.5rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  paint-order: stroke;
+  stroke: var(--c-bg);
+  stroke-linejoin: round;
+  stroke-width: 2.4px;
+}
+
+.badge-year-metric {
+  fill: currentColor;
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  paint-order: stroke;
+  stroke: var(--c-bg);
+  stroke-linejoin: round;
+  stroke-width: 2.8px;
+}
+</style>

--- a/apps/docs/docs/.vuepress/components/ContributorBadgeWall.vue
+++ b/apps/docs/docs/.vuepress/components/ContributorBadgeWall.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import ContributorBadgeIcon from "@/components/ContributorBadgeIcon.vue";
+
+type ContributorBadge = {
+  id: string;
+  title: string;
+  description: string;
+  category: "count" | "rank" | "year" | "history" | "support";
+  tier?: number;
+  metric?: number;
+  rank?: number;
+  year?: number;
+  icon: string;
+  tone: "hunter" | "owner" | "history" | "support" | "muted";
+  accent?: string;
+};
+
+defineProps<{
+  badges: ContributorBadge[];
+}>();
+
+const getBadgeDetail = function (badge: ContributorBadge): string {
+  if (badge.category === "rank" && badge.tier) return `Top ${badge.tier}`;
+  if (badge.category === "year" && badge.year) return `${badge.year}`;
+  if (badge.category === "count" && badge.tier && badge.tier > 1) {
+    return `${badge.tier}+`;
+  }
+  return "";
+};
+
+const getBadgeIconLabel = function (badge: ContributorBadge): string {
+  if (badge.category === "rank" && badge.tier) return `${badge.tier}`;
+  if (badge.category === "year" && badge.year) return `${badge.year}`;
+  return getBadgeDetail(badge);
+};
+
+const getBadgeStyle = function (badge: ContributorBadge): Record<string, string> {
+  return badge.accent ? { "--badge-accent": badge.accent } : {};
+};
+
+const getBadgeAriaLabel = function (badge: ContributorBadge): string {
+  const detail = getBadgeDetail(badge);
+  return [badge.title, detail, badge.description].filter(Boolean).join(". ");
+};
+</script>
+
+<template>
+  <div
+    v-if="badges.length"
+    class="profile-badges"
+    aria-label="Contributor badge wall"
+  >
+    <div
+      v-for="badge in badges"
+      :key="badge.id"
+      class="profile-badge"
+      :class="`profile-badge-${badge.tone}`"
+      :style="getBadgeStyle(badge)"
+      tabindex="0"
+      :aria-label="getBadgeAriaLabel(badge)"
+      :aria-describedby="`badge-tooltip-${badge.id}`"
+    >
+      <ContributorBadgeIcon
+        :icon="badge.icon"
+        :label="getBadgeIconLabel(badge)"
+      />
+      <span
+        :id="`badge-tooltip-${badge.id}`"
+        class="profile-badge-tooltip"
+        role="tooltip"
+      >
+        <span class="profile-badge-title">
+          {{ badge.title }}
+          <span v-if="getBadgeDetail(badge)" class="profile-badge-detail">
+            {{ getBadgeDetail(badge) }}
+          </span>
+        </span>
+        <span class="profile-badge-description">{{ badge.description }}</span>
+      </span>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.profile-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.75rem;
+}
+
+.profile-badge {
+  position: relative;
+  width: 70px;
+  height: 70px;
+  color: var(--badge-accent);
+  cursor: help;
+
+  &:focus-visible {
+    outline: 2px solid var(--badge-accent);
+    outline-offset: 3px;
+    border-radius: 50%;
+  }
+
+  &:hover,
+  &:focus-visible {
+    .profile-badge-tooltip {
+      opacity: 1;
+      transform: translate(-50%, -0.25rem);
+      visibility: visible;
+    }
+  }
+}
+
+.profile-badge-tooltip {
+  position: absolute;
+  bottom: calc(100% + 0.55rem);
+  left: 50%;
+  z-index: 2;
+  width: max-content;
+  max-width: min(18rem, calc(100vw - 2rem));
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  background: var(--c-bg);
+  box-shadow: 0 0.4rem 1rem rgb(0 0 0 / 14%);
+  color: var(--c-text);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0);
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease,
+    visibility 0.15s ease;
+  visibility: hidden;
+
+  &::after {
+    position: absolute;
+    bottom: -0.38rem;
+    left: 50%;
+    width: 0.7rem;
+    height: 0.7rem;
+    border-right: 1px solid var(--c-border);
+    border-bottom: 1px solid var(--c-border);
+    background: var(--c-bg);
+    content: "";
+    transform: translateX(-50%) rotate(45deg);
+  }
+}
+
+.profile-badge-title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: baseline;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.profile-badge-detail {
+  color: var(--c-text-light);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.profile-badge-description {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--c-text-light);
+  font-size: 0.76rem;
+  line-height: 1.25;
+}
+
+.profile-badge-hunter {
+  --badge-accent: #2f7d78;
+}
+
+.profile-badge-owner {
+  --badge-accent: #816a2d;
+}
+
+.profile-badge-history {
+  --badge-accent: #8a5b3d;
+}
+
+.profile-badge-support {
+  --badge-accent: #b24b68;
+}
+
+.profile-badge-muted {
+  --badge-accent: #7a7f87;
+}
+</style>

--- a/apps/docs/docs/.vuepress/config-us.ts
+++ b/apps/docs/docs/.vuepress/config-us.ts
@@ -126,7 +126,7 @@ const docSideBar = function (): any {
     {
       text: "Support US",
       collapsible: true,
-      children: ["/support/", "/contributors/"],
+      children: ["/support/", "/contributors/", "/docs/contributor-badges/"],
     },
     {
       text: "Resources",

--- a/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
@@ -9,10 +9,9 @@ import {
   getContributorProfileStats,
   toContributorProfilePackageEntry,
 } from "@/components/contributor-profile";
+import ContributorBadgeWall from "@/components/ContributorBadgeWall.vue";
 import { useDefaultStore } from "@/store";
-import {
-  getAvatarImageUrl,
-} from "@openupm/common/build/urls.js";
+import { getAvatarImageUrl } from "@openupm/common/build/urls.js";
 import { PackageMetadataLocal } from "@openupm/types";
 
 type ContributorProfileFrontmatter = {
@@ -23,7 +22,22 @@ type ContributorProfileFrontmatter = {
     totalSubmittedCount: number;
     profileUrl?: string;
     profileHost?: string;
+    badges?: ContributorBadge[];
   };
+};
+
+type ContributorBadge = {
+  id: string;
+  title: string;
+  description: string;
+  category: "count" | "rank" | "year" | "history" | "support";
+  tier?: number;
+  metric?: number;
+  rank?: number;
+  year?: number;
+  icon: string;
+  tone: "hunter" | "owner" | "history" | "support" | "muted";
+  accent?: string;
 };
 
 const frontmatter = usePageFrontmatter<ContributorProfileFrontmatter>();
@@ -51,7 +65,8 @@ const isGitHubProfileHost = function (profileHost: string): boolean {
 };
 
 const githubLink = computed(() => {
-  const profileHost = frontmatter.value.contributorProfile?.profileHost || "github.com";
+  const profileHost =
+    frontmatter.value.contributorProfile?.profileHost || "github.com";
   const text = isGitHubProfileHost(profileHost)
     ? "GitHub profile"
     : `${profileHost} profile`;
@@ -71,7 +86,10 @@ const metadataLocalList = computed(() => {
 
 const stats = computed(() => {
   if (metadataLocalList.value.length) {
-    return getContributorProfileStats(metadataLocalList.value, githubUser.value);
+    return getContributorProfileStats(
+      metadataLocalList.value,
+      githubUser.value,
+    );
   }
   return (
     frontmatter.value.contributorProfile || {
@@ -80,6 +98,10 @@ const stats = computed(() => {
       totalSubmittedCount: 0,
     }
   );
+});
+
+const badges = computed(() => {
+  return frontmatter.value.contributorProfile?.badges || [];
 });
 
 const ownedPackages = computed(() => {
@@ -117,7 +139,11 @@ const isLoading = computed(() => {
             </ul>
           </nav>
           <header class="profile-header">
-            <LazyImage :src="avatarUrl" :alt="githubUser" class="avatar avatar-xl" />
+            <LazyImage
+              :src="avatarUrl"
+              :alt="githubUser"
+              class="avatar avatar-xl"
+            />
             <div class="profile-header-text">
               <h1>{{ githubUser }}</h1>
               <div class="profile-stats">
@@ -125,10 +151,14 @@ const isLoading = computed(() => {
                 <span>{{ stats.discoveredCount }} discovered</span>
               </div>
               <div class="profile-actions">
-                <AutoLink class="nav-link external github-link" :item="githubLink" />
+                <AutoLink
+                  class="nav-link external github-link"
+                  :item="githubLink"
+                />
               </div>
             </div>
           </header>
+          <ContributorBadgeWall :badges="badges" />
 
           <div v-if="isLoading" class="placeholder-loader-wrapper">
             <PlaceholderLoader />
@@ -151,13 +181,19 @@ const isLoading = computed(() => {
                   <tbody>
                     <tr v-for="metadata in ownedPackages" :key="metadata.name">
                       <td>
-                        <RouterLink :to="metadata.path">{{ metadata.displayName }}</RouterLink>
-                        <code class="mobile-package-name">{{ metadata.name }}</code>
+                        <RouterLink :to="metadata.path">{{
+                          metadata.displayName
+                        }}</RouterLink>
+                        <code class="mobile-package-name">{{
+                          metadata.name
+                        }}</code>
                       </td>
                       <td class="package-name-column">
                         <code>{{ metadata.name }}</code>
                       </td>
-                      <td class="submitted-column">{{ metadata.createdAtText }}</td>
+                      <td class="submitted-column">
+                        {{ metadata.createdAtText }}
+                      </td>
                     </tr>
                   </tbody>
                 </table>
@@ -179,15 +215,24 @@ const isLoading = computed(() => {
                     </tr>
                   </thead>
                   <tbody>
-                    <tr v-for="metadata in discoveredPackages" :key="metadata.name">
+                    <tr
+                      v-for="metadata in discoveredPackages"
+                      :key="metadata.name"
+                    >
                       <td>
-                        <RouterLink :to="metadata.path">{{ metadata.displayName }}</RouterLink>
-                        <code class="mobile-package-name">{{ metadata.name }}</code>
+                        <RouterLink :to="metadata.path">{{
+                          metadata.displayName
+                        }}</RouterLink>
+                        <code class="mobile-package-name">{{
+                          metadata.name
+                        }}</code>
                       </td>
                       <td class="package-name-column">
                         <code>{{ metadata.name }}</code>
                       </td>
-                      <td class="submitted-column">{{ metadata.createdAtText }}</td>
+                      <td class="submitted-column">
+                        {{ metadata.createdAtText }}
+                      </td>
                     </tr>
                   </tbody>
                 </table>

--- a/apps/docs/docs/contributors/index.md
+++ b/apps/docs/docs/contributors/index.md
@@ -66,6 +66,8 @@ backers:
 
 A heartfelt thank you to all our contributors! 🌟 If you'd like to be honored on this page and support our mission, please visit [support page](/support/) to discover how you can make a difference. 💖
 
+[Contributor badge reference](/docs/contributor-badges/) shows all profile badge icons and award rules.
+
 ## Sponsors
 
 <SponsorList :items="$page.frontmatter.sponsors" />

--- a/apps/docs/docs/docs/contributor-badges/index.md
+++ b/apps/docs/docs/docs/contributor-badges/index.md
@@ -1,0 +1,314 @@
+---
+title: Contributor Badges
+badgeExamples:
+  hunterTiers:
+    - id: package-hunter-1
+      title: Package Hunter
+      description: Discovered at least 1 OpenUPM package.
+      category: count
+      tier: 1
+      metric: 1
+      icon: search
+      tone: hunter
+    - id: package-hunter-5
+      title: Package Hunter
+      description: Discovered at least 5 OpenUPM packages.
+      category: count
+      tier: 5
+      metric: 5
+      icon: search
+      tone: hunter
+    - id: package-hunter-25
+      title: Package Hunter
+      description: Discovered at least 25 OpenUPM packages.
+      category: count
+      tier: 25
+      metric: 25
+      icon: search
+      tone: hunter
+    - id: package-hunter-50
+      title: Package Hunter
+      description: Discovered at least 50 OpenUPM packages.
+      category: count
+      tier: 50
+      metric: 50
+      icon: search
+      tone: hunter
+    - id: package-hunter-100
+      title: Package Hunter
+      description: Discovered at least 100 OpenUPM packages.
+      category: count
+      tier: 100
+      metric: 100
+      icon: search
+      tone: hunter
+  ownerTiers:
+    - id: package-owner-1
+      title: Package Owner
+      description: Owned at least 1 OpenUPM package.
+      category: count
+      tier: 1
+      metric: 1
+      icon: box
+      tone: owner
+    - id: package-owner-5
+      title: Package Owner
+      description: Owned at least 5 OpenUPM packages.
+      category: count
+      tier: 5
+      metric: 5
+      icon: box
+      tone: owner
+    - id: package-owner-25
+      title: Package Owner
+      description: Owned at least 25 OpenUPM packages.
+      category: count
+      tier: 25
+      metric: 25
+      icon: box
+      tone: owner
+    - id: package-owner-50
+      title: Package Owner
+      description: Owned at least 50 OpenUPM packages.
+      category: count
+      tier: 50
+      metric: 50
+      icon: box
+      tone: owner
+    - id: package-owner-100
+      title: Package Owner
+      description: Owned at least 100 OpenUPM packages.
+      category: count
+      tier: 100
+      metric: 100
+      icon: box
+      tone: owner
+  hunterYears:
+    - id: package-hunter-2021
+      title: Package Hunter
+      description: Discovered an OpenUPM package in 2021.
+      category: year
+      year: 2021
+      icon: year-search
+      tone: hunter
+      accent: "#2f7d78"
+    - id: package-hunter-2022
+      title: Package Hunter
+      description: Discovered an OpenUPM package in 2022.
+      category: year
+      year: 2022
+      icon: year-search
+      tone: hunter
+      accent: "#257f8c"
+    - id: package-hunter-2023
+      title: Package Hunter
+      description: Discovered an OpenUPM package in 2023.
+      category: year
+      year: 2023
+      icon: year-search
+      tone: hunter
+      accent: "#2b719d"
+    - id: package-hunter-2024
+      title: Package Hunter
+      description: Discovered an OpenUPM package in 2024.
+      category: year
+      year: 2024
+      icon: year-search
+      tone: hunter
+      accent: "#38699f"
+    - id: package-hunter-2025
+      title: Package Hunter
+      description: Discovered an OpenUPM package in 2025.
+      category: year
+      year: 2025
+      icon: year-search
+      tone: hunter
+      accent: "#4d6795"
+    - id: package-hunter-2026
+      title: Package Hunter
+      description: Discovered an OpenUPM package in 2026.
+      category: year
+      year: 2026
+      icon: year-search
+      tone: hunter
+      accent: "#5b6889"
+  ownerYears:
+    - id: package-owner-2021
+      title: Package Owner
+      description: Owned an OpenUPM package in 2021.
+      category: year
+      year: 2021
+      icon: year-box
+      tone: owner
+      accent: "#816a2d"
+    - id: package-owner-2022
+      title: Package Owner
+      description: Owned an OpenUPM package in 2022.
+      category: year
+      year: 2022
+      icon: year-box
+      tone: owner
+      accent: "#8a6131"
+    - id: package-owner-2023
+      title: Package Owner
+      description: Owned an OpenUPM package in 2023.
+      category: year
+      year: 2023
+      icon: year-box
+      tone: owner
+      accent: "#92583c"
+    - id: package-owner-2024
+      title: Package Owner
+      description: Owned an OpenUPM package in 2024.
+      category: year
+      year: 2024
+      icon: year-box
+      tone: owner
+      accent: "#92504d"
+    - id: package-owner-2025
+      title: Package Owner
+      description: Owned an OpenUPM package in 2025.
+      category: year
+      year: 2025
+      icon: year-box
+      tone: owner
+      accent: "#884f61"
+    - id: package-owner-2026
+      title: Package Owner
+      description: Owned an OpenUPM package in 2026.
+      category: year
+      year: 2026
+      icon: year-box
+      tone: owner
+      accent: "#765776"
+  hunterRanks:
+    - id: top-package-hunter-10
+      title: Top Package Hunter
+      description: Ranked in the top 10 package hunters.
+      category: rank
+      tier: 10
+      rank: 1
+      icon: trophy
+      tone: hunter
+    - id: top-package-hunter-25
+      title: Top Package Hunter
+      description: Ranked in the top 25 package hunters.
+      category: rank
+      tier: 25
+      rank: 25
+      icon: trophy
+      tone: hunter
+    - id: top-package-hunter-50
+      title: Top Package Hunter
+      description: Ranked in the top 50 package hunters.
+      category: rank
+      tier: 50
+      rank: 50
+      icon: trophy
+      tone: hunter
+    - id: top-package-hunter-100
+      title: Top Package Hunter
+      description: Ranked in the top 100 package hunters.
+      category: rank
+      tier: 100
+      rank: 100
+      icon: trophy
+      tone: hunter
+
+  ownerRanks:
+    - id: top-package-owner-10
+      title: Top Package Owner
+      description: Ranked in the top 10 package owners.
+      category: rank
+      tier: 10
+      rank: 1
+      icon: trophy
+      tone: owner
+    - id: top-package-owner-25
+      title: Top Package Owner
+      description: Ranked in the top 25 package owners.
+      category: rank
+      tier: 25
+      rank: 25
+      icon: trophy
+      tone: owner
+    - id: top-package-owner-50
+      title: Top Package Owner
+      description: Ranked in the top 50 package owners.
+      category: rank
+      tier: 50
+      rank: 50
+      icon: trophy
+      tone: owner
+    - id: top-package-owner-100
+      title: Top Package Owner
+      description: Ranked in the top 100 package owners.
+      category: rank
+      tier: 100
+      rank: 100
+      icon: trophy
+      tone: owner
+  historySupport:
+    - id: early-contributor
+      title: Early Contributor
+      description: Submitted an owned or discovered package before 2021-01-01.
+      category: history
+      icon: spark
+      tone: history
+    - id: current-backer
+      title: Current Backer
+      description: Currently supports OpenUPM as a backer.
+      category: support
+      icon: coin
+      tone: support
+    - id: former-backer
+      title: Former Backer
+      description: Previously supported OpenUPM as a backer.
+      category: support
+      icon: coin
+      tone: muted
+---
+
+# Contributor Badges
+
+## Package Hunter tiers
+
+<ContributorBadgeWall :badges="$page.frontmatter.badgeExamples.hunterTiers" />
+
+Rules: 1, 5, 25, 50, and 100 discovered packages. Only the highest reached tier is shown on a contributor profile.
+
+## Package Owner tiers
+
+<ContributorBadgeWall :badges="$page.frontmatter.badgeExamples.ownerTiers" />
+
+Rules: 1, 5, 25, 50, and 100 owned packages. Only the highest reached tier is shown on a contributor profile.
+
+## Package Hunter years
+
+<ContributorBadgeWall :badges="$page.frontmatter.badgeExamples.hunterYears" />
+
+Rules: one badge for each year from 2021 through 2030 where the contributor discovered at least one package. The reference page shows years through the current build year.
+
+## Package Owner years
+
+<ContributorBadgeWall :badges="$page.frontmatter.badgeExamples.ownerYears" />
+
+Rules: one badge for each year from 2021 through 2030 where the contributor owned at least one package. The reference page shows years through the current build year.
+
+## Top Package Hunter ranks
+
+<ContributorBadgeWall :badges="$page.frontmatter.badgeExamples.hunterRanks" />
+
+Rules: top 10, 25, 50, and 100 package hunters. Only the highest reached rank badge is shown on a contributor profile.
+
+## Top Package Owner ranks
+
+<ContributorBadgeWall :badges="$page.frontmatter.badgeExamples.ownerRanks" />
+
+Rules: top 10, 25, 50, and 100 package owners. Only the highest reached rank badge is shown on a contributor profile.
+
+## History and support
+
+<ContributorBadgeWall :badges="$page.frontmatter.badgeExamples.historySupport" />
+
+Rules: Early Contributor is awarded for a first owned or discovered package before 2021-01-01. Current Backer is awarded when the contributor appears in the backer list with no expiry or an expiry on or after the build date. Former Backer is awarded when the contributor appears in the backer list with an expiry before the build date.

--- a/apps/docs/docs/docs/dev/style-cheatsheet.md
+++ b/apps/docs/docs/docs/dev/style-cheatsheet.md
@@ -30,6 +30,64 @@ This is a paragraph.
 
 <span class="chip"><i class="fa fa-user"></i>UserX</span>
 
+### Badge Icons
+
+Contributor badge icons use the local `ContributorBadgeIcon` widget instead of
+Font Awesome. Use it when a compact, self-contained achievement mark is needed
+on contributor-facing UI.
+
+```vue
+<ContributorBadgeIcon icon="search" />
+<ContributorBadgeIcon icon="box" label="25+" />
+<ContributorBadgeIcon icon="trophy" label="10" />
+<ContributorBadgeIcon icon="year-search" label="2026" />
+```
+
+<div class="badge-icon-style-row">
+  <span class="badge-icon-style-sample badge-icon-style-hunter">
+    <ContributorBadgeIcon icon="search" />
+  </span>
+  <span class="badge-icon-style-sample badge-icon-style-owner">
+    <ContributorBadgeIcon icon="box" label="25+" />
+  </span>
+  <span class="badge-icon-style-sample badge-icon-style-hunter">
+    <ContributorBadgeIcon icon="trophy" label="10" />
+  </span>
+  <span class="badge-icon-style-sample badge-icon-style-support">
+    <ContributorBadgeIcon icon="coin" />
+  </span>
+  <span class="badge-icon-style-sample badge-icon-style-muted">
+    <ContributorBadgeIcon icon="coin" />
+  </span>
+  <span class="badge-icon-style-sample badge-icon-style-year">
+    <ContributorBadgeIcon icon="year-search" label="2026" />
+  </span>
+</div>
+
+Badge icon rules:
+
+- Render at `70x70` with the component's fixed SVG viewbox.
+- Keep each icon self-descriptive without relying on nearby text.
+- Use the same icon for related states and separate them by tone when possible.
+- Put tier text in the `label` prop, for example `25+`.
+- For trophy rank badges, use only the rank number in the icon label, for
+  example `10`; keep the full `Top 10` wording in the tooltip or nearby text.
+- For year badges, feature the four-digit year as the label and keep the role
+  icon small. Use `year-search` for Package Hunter years and `year-box` for
+  Package Owner years.
+- Use `search`, `box`, `trophy`, `spark`, `coin`, `year-search`, and `year-box`
+  before adding a new icon.
+- Add new icons inside `ContributorBadgeIcon.vue` so they remain reusable.
+- Set tone through `currentColor`; do not use remote images or generated assets.
+
+Current badge tones:
+
+- `hunter`: `#2f7d78`
+- `owner`: `#816a2d`
+- `history`: `#8a5b3d`
+- `support`: `#b24b68`
+- `muted`: `#7a7f87`
+
 ### Quotes
 
 ::: tip Tip
@@ -47,3 +105,38 @@ This is a danger quote
 ::: details Details
 This is a details quote
 :::
+
+<style>
+.badge-icon-style-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.badge-icon-style-sample {
+  display: inline-block;
+  width: 70px;
+  height: 70px;
+}
+
+.badge-icon-style-hunter {
+  color: #2f7d78;
+}
+
+.badge-icon-style-owner {
+  color: #816a2d;
+}
+
+.badge-icon-style-support {
+  color: #b24b68;
+}
+
+.badge-icon-style-muted {
+  color: #7a7f87;
+}
+
+.badge-icon-style-year {
+  color: #5b6889;
+}
+</style>

--- a/design.md
+++ b/design.md
@@ -45,3 +45,24 @@ patterns where the site chrome or documentation flow is involved.
   `--c-text-light` from the VuePress theme so light and dark modes stay aligned.
 - Do not introduce one-off row backgrounds, gradients, or decorative color
   bands without checking dark mode.
+
+## Contributor Badge Icons
+
+- Use `ContributorBadgeIcon` for contributor achievement marks. It is a local
+  70x70 SVG widget, not a Font Awesome icon or remote badge image.
+- Keep badge icons self-descriptive at icon size. Use the established icon
+  vocabulary first: `search`, `box`, `trophy`, `spark`, `coin`,
+  `year-search`, and `year-box`.
+- Drive badge color through `currentColor` and the shared tones used by
+  `ContributorBadgeWall`: hunter, owner, history, support, and muted.
+- Keep related states on the same glyph when the concept is the same. For
+  example, current and former backers both use the coin icon, with former backer
+  rendered in the muted tone.
+- For count tiers, use compact icon labels such as `25+`. For trophy rank
+  badges, put only the number in the icon, such as `10`, and keep the full
+  `Top 10` wording in tooltip or surrounding accessible text.
+- For year badges, make the four-digit year the main visual and keep the role
+  glyph smaller. Use subtly different accent colors per year while preserving
+  the hunter or owner color family.
+- Document new reusable badge glyphs in
+  `apps/docs/docs/docs/dev/style-cheatsheet.md` when adding them.

--- a/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/contributors.test.ts
@@ -2,10 +2,18 @@ import { PackageMetadataLocal } from '@openupm/types';
 
 import {
   addContributorProfileUrls,
+  buildContributorBadges,
   buildContributorProfile,
   collectContributorProfileGithubUsers,
+  CONTRIBUTOR_BADGE_YEARS,
   getContributorPageOrGithubUrl,
 } from '../src/contributors.js';
+
+const leaderboard = (githubUser: string, rank: number) =>
+  Array.from({ length: rank }, (_, index) => ({
+    githubUser: index === rank - 1 ? githubUser : `user-${index + 1}`,
+    score: 200 - index,
+  }));
 
 describe('contributor profile generation', () => {
   it('includes hunters, owners, and GitHub parent owners without duplicates', () => {
@@ -54,7 +62,7 @@ describe('contributor profile generation', () => {
       },
     ] as PackageMetadataLocal[];
 
-    expect(buildContributorProfile('Alice', metadata)).toEqual({
+    expect(buildContributorProfile('Alice', metadata)).toMatchObject({
       githubUser: 'Alice',
       ownedCount: 2,
       discoveredCount: 1,
@@ -62,6 +70,16 @@ describe('contributor profile generation', () => {
       profileUrl: 'https://github.com/Alice',
       profileHost: 'github.com',
     });
+    expect(buildContributorProfile('Alice', metadata).badges).toEqual([
+      expect.objectContaining({
+        id: 'package-hunter-1',
+        metric: 1,
+      }),
+      expect.objectContaining({
+        id: 'package-owner-1',
+        metric: 2,
+      }),
+    ]);
   });
 
   it('uses the contributor upstream profile URL and host from matching metadata', () => {
@@ -124,6 +142,240 @@ describe('contributor profile generation', () => {
         githubUser: 'carol',
         url: 'https://example.com/carol',
       },
+    ]);
+  });
+
+  it.each([1, 5, 25, 50, 100])(
+    'selects the highest package hunter count tier at %i discoveries',
+    (tier) => {
+      expect(
+        buildContributorBadges('Alice', [], 0, tier).filter((badge) =>
+          badge.id.startsWith('package-hunter-'),
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          id: `package-hunter-${tier}`,
+          metric: tier,
+          tier,
+        }),
+      ]);
+    },
+  );
+
+  it.each([1, 5, 25, 50, 100])(
+    'selects the highest package owner count tier at %i owned packages',
+    (tier) => {
+      expect(
+        buildContributorBadges('Alice', [], tier, 0).filter((badge) =>
+          badge.id.startsWith('package-owner-'),
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          id: `package-owner-${tier}`,
+          metric: tier,
+          tier,
+        }),
+      ]);
+    },
+  );
+
+  it('keeps only the highest reached count tier per badge family', () => {
+    expect(
+      buildContributorBadges('Alice', [], 125, 51)
+        .filter((badge) => badge.category === 'count')
+        .map((badge) => badge.id),
+    ).toEqual(['package-hunter-50', 'package-owner-100']);
+  });
+
+  it('adds package hunter and owner year badges from 2021 through 2030', () => {
+    const metadata = [
+      {
+        name: 'com.example.before-range',
+        owner: 'Alice',
+        hunter: 'Alice',
+        createdAt: Date.UTC(2020, 0, 1),
+      },
+      {
+        name: 'com.example.hunter-2021',
+        owner: 'bob',
+        hunter: 'Alice',
+        createdAt: Date.UTC(2021, 6, 1),
+      },
+      {
+        name: 'com.example.owner-2026',
+        owner: 'Alice',
+        hunter: 'bob',
+        createdAt: Date.UTC(2026, 6, 1),
+      },
+      {
+        name: 'com.example.owner-2030',
+        owner: 'fork',
+        parentOwner: 'Alice',
+        hunter: 'bob',
+        createdAt: Date.UTC(2030, 6, 1),
+      },
+      {
+        name: 'com.example.after-range',
+        owner: 'Alice',
+        hunter: 'Alice',
+        createdAt: Date.UTC(2031, 0, 1),
+      },
+    ] as PackageMetadataLocal[];
+
+    const yearBadges = buildContributorBadges('Alice', metadata, 3, 3).filter(
+      (badge) => badge.category === 'year',
+    );
+
+    expect(CONTRIBUTOR_BADGE_YEARS).toContain(2030);
+    expect(yearBadges).toEqual([
+      expect.objectContaining({
+        id: 'package-hunter-2021',
+        year: 2021,
+        icon: 'year-search',
+        tone: 'hunter',
+        accent: '#2f7d78',
+      }),
+      expect.objectContaining({
+        id: 'package-owner-2026',
+        year: 2026,
+        icon: 'year-box',
+        tone: 'owner',
+        accent: '#765776',
+      }),
+      expect.objectContaining({
+        id: 'package-owner-2030',
+        year: 2030,
+        icon: 'year-box',
+        tone: 'owner',
+        accent: '#5e8152',
+      }),
+    ]);
+    expect(yearBadges.map((badge) => badge.id)).not.toContain(
+      'package-hunter-2020',
+    );
+    expect(yearBadges.map((badge) => badge.id)).not.toContain(
+      'package-owner-2031',
+    );
+  });
+
+  it.each([
+    [10, 'top-package-hunter-10'],
+    [25, 'top-package-hunter-25'],
+    [50, 'top-package-hunter-50'],
+    [100, 'top-package-hunter-100'],
+  ])('selects the highest top hunter rank tier at rank %i', (rank, id) => {
+    expect(
+      buildContributorBadges('Alice', [], 0, 0, {
+        hunters: leaderboard('Alice', rank),
+      }).filter((badge) => badge.id.startsWith('top-package-hunter-')),
+    ).toEqual([
+      expect.objectContaining({
+        id,
+        rank,
+        icon: 'trophy',
+        tone: 'hunter',
+      }),
+    ]);
+  });
+
+  it.each([
+    [10, 'top-package-owner-10'],
+    [25, 'top-package-owner-25'],
+    [50, 'top-package-owner-50'],
+    [100, 'top-package-owner-100'],
+  ])('selects the highest top owner rank tier at rank %i', (rank, id) => {
+    expect(
+      buildContributorBadges('Alice', [], 0, 0, {
+        owners: leaderboard('Alice', rank),
+      }).filter((badge) => badge.id.startsWith('top-package-owner-')),
+    ).toEqual([
+      expect.objectContaining({
+        id,
+        rank,
+        icon: 'trophy',
+        tone: 'owner',
+      }),
+    ]);
+  });
+
+  it('adds early contributor only before the 2021-01-01 cutoff', () => {
+    const beforeCutoff = Date.UTC(2020, 11, 31);
+    const atCutoff = Date.UTC(2021, 0, 1);
+    const metadata = [
+      {
+        name: 'com.example.early',
+        owner: 'Alice',
+        hunter: 'bob',
+        createdAt: beforeCutoff,
+      },
+      {
+        name: 'com.example.later',
+        owner: 'carol',
+        hunter: 'dave',
+        createdAt: atCutoff,
+      },
+    ] as PackageMetadataLocal[];
+
+    expect(buildContributorBadges('Alice', metadata, 1, 0)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'early-contributor' }),
+      ]),
+    );
+    expect(buildContributorBadges('carol', metadata, 1, 0)).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'early-contributor' }),
+      ]),
+    );
+  });
+
+  it('adds current and former backer badges from backer expiry dates', () => {
+    const buildDate = new Date(Date.UTC(2026, 4, 17));
+    const backers = [
+      { githubUser: 'CurrentNoExpiry' },
+      { githubUser: 'CurrentExpiry', expires: '2026-05-17' },
+      { githubUser: 'FormerExpiry', expires: '2026-05-16' },
+      { githubUser: 'InvalidExpiry', expires: '2026-02-31' },
+    ];
+
+    expect(
+      buildContributorBadges('CurrentNoExpiry', [], 0, 0, {
+        backers,
+        buildDate,
+      }),
+    ).toEqual([
+      expect.objectContaining({ id: 'current-backer', icon: 'coin' }),
+    ]);
+    expect(
+      buildContributorBadges('CurrentExpiry', [], 0, 0, {
+        backers,
+        buildDate,
+      }),
+    ).toEqual([
+      expect.objectContaining({ id: 'current-backer', icon: 'coin' }),
+    ]);
+    expect(
+      buildContributorBadges('FormerExpiry', [], 0, 0, {
+        backers,
+        buildDate,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        id: 'former-backer',
+        icon: 'coin',
+        tone: 'muted',
+      }),
+    ]);
+    expect(
+      buildContributorBadges('InvalidExpiry', [], 0, 0, {
+        backers,
+        buildDate,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        id: 'former-backer',
+        icon: 'coin',
+        tone: 'muted',
+      }),
     ]);
   });
 });

--- a/packages/vuepress-plugin-openupm/src/contributors.ts
+++ b/packages/vuepress-plugin-openupm/src/contributors.ts
@@ -8,11 +8,68 @@ export type ContributorProfile = {
   totalSubmittedCount: number;
   profileUrl: string;
   profileHost: string;
+  badges: ContributorBadge[];
+};
+
+export type ContributorBadge = {
+  id: string;
+  title: string;
+  description: string;
+  category: 'count' | 'rank' | 'year' | 'history' | 'support';
+  tier?: number;
+  metric?: number;
+  rank?: number;
+  year?: number;
+  icon: string;
+  tone: 'hunter' | 'owner' | 'history' | 'support' | 'muted';
+  accent?: string;
 };
 
 export type GithubUserLink = {
   githubUser?: string | null;
   url?: string;
+};
+
+export type ContributorBacker = GithubUserLink & {
+  expires?: unknown;
+};
+
+type ContributorProfileBadgeOptions = {
+  hunters?: GithubUserWithScore[];
+  owners?: GithubUserWithScore[];
+  backers?: ContributorBacker[];
+  buildDate?: Date;
+};
+
+const EARLY_CONTRIBUTOR_CUTOFF = Date.UTC(2021, 0, 1);
+const COUNT_TIERS = [1, 5, 25, 50, 100] as const;
+const RANK_TIERS = [100, 50, 25, 10] as const;
+export const CONTRIBUTOR_BADGE_YEARS = [
+  2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030,
+] as const;
+const HUNTER_YEAR_ACCENTS: Record<number, string> = {
+  2021: '#2f7d78',
+  2022: '#257f8c',
+  2023: '#2b719d',
+  2024: '#38699f',
+  2025: '#4d6795',
+  2026: '#5b6889',
+  2027: '#457a86',
+  2028: '#348271',
+  2029: '#4b825d',
+  2030: '#687b4d',
+};
+const OWNER_YEAR_ACCENTS: Record<number, string> = {
+  2021: '#816a2d',
+  2022: '#8a6131',
+  2023: '#92583c',
+  2024: '#92504d',
+  2025: '#884f61',
+  2026: '#765776',
+  2027: '#7d6657',
+  2028: '#89713e',
+  2029: '#777b3f',
+  2030: '#5e8152',
 };
 
 export const normalizeGithubUser = (githubUser: string): string =>
@@ -21,8 +78,7 @@ export const normalizeGithubUser = (githubUser: string): string =>
 const matchesGithubUser = (
   actual: string | null | undefined,
   expected: string,
-): boolean =>
-  actual ? normalizeGithubUser(actual) === expected : false;
+): boolean => (actual ? normalizeGithubUser(actual) === expected : false);
 
 const ownsPackage = (
   metadata: PackageMetadataLocal,
@@ -35,6 +91,259 @@ const discoveredPackage = (
   metadata: PackageMetadataLocal,
   normalizedGithubUser: string,
 ): boolean => matchesGithubUser(metadata.hunter, normalizedGithubUser);
+
+const getHighestReachedTier = function (
+  count: number,
+  tiers: readonly number[],
+): number | undefined {
+  return tiers.filter((tier) => count >= tier).at(-1);
+};
+
+const getHighestReachedRankTier = function (
+  rank: number | undefined,
+): number | undefined {
+  if (!rank) return undefined;
+  return RANK_TIERS.filter((tier) => rank <= tier).at(-1);
+};
+
+const getLeaderboardRank = function (
+  leaderboard: GithubUserWithScore[] | undefined,
+  normalizedGithubUser: string,
+): number | undefined {
+  if (!leaderboard) return undefined;
+  const index = leaderboard.findIndex((contributor) =>
+    matchesGithubUser(contributor.githubUser, normalizedGithubUser),
+  );
+  return index === -1 ? undefined : index + 1;
+};
+
+const hasEarlyContribution = function (
+  metadataLocalList: PackageMetadataLocal[],
+  normalizedGithubUser: string,
+): boolean {
+  return metadataLocalList.some((metadata) => {
+    if (
+      !ownsPackage(metadata, normalizedGithubUser) &&
+      !discoveredPackage(metadata, normalizedGithubUser)
+    ) {
+      return false;
+    }
+    return (
+      typeof metadata.createdAt === 'number' &&
+      metadata.createdAt < EARLY_CONTRIBUTOR_CUTOFF
+    );
+  });
+};
+
+const getContributionYears = function (
+  metadataLocalList: PackageMetadataLocal[],
+  normalizedGithubUser: string,
+  matchesRole: (
+    metadata: PackageMetadataLocal,
+    normalizedGithubUser: string,
+  ) => boolean,
+): number[] {
+  const years = new Set<number>();
+  for (const metadata of metadataLocalList) {
+    if (!matchesRole(metadata, normalizedGithubUser)) continue;
+    if (typeof metadata.createdAt !== 'number') continue;
+    const year = new Date(metadata.createdAt).getUTCFullYear();
+    if ((CONTRIBUTOR_BADGE_YEARS as readonly number[]).includes(year)) {
+      years.add(year);
+    }
+  }
+  return [...years].sort((a, b) => a - b);
+};
+
+const parseDateOnlyUtc = function (value: unknown): number | undefined {
+  if (value instanceof Date) {
+    const year = value.getUTCFullYear();
+    const month = value.getUTCMonth() + 1;
+    const day = value.getUTCDate();
+    return Date.UTC(year, month - 1, day);
+  }
+  if (typeof value !== 'string') return undefined;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return undefined;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const date = new Date(timestamp);
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
+  return timestamp;
+};
+
+const getBackerState = function (
+  backers: ContributorBacker[] | undefined,
+  normalizedGithubUser: string,
+  buildDate: Date,
+): 'current' | 'former' | undefined {
+  const backer = backers?.find(
+    (candidate) =>
+      candidate.githubUser &&
+      matchesGithubUser(candidate.githubUser, normalizedGithubUser),
+  );
+  if (!backer) return undefined;
+  if (
+    !('expires' in backer) ||
+    backer.expires === null ||
+    backer.expires === undefined
+  ) {
+    return 'current';
+  }
+  const expires = parseDateOnlyUtc(backer.expires);
+  if (!expires) return 'former';
+  const buildDateOnly = Date.UTC(
+    buildDate.getUTCFullYear(),
+    buildDate.getUTCMonth(),
+    buildDate.getUTCDate(),
+  );
+  return expires >= buildDateOnly ? 'current' : 'former';
+};
+
+export const buildContributorBadges = function (
+  githubUser: string,
+  metadataLocalList: PackageMetadataLocal[],
+  ownedCount: number,
+  discoveredCount: number,
+  options: ContributorProfileBadgeOptions = {},
+): ContributorBadge[] {
+  const normalizedGithubUser = normalizeGithubUser(githubUser);
+  const badges: ContributorBadge[] = [];
+  const hunterTier = getHighestReachedTier(discoveredCount, COUNT_TIERS);
+  if (hunterTier) {
+    badges.push({
+      id: `package-hunter-${hunterTier}`,
+      title: 'Package Hunter',
+      description: `Discovered at least ${hunterTier} OpenUPM package${
+        hunterTier === 1 ? '' : 's'
+      }.`,
+      category: 'count',
+      tier: hunterTier,
+      metric: discoveredCount,
+      icon: 'search',
+      tone: 'hunter',
+    });
+  }
+  const ownerTier = getHighestReachedTier(ownedCount, COUNT_TIERS);
+  if (ownerTier) {
+    badges.push({
+      id: `package-owner-${ownerTier}`,
+      title: 'Package Owner',
+      description: `Owned at least ${ownerTier} OpenUPM package${
+        ownerTier === 1 ? '' : 's'
+      }.`,
+      category: 'count',
+      tier: ownerTier,
+      metric: ownedCount,
+      icon: 'box',
+      tone: 'owner',
+    });
+  }
+  const hunterRank = getLeaderboardRank(options.hunters, normalizedGithubUser);
+  const hunterRankTier = getHighestReachedRankTier(hunterRank);
+  if (hunterRank && hunterRankTier) {
+    badges.push({
+      id: `top-package-hunter-${hunterRankTier}`,
+      title: 'Top Package Hunter',
+      description: `Ranked in the top ${hunterRankTier} package hunters.`,
+      category: 'rank',
+      tier: hunterRankTier,
+      rank: hunterRank,
+      icon: 'trophy',
+      tone: 'hunter',
+    });
+  }
+  const ownerRank = getLeaderboardRank(options.owners, normalizedGithubUser);
+  const ownerRankTier = getHighestReachedRankTier(ownerRank);
+  if (ownerRank && ownerRankTier) {
+    badges.push({
+      id: `top-package-owner-${ownerRankTier}`,
+      title: 'Top Package Owner',
+      description: `Ranked in the top ${ownerRankTier} package owners.`,
+      category: 'rank',
+      tier: ownerRankTier,
+      rank: ownerRank,
+      icon: 'trophy',
+      tone: 'owner',
+    });
+  }
+  for (const year of getContributionYears(
+    metadataLocalList,
+    normalizedGithubUser,
+    discoveredPackage,
+  )) {
+    badges.push({
+      id: `package-hunter-${year}`,
+      title: 'Package Hunter',
+      description: `Discovered an OpenUPM package in ${year}.`,
+      category: 'year',
+      year,
+      icon: 'year-search',
+      tone: 'hunter',
+      accent: HUNTER_YEAR_ACCENTS[year],
+    });
+  }
+  for (const year of getContributionYears(
+    metadataLocalList,
+    normalizedGithubUser,
+    ownsPackage,
+  )) {
+    badges.push({
+      id: `package-owner-${year}`,
+      title: 'Package Owner',
+      description: `Owned an OpenUPM package in ${year}.`,
+      category: 'year',
+      year,
+      icon: 'year-box',
+      tone: 'owner',
+      accent: OWNER_YEAR_ACCENTS[year],
+    });
+  }
+  if (hasEarlyContribution(metadataLocalList, normalizedGithubUser)) {
+    badges.push({
+      id: 'early-contributor',
+      title: 'Early Contributor',
+      description:
+        'Submitted an owned or discovered package before 2021-01-01.',
+      category: 'history',
+      icon: 'spark',
+      tone: 'history',
+    });
+  }
+  const backerState = getBackerState(
+    options.backers,
+    normalizedGithubUser,
+    options.buildDate || new Date(),
+  );
+  if (backerState === 'current') {
+    badges.push({
+      id: 'current-backer',
+      title: 'Current Backer',
+      description: 'Currently supports OpenUPM as a backer.',
+      category: 'support',
+      icon: 'coin',
+      tone: 'support',
+    });
+  } else if (backerState === 'former') {
+    badges.push({
+      id: 'former-backer',
+      title: 'Former Backer',
+      description: 'Previously supported OpenUPM as a backer.',
+      category: 'support',
+      icon: 'coin',
+      tone: 'muted',
+    });
+  }
+  return badges;
+};
 
 const getUrlHost = function (url: string | null | undefined): string {
   if (!url) return 'github.com';
@@ -122,6 +431,7 @@ export const addContributorProfileUrls = function <T extends GithubUserLink>(
 export const buildContributorProfile = function (
   githubUser: string,
   metadataLocalList: PackageMetadataLocal[],
+  options: ContributorProfileBadgeOptions = {},
 ): ContributorProfile {
   const normalizedGithubUser = normalizeGithubUser(githubUser);
   const ownedCount = metadataLocalList.filter((metadata) =>
@@ -138,5 +448,12 @@ export const buildContributorProfile = function (
     totalSubmittedCount: ownedCount + discoveredCount,
     profileUrl,
     profileHost: getUrlHost(profileUrl),
+    badges: buildContributorBadges(
+      githubUser,
+      metadataLocalList,
+      ownedCount,
+      discoveredCount,
+      options,
+    ),
   };
 };

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -36,6 +36,7 @@ import {
   addContributorProfileUrls,
   buildContributorProfile,
   collectContributorProfileGithubUsers,
+  ContributorBacker,
 } from './contributors.js';
 import {
   buildPackageAliasRedirects,
@@ -157,9 +158,26 @@ const createContributorProfilePages = async function (
   app: App,
 ): Promise<Page[]> {
   const pages: Page[] = [];
-  const { contributorProfileGithubUsers, metadataLocalList } = PLUGIN_DATA;
+  const { contributorProfileGithubUsers, hunters, metadataLocalList, owners } =
+    PLUGIN_DATA;
+  const contributorsPage = app.pages.find((page) =>
+    page.path.endsWith('/contributors/'),
+  );
+  const contributorsFrontmatter = contributorsPage?.frontmatter;
+  const rawBackers = contributorsFrontmatter
+    ? contributorsFrontmatter.backers
+    : undefined;
+  const backers = Array.isArray(rawBackers)
+    ? (rawBackers as ContributorBacker[])
+    : [];
+  const buildDate = new Date();
   for (const githubUser of contributorProfileGithubUsers) {
-    const profile = buildContributorProfile(githubUser, metadataLocalList);
+    const profile = buildContributorProfile(githubUser, metadataLocalList, {
+      backers,
+      buildDate,
+      hunters,
+      owners,
+    });
     const frontmatter = {
       layout: 'ContributorProfileLayout',
       sidebar: false,


### PR DESCRIPTION
## Summary
- generate contributor profile badges for counts, ranks, yearly hunter/owner activity, early contributions, and backer state
- render a reusable SVG badge wall on contributor profiles
- add a contributor badge reference page, sidebar link, and reusable design documentation

## Validation
- npm test -- --run contributors.test.ts
- npm test -- --run contributorProfile.spec.ts
- npm run lint
- npm run docs:build:limit