### PR TITLE
Add UnityNuGet package pages blog post

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,18 +57,8 @@
 
 - Docs commands run from `apps/docs`.
 - `npm run docs:build:limit` is the fastest full SSR build smoke test for the docs app.
-- New blog posts live at `apps/docs/docs/blog/<slug>/index.md`.
-- Add each new blog post to `BLOG_POSTS` in
-  `apps/docs/docs/.vuepress/blog.ts`; this drives the blog index, adjacent
-  post navigation, and RSS metadata.
-- Keep blog frontmatter aligned with the `BlogPost` metadata entry: `title`,
-  `author`, `date`, `readingTime`, and `description`/`excerpt` should describe
-  the same post.
-- Blog ordering tests should verify general ordering behavior, such as dates
-  sorted newest first, rather than hard-coding the current first or last post
-  unless the test is intentionally covering a specific legacy post.
-- For blog-only changes, run `npm run test -- blog.spec.ts` and
-  `npm run lint` from `apps/docs`, then run `npm run docs:build:limit`.
+- If the shell is not already using the repo-pinned Node/npm versions, run docs
+  commands through Volta, for example `volta run npm run lint`.
 - If `docs:build:limit` fails because
   `node_modules/vuepress-plugin-openupm/build/index.js` is missing, first build
   the local plugin dependency from the repo root with
@@ -77,6 +67,58 @@
   - `date-fns/locale`
   - `@intlify/shared`
 - Do not remove those aliases unless the upstream VuePress / Vue I18n dependency stack is upgraded and revalidated.
+
+## Blog Post Workflow
+
+- New blog posts live at `apps/docs/docs/blog/<slug>/index.md`.
+- Add each new blog post to `BLOG_POSTS` in
+  `apps/docs/docs/.vuepress/blog.ts`; this drives the blog index, adjacent
+  post navigation, and RSS metadata.
+- Keep blog frontmatter aligned with the `BlogPost` metadata entry: `title`,
+  `author`, `date`, `readingTime`, and `description`/`excerpt` should describe
+  the same post.
+- Use the current date for new posts unless the user explicitly asks for a
+  different publish date. Keep dates as `YYYY-MM-DD`.
+- Keep frontmatter concise: `title`, `author`, `date`, `readingTime`,
+  `description`, and usually `editLink: false`.
+- For a new post, start by reading a recent nearby post and `BLOG_POSTS` so the
+  title style, metadata, and closing navigation match the site.
+- Add `<BlogPostMeta />` after the H1 and `<BlogPostNav />` at the end unless
+  there is a strong reason to follow a different legacy post format.
+- Keep posts user-facing. Avoid implementation details such as internal build
+  strategy, cache mechanics, deployment topology, local paths, private hostnames,
+  LAN URLs, or temporary preview URLs unless the user specifically asks for
+  operator notes outside the public repo.
+- Use Markdown links for referenced articles, package pages, docs pages, issues,
+  and examples. Avoid bare URLs in prose, especially URLs copied from local
+  staging or development output.
+- Prefer relative links for OpenUPM site pages, for example
+  `[NuGet Packages](/nuget/)` or
+  `[org.nuget.system](/packages/?q=org.nuget.system)`.
+- When linking package examples, use the package name as link text instead of
+  showing the full URL.
+- Make limitations accurate without overexplaining internals. If a feature is
+  searchable but not part of the normal filterable package list, state both
+  surfaces explicitly.
+- Blog ordering tests should verify general ordering behavior, such as dates
+  sorted newest first, rather than hard-coding the current first or last post
+  unless the test is intentionally covering a specific legacy post.
+- For blog-only changes, run `npm run test -- blog.spec.ts` and
+  `npm run lint` from `apps/docs`, then run `npm run docs:build:limit`. Use
+  `volta run` for those commands when needed.
+- If a VuePress dev server is already running, stop it before
+  `docs:build:limit`; the build cleans `.vuepress/.temp` and can conflict with
+  a live dev server.
+- When the user wants to review the post locally, start the dev server from
+  `apps/docs` with:
+  `VITE_OPENUPM_API_SERVER_URL=https://api.openupm.com npm run docs:dev -- --host 0.0.0.0 --port 8080`.
+- Before starting the review server, check whether the port is already in use.
+  If it is, either stop the stale server or choose another port and report that
+  port.
+- For LAN review, bind to `0.0.0.0`, determine the active LAN address from the
+  machine, and give the user a concrete `http://<lan-ip>:<port>/...` URL for
+  the page they should review. Do not commit that LAN URL to the repo or include
+  it in public PR text.
 
 ## Local Data
 

--- a/apps/docs/docs/.vuepress/blog.ts
+++ b/apps/docs/docs/.vuepress/blog.ts
@@ -17,7 +17,7 @@ export const BLOG_POSTS: BlogPost[] = [
     title: "UnityNuGet Package Pages Now on OpenUPM",
     slug: "unitynuget-package-pages-now-on-openupm",
     author: "Favo Yang",
-    date: "2026-05-18",
+    date: "2026-05-17",
     readingTime: "2 min read",
     excerpt:
       "OpenUPM now generates website package pages for UnityNuGet packages, making org.nuget packages easier to find, inspect, and install from the web.",

--- a/apps/docs/docs/.vuepress/blog.ts
+++ b/apps/docs/docs/.vuepress/blog.ts
@@ -14,6 +14,15 @@ export const BLOG_RSS_PATH = "/blog/rss.xml";
 
 export const BLOG_POSTS: BlogPost[] = [
   {
+    title: "UnityNuGet Package Pages Now on OpenUPM",
+    slug: "unitynuget-package-pages-now-on-openupm",
+    author: "Favo Yang",
+    date: "2026-05-18",
+    readingTime: "2 min read",
+    excerpt:
+      "OpenUPM now generates website package pages for UnityNuGet packages, making org.nuget packages easier to find, inspect, and install from the web.",
+  },
+  {
     title: "OpenUPM Recent Improvements, May 2026",
     slug: "openupm-recent-improvements-may-2026",
     author: "Favo Yang",

--- a/apps/docs/docs/blog/unitynuget-package-pages-now-on-openupm/index.md
+++ b/apps/docs/docs/blog/unitynuget-package-pages-now-on-openupm/index.md
@@ -1,0 +1,63 @@
+---
+title: "UnityNuGet Package Pages Now on OpenUPM"
+author: "Favo Yang"
+date: "2026-05-18"
+readingTime: "2 min read"
+description: "OpenUPM now generates website package pages for UnityNuGet packages, making org.nuget packages easier to find, inspect, and install from the web."
+editLink: false
+---
+# UnityNuGet Package Pages Now on OpenUPM
+
+<BlogPostMeta />
+
+OpenUPM now generates website package pages for UnityNuGet packages.
+
+Until now, `org.nuget` packages could be resolved through the OpenUPM registry
+uplink, and recently became visible through registry search, but they were not
+easy to browse on the OpenUPM website. That made common packages such as
+`org.nuget.newtonsoft.json` harder to discover, inspect, and share from the
+web.
+
+UnityNuGet packages now have OpenUPM website pages with the same URL shape as
+normal OpenUPM package pages. For example:
+
+- [org.nuget.newtonsoft.json](/packages/org.nuget.newtonsoft.json/)
+- [org.nuget.system.text.json](/packages/org.nuget.system.text.json/)
+
+These pages can appear in website search results and are easy to share in
+issues, documentation, and support answers.
+
+Try searching for [org.nuget.system](/packages/?q=org.nuget.system) to see the
+UnityNuGet package group in the package results.
+
+## What You Can See
+
+UnityNuGet package pages show the information that is useful for Unity Package
+Manager users:
+
+- package name and NuGet identity;
+- latest version and available versions;
+- description, author, and repository link when available;
+- package dependencies;
+- install commands for stable and latest versions.
+
+This makes `org.nuget` packages easier to link in issues, documentation, and
+support answers. It also gives Unity developers a single OpenUPM website entry
+point for both native OpenUPM packages and UnityNuGet packages.
+
+## Search Behavior
+
+Website search can now find generated UnityNuGet package pages. Search results
+show OpenUPM packages and UnityNuGet package pages as separate result groups so
+the package source is clear.
+
+This completes the first website-facing step after
+[UnityNuGet search started working through OpenUPM](/blog/unitynuget-search-now-works-through-openupm/).
+The goal is simple: `org.nuget` packages should be resolvable, searchable, and
+shareable through OpenUPM without blurring the line between native OpenUPM
+packages and UnityNuGet uplink packages.
+
+See the updated [NuGet Packages](/nuget/) documentation for setup details and
+current limitations.
+
+<BlogPostNav />

--- a/apps/docs/docs/blog/unitynuget-package-pages-now-on-openupm/index.md
+++ b/apps/docs/docs/blog/unitynuget-package-pages-now-on-openupm/index.md
@@ -1,7 +1,7 @@
 ---
 title: "UnityNuGet Package Pages Now on OpenUPM"
 author: "Favo Yang"
-date: "2026-05-18"
+date: "2026-05-17"
 readingTime: "2 min read"
 description: "OpenUPM now generates website package pages for UnityNuGet packages, making org.nuget packages easier to find, inspect, and install from the web."
 editLink: false

--- a/apps/docs/docs/nuget/index.md
+++ b/apps/docs/docs/nuget/index.md
@@ -28,7 +28,7 @@ To improve convenience, the OpenUPM registry [uplinks](https://verdaccio.org/doc
 
 The integration comes with a few limitations:
 
-- NuGet packages have generated website pages based on the UnityNuGet curated package list, but they are not shown in the normal OpenUPM package list.
+- NuGet packages have generated website pages based on the UnityNuGet curated package list. They can appear in website search results as a separate UnityNuGet package group, but they are not included in the normal filterable OpenUPM package list.
 - Package page details and search results are served by the registry uplink and may depend on UnityNuGet availability and cache freshness. If UnityNuGet is temporarily unavailable, already cached package metadata and tarballs continue to resolve through OpenUPM, but new uncached package details and search results may be delayed until the uplink recovers.
 
 To demonstrate the uplinks feature, we have created a staging package at [https://github.com/openupm/com.example.nuget-consumer](https://github.com/openupm/com.example.nuget-consumer) which includes:


### PR DESCRIPTION
## Summary
- Add a blog post announcing UnityNuGet package pages on OpenUPM.
- Update NuGet docs wording to clarify website search results versus the normal filterable package list.
- Add blog authoring and LAN staging workflow guidance to AGENTS.md.

## Validation
- Blog metadata test passed.
- Docs lint passed.
- Limited docs build passed.