### PR TITLE
[codex] Add docs SEO crawl metadata

### DIFF
--- a/apps/docs/__tests__/seoMetadata.spec.ts
+++ b/apps/docs/__tests__/seoMetadata.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyBlogSeoMetadata,
+  getSitemapLastModified,
+} from "../docs/.vuepress/seoMetadata";
+
+describe("docs SEO metadata", () => {
+  it("fills missing blog cover metadata from BLOG_POSTS", () => {
+    const page = {
+      path: "/blog/openupm-2025-recap-6283fcd0217e/",
+      frontmatter: {},
+    };
+
+    applyBlogSeoMetadata(page as never);
+
+    expect(page.frontmatter).toMatchObject({
+      cover: "/images/blog-covers/openupm-2025-recap-6283fcd0217e.png",
+    });
+  });
+
+  it("keeps explicit blog cover metadata", () => {
+    const page = {
+      path: "/blog/contributor-profile-badges/",
+      frontmatter: { cover: "/custom.png" },
+    };
+
+    applyBlogSeoMetadata(page as never);
+
+    expect(page.frontmatter.cover).toBe("/custom.png");
+  });
+
+  it("uses frontmatter lastmod before falling back to build-time metadata", () => {
+    expect(
+      getSitemapLastModified({
+        frontmatter: { lastmod: "2026-01-02T00:00:00.000Z" },
+      } as never),
+    ).toBe("2026-01-02T00:00:00.000Z");
+  });
+
+  it("uses blog dates as deterministic sitemap dates", () => {
+    expect(
+      getSitemapLastModified({
+        frontmatter: { date: "2026-01-02" },
+      } as never),
+    ).toBe("2026-01-02T00:00:00.000Z");
+  });
+});

--- a/apps/docs/docs/.vuepress/config.ts
+++ b/apps/docs/docs/.vuepress/config.ts
@@ -15,6 +15,7 @@ import { mediumZoomPlugin } from "@vuepress/plugin-medium-zoom";
 import OpenupmPlugin from "vuepress-plugin-openupm";
 import { blogRssPlugin } from "./blogRssPlugin";
 import { getSearchExtraFields } from "./searchExtraFields";
+import { applyBlogSeoMetadata, getSitemapLastModified } from "./seoMetadata";
 
 const __dirname = getDirname(import.meta.url);
 
@@ -124,6 +125,10 @@ const config: any = mergeWith(
         getExtraFields: getSearchExtraFields,
       }),
       OpenupmPlugin(),
+      {
+        name: "openupm-seo-metadata",
+        extendsPage: applyBlogSeoMetadata,
+      },
       seoPlugin({
         hostname: themeConfig.domain,
         fallBackImage: urlJoin(
@@ -134,10 +139,7 @@ const config: any = mergeWith(
       }),
       sitemapPlugin({
         hostname: themeConfig.domain,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        modifyTimeGetter: (page, app) => {
-          return new Date().toISOString();
-        },
+        modifyTimeGetter: getSitemapLastModified,
       }),
       mediumZoomPlugin({
         selector:

--- a/apps/docs/docs/.vuepress/seoMetadata.ts
+++ b/apps/docs/docs/.vuepress/seoMetadata.ts
@@ -1,0 +1,43 @@
+import { statSync } from "node:fs";
+
+import type { Page } from "@vuepress/core";
+
+import { BLOG_POSTS } from "./blog";
+
+const blogPostCoverByPath = new Map(
+  BLOG_POSTS.filter((post) => post.featuredImage).map((post) => [
+    `/blog/${post.slug}/`,
+    post.featuredImage,
+  ]),
+);
+
+const toIsoString = (value: unknown): string => {
+  if (typeof value !== "string" && typeof value !== "number") return "";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString();
+};
+
+export const applyBlogSeoMetadata = (page: Page): void => {
+  if (!page.path.startsWith("/blog/") || page.path === "/blog/") return;
+  if (!page.frontmatter.cover) {
+    const cover = blogPostCoverByPath.get(page.path);
+    if (cover) page.frontmatter.cover = cover;
+  }
+};
+
+export const getSitemapLastModified = (page: Page): string => {
+  if (typeof page.frontmatter.lastmod === "string")
+    return page.frontmatter.lastmod;
+  const pageDate = toIsoString(page.frontmatter.date || page.frontmatter.time);
+  if (pageDate) return pageDate;
+  if (page.data.git?.updatedTime)
+    return new Date(page.data.git.updatedTime).toISOString();
+  if (page.filePath) {
+    try {
+      return statSync(page.filePath).mtime.toISOString();
+    } catch {
+      return "";
+    }
+  }
+  return "";
+};

--- a/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
@@ -1,0 +1,92 @@
+import { PackageMetadataLocal, Topic } from '@openupm/types';
+
+import {
+  buildCrawlablePackageSummaries,
+  buildPackageListDescription,
+  buildPackageStructuredData,
+  getLatestPackageLastModified,
+  getPackageLastModified,
+  structuredDataHead,
+} from '../src/seo.js';
+
+const topic = {
+  name: 'AI',
+  slug: 'ai',
+  keywords: ['machine learning', 'llm'],
+  urlPath: '/packages/topics/ai/',
+} as Topic;
+
+const packageMetadata = {
+  name: 'com.example.ai',
+  aliases: [],
+  repoUrl: 'https://github.com/example/ai',
+  displayName: 'Example AI',
+  description: 'AI helpers for Unity projects.',
+  licenseSpdxId: 'MIT',
+  licenseName: 'MIT License',
+  topics: ['ai'],
+  hunter: 'hunter',
+  createdAt: 1_700_000_000_000,
+  image: 'https://example.com/cover.png',
+  trackingMode: 'git',
+  repo: 'ai',
+  owner: 'example',
+  ownerUrl: 'https://github.com/example',
+  parentRepo: null,
+  parentOwner: null,
+  parentOwnerUrl: null,
+  readmeBranch: 'main',
+  hunterUrl: 'https://github.com/hunter',
+} as PackageMetadataLocal;
+
+describe('SEO metadata helpers', () => {
+  it('builds descriptions for topic package pages', () => {
+    expect(buildPackageListDescription(topic)).toContain(
+      'OpenUPM Unity packages tagged AI',
+    );
+    expect(buildPackageListDescription(topic)).toContain('machine learning');
+  });
+
+  it('builds crawlable package summaries with stable package links', () => {
+    expect(buildCrawlablePackageSummaries(topic, [packageMetadata])).toEqual([
+      {
+        description: 'AI helpers for Unity projects.',
+        name: 'com.example.ai',
+        path: '/packages/com.example.ai/',
+        title: 'Example AI',
+      },
+    ]);
+  });
+
+  it('builds SoftwareApplication and breadcrumb JSON-LD for package pages', () => {
+    const structuredData = buildPackageStructuredData(packageMetadata, [topic]);
+
+    expect(structuredData[0]).toMatchObject({
+      '@type': 'SoftwareApplication',
+      name: 'Example AI',
+      alternateName: 'com.example.ai',
+      codeRepository: 'https://github.com/example/ai',
+      keywords: 'AI',
+    });
+    expect(structuredData[1]).toMatchObject({
+      '@type': 'BreadcrumbList',
+    });
+    expect(structuredDataHead(structuredData)[0][1]).toEqual({
+      type: 'application/ld+json',
+    });
+  });
+
+  it('uses latest package metadata timestamps for deterministic sitemap dates', () => {
+    const packageLastModifiedMap = {
+      [packageMetadata.name]: 1_710_000_000_000,
+    };
+    expect(getPackageLastModified(packageMetadata, packageLastModifiedMap)).toBe(
+      '2024-03-09T16:00:00.000Z',
+    );
+    expect(
+      getLatestPackageLastModified([packageMetadata], packageLastModifiedMap),
+    ).toBe(
+      '2024-03-09T16:00:00.000Z',
+    );
+  });
+});

--- a/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
@@ -76,6 +76,19 @@ describe('SEO metadata helpers', () => {
     });
   });
 
+  it('escapes JSON-LD script-breaking characters', () => {
+    const structuredData = structuredDataHead([
+      {
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareApplication',
+        name: '</script><script>alert(1)</script>',
+      },
+    ]);
+
+    expect(structuredData[0][2]).toContain('\\u003c/script\\u003e');
+    expect(structuredData[0][2]).not.toContain('</script>');
+  });
+
   it('uses latest package metadata timestamps for deterministic sitemap dates', () => {
     const packageLastModifiedMap = {
       [packageMetadata.name]: 1_710_000_000_000,

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -85,20 +85,29 @@ const loadPackageLastModifiedMap = async (
   const releasesDir = path.resolve(getLocalDataDir(), 'packages-releases');
   const entries = await Promise.all(
     packageNames.map(async (packageName) => {
-      const releasesPath = path.resolve(releasesDir, `${packageName}.json`);
-      if (!(await fs.pathExists(releasesPath))) return [packageName, undefined];
-      const packageInfo = JSON.parse(await fs.readFile(releasesPath, 'utf8')) as {
-        releases?: PackageRelease[];
-      };
-      const latestReleaseUpdatedAt = Math.max(
-        ...(packageInfo.releases || []).map((release) => release.updatedAt || 0),
-      );
-      return [
-        packageName,
-        Number.isFinite(latestReleaseUpdatedAt) && latestReleaseUpdatedAt > 0
-          ? latestReleaseUpdatedAt
-          : undefined,
-      ];
+      try {
+        const releasesPath = path.resolve(releasesDir, `${packageName}.json`);
+        if (!(await fs.pathExists(releasesPath)))
+          return [packageName, undefined];
+        const packageInfo = JSON.parse(
+          await fs.readFile(releasesPath, 'utf8'),
+        ) as {
+          releases?: PackageRelease[];
+        };
+        const latestReleaseUpdatedAt = Math.max(
+          ...(packageInfo.releases || []).map(
+            (release) => release.updatedAt || 0,
+          ),
+        );
+        return [
+          packageName,
+          Number.isFinite(latestReleaseUpdatedAt) && latestReleaseUpdatedAt > 0
+            ? latestReleaseUpdatedAt
+            : undefined,
+        ];
+      } catch {
+        return [packageName, undefined];
+      }
     }),
   );
   return Object.fromEntries(entries);

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -12,10 +12,12 @@ import {
   Topic,
   BLOCKED_SCOPES_FILENAME,
   METADATA_LOCAL_LIST_FILENAME,
+  PackageRelease,
   SDPXLIST_FILENAME,
 } from '@openupm/types';
 import {
   collectPackageHuntersAndOwners,
+  getLocalDataDir,
   loadPackageNames,
   loadPackageMetadataLocal,
   loadTopics,
@@ -47,6 +49,17 @@ import {
   UnityNuGetInventoryEntry,
 } from './unitynuget/registry.js';
 import { writePublicGen } from './utils/write-file.js';
+import {
+  buildCrawlablePackageSummaries,
+  buildPackageListContent,
+  buildPackageListDescription,
+  buildPackageStructuredData,
+  buildUnityNuGetStructuredData,
+  getLatestPackageLastModified,
+  getPackageLastModified,
+  OPENUPM_FALLBACK_IMAGE,
+  structuredDataHead,
+} from './seo.js';
 
 type Contributor = GithubUserWithScore & {
   text: string;
@@ -57,12 +70,38 @@ type PluginData = {
   blockedScopes: string[];
   contributorProfileGithubUsers: string[];
   hunters: Contributor[];
+  packageLastModifiedMap: Record<string, number | undefined>;
   metadataLocalList: PackageMetadataLocal[];
   metadataGroupByNamespace: Record<string, PackageMetadataLocal[]>;
   owners: Contributor[];
   sdpxList: License[];
   topicsWithAll: Topic[];
   unityNuGetInventory: UnityNuGetInventoryEntry[];
+};
+
+const loadPackageLastModifiedMap = async (
+  packageNames: string[],
+): Promise<Record<string, number | undefined>> => {
+  const releasesDir = path.resolve(getLocalDataDir(), 'packages-releases');
+  const entries = await Promise.all(
+    packageNames.map(async (packageName) => {
+      const releasesPath = path.resolve(releasesDir, `${packageName}.json`);
+      if (!(await fs.pathExists(releasesPath))) return [packageName, undefined];
+      const packageInfo = JSON.parse(await fs.readFile(releasesPath, 'utf8')) as {
+        releases?: PackageRelease[];
+      };
+      const latestReleaseUpdatedAt = Math.max(
+        ...(packageInfo.releases || []).map((release) => release.updatedAt || 0),
+      );
+      return [
+        packageName,
+        Number.isFinite(latestReleaseUpdatedAt) && latestReleaseUpdatedAt > 0
+          ? latestReleaseUpdatedAt
+          : undefined,
+      ];
+    }),
+  );
+  return Object.fromEntries(entries);
 };
 
 type VuePressPlugin = {
@@ -83,6 +122,7 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
   const metadataLocalList = (
     await Promise.all(packageNames.map(loadPackageMetadataLocal))
   ).filter((x) => x) as PackageMetadataLocal[];
+  const packageLastModifiedMap = await loadPackageLastModifiedMap(packageNames);
   // Group package metadata by namespace.
   const metadataGroupByNamespace = groupBy(metadataLocalList, (x) =>
     getPackageNamespace(x.name),
@@ -141,6 +181,7 @@ const PLUGIN_DATA = await (async (): Promise<PluginData> => {
     blockedScopes,
     contributorProfileGithubUsers,
     hunters,
+    packageLastModifiedMap,
     metadataLocalList,
     metadataGroupByNamespace,
     owners,
@@ -202,7 +243,8 @@ const createContributorProfilePages = async function (
  */
 const createDetailPages = async function (app: App): Promise<Page[]> {
   const pages: Page[] = [];
-  const { metadataLocalList, topicsWithAll } = PLUGIN_DATA;
+  const { metadataLocalList, packageLastModifiedMap, topicsWithAll } =
+    PLUGIN_DATA;
   for (const metadataLocal of metadataLocalList) {
     const displayName = getLocalePackageDisplayName(metadataLocal);
     const title = metadataLocal.displayName
@@ -221,6 +263,15 @@ const createDetailPages = async function (app: App): Promise<Page[]> {
       cover,
       author,
       tags,
+      head: structuredDataHead(
+        buildPackageStructuredData(
+          metadataLocal,
+          topicsWithAll.filter(
+            (x) => x.slug && metadataLocal.topics.includes(x.slug),
+          ),
+        ),
+      ),
+      lastmod: getPackageLastModified(metadataLocal, packageLastModifiedMap),
       metadataLocal: metadataLocal,
       topics: topicsWithAll.filter(
         (x) => x.slug && metadataLocal.topics.includes(x.slug),
@@ -250,6 +301,8 @@ const createUnityNuGetDetailPages = async function (app: App): Promise<Page[]> {
       sidebar: [{ text: '', children: [] }],
       title: `${entry.nugetId} | ${entry.packageName} | UnityNuGet Package | Unity Package Manager (UPM)`,
       description: `${entry.nugetId} is available as ${entry.packageName} through the OpenUPM registry UnityNuGet uplink.`,
+      cover: OPENUPM_FALLBACK_IMAGE,
+      head: structuredDataHead(buildUnityNuGetStructuredData(entry)),
       packageKind: 'unitynuget',
       name: entry.packageName,
       nugetId: entry.nugetId,
@@ -271,20 +324,33 @@ const createUnityNuGetDetailPages = async function (app: App): Promise<Page[]> {
  */
 const createListPages = async function (app: App): Promise<Page[]> {
   const pages: Page[] = [];
-  const { topicsWithAll } = PLUGIN_DATA;
+  const { metadataLocalList, packageLastModifiedMap, topicsWithAll } =
+    PLUGIN_DATA;
   for (const topic of topicsWithAll) {
+    const topicMetadataLocalList = metadataLocalList.filter((metadataLocal) =>
+      topic.slug ? metadataLocal.topics.includes(topic.slug) : true,
+    );
+    const crawlablePackageSummaries = buildCrawlablePackageSummaries(
+      topic,
+      topicMetadataLocalList,
+    );
     // Create page
     const frontmatter = {
       layout: 'PackageListLayout',
       // Hack: use an empty element to show sidebar
       sidebar: [{ text: '', children: [] }],
       title: topic.slug ? `Packages - ${topic.name}` : 'Packages',
+      description: buildPackageListDescription(topic),
+      lastmod: getLatestPackageLastModified(
+        topicMetadataLocalList,
+        packageLastModifiedMap,
+      ),
       topicSlug: topic.slug,
     };
     const pageOptions = {
       path: topic.urlPath,
       frontmatter,
-      content: '',
+      content: buildPackageListContent(topic, crawlablePackageSummaries),
     };
     const page = await createPage(app, pageOptions);
     pages.push(page);

--- a/packages/vuepress-plugin-openupm/src/seo.ts
+++ b/packages/vuepress-plugin-openupm/src/seo.ts
@@ -51,6 +51,12 @@ const escapeHtml = (value: string): string =>
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
 
+const serializeStructuredData = (item: StructuredData): string =>
+  JSON.stringify(item)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+
 export const getPackageLastModified = (
   metadataLocal: PackageMetadataLocal,
   packageLastModifiedMap: PackageLastModifiedMap = {},
@@ -239,5 +245,5 @@ export const structuredDataHead = (
   structuredData.map((item) => [
     'script',
     { type: 'application/ld+json' },
-    JSON.stringify(item),
+    serializeStructuredData(item),
   ] as HeadConfig);

--- a/packages/vuepress-plugin-openupm/src/seo.ts
+++ b/packages/vuepress-plugin-openupm/src/seo.ts
@@ -1,0 +1,243 @@
+import type { HeadConfig } from 'vuepress/core';
+
+import { PackageMetadataLocal, Topic } from '@openupm/types';
+import {
+  getLocalePackageDescription,
+  getLocalePackageDisplayName,
+} from '@openupm/common/build/utils.js';
+import {
+  getPackageDetailPagePath,
+  getPackageDetailPageUrl,
+  getPackageListPagePath,
+} from '@openupm/common/build/urls.js';
+
+export type StructuredData = Record<string, unknown>;
+
+export interface CrawlablePackageSummary {
+  description: string;
+  name: string;
+  path: string;
+  title: string;
+}
+
+export type PackageLastModifiedMap = Record<string, number | undefined>;
+
+export const OPENUPM_FALLBACK_IMAGE = '/images/openupm-twitter.png';
+const OPENUPM_ORIGIN = 'https://openupm.com';
+
+const toIsoString = (timestamp: number): string | undefined => {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return undefined;
+  return new Date(timestamp).toISOString();
+};
+
+const stripMarkdownLinkSyntax = (value: string): string =>
+  value.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+
+const cleanText = (value: string): string =>
+  stripMarkdownLinkSyntax(value)
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const truncateText = (value: string, maxLength: number): string => {
+  const normalized = cleanText(value);
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+export const getPackageLastModified = (
+  metadataLocal: PackageMetadataLocal,
+  packageLastModifiedMap: PackageLastModifiedMap = {},
+): string | undefined =>
+  toIsoString(
+    Math.max(
+      packageLastModifiedMap[metadataLocal.name] || 0,
+      metadataLocal.createdAt || 0,
+    ),
+  );
+
+export const getLatestPackageLastModified = (
+  metadataLocalList: PackageMetadataLocal[],
+  packageLastModifiedMap: PackageLastModifiedMap = {},
+): string | undefined => {
+  const latestTimestamp = Math.max(
+    ...metadataLocalList.map((metadataLocal) =>
+      Math.max(
+        packageLastModifiedMap[metadataLocal.name] || 0,
+        metadataLocal.createdAt || 0,
+      ),
+    ),
+  );
+  return toIsoString(latestTimestamp);
+};
+
+export const buildPackageListDescription = (topic: Topic): string => {
+  if (!topic.slug) {
+    return 'Browse open-source Unity packages published through OpenUPM, including editor tools, runtime libraries, integrations, and package manager utilities.';
+  }
+  const keywords = topic.keywords.length
+    ? ` Related keywords include ${topic.keywords.slice(0, 6).join(', ')}.`
+    : '';
+  return `Browse OpenUPM Unity packages tagged ${topic.name}, with package details, repository links, install instructions, and related package metadata.${keywords}`;
+};
+
+export const buildCrawlablePackageSummaries = (
+  topic: Topic,
+  metadataLocalList: PackageMetadataLocal[],
+  limit = 8,
+): CrawlablePackageSummary[] =>
+  metadataLocalList
+    .filter((metadataLocal) =>
+      topic.slug ? metadataLocal.topics.includes(topic.slug) : true,
+    )
+    .filter((metadataLocal) => !metadataLocal.excludedFromList)
+    .sort((a, b) => {
+      const titleA = getLocalePackageDisplayName(a) || a.name;
+      const titleB = getLocalePackageDisplayName(b) || b.name;
+      return titleA.localeCompare(titleB);
+    })
+    .slice(0, limit)
+    .map((metadataLocal) => ({
+      description: truncateText(getLocalePackageDescription(metadataLocal), 180),
+      name: metadataLocal.name,
+      path: getPackageDetailPagePath(metadataLocal.name),
+      title: getLocalePackageDisplayName(metadataLocal) || metadataLocal.name,
+    }));
+
+export const buildPackageListContent = (
+  topic: Topic,
+  summaries: CrawlablePackageSummary[],
+): string => {
+  const heading = topic.slug ? `${topic.name} Unity Packages` : 'Unity Packages';
+  const summaryItems = summaries
+    .map(
+      (summary) =>
+        `<li><a href="${escapeHtml(summary.path)}">${escapeHtml(summary.title)}</a> ` +
+        `<span>${escapeHtml(summary.name)}</span> ` +
+        `<span>${escapeHtml(summary.description)}</span></li>`,
+    )
+    .join('');
+  return [
+    '<section class="package-list-crawl-metadata" hidden>',
+    `<h1>${escapeHtml(heading)}</h1>`,
+    `<p>${escapeHtml(buildPackageListDescription(topic))}</p>`,
+    summaryItems ? `<ul>${summaryItems}</ul>` : '',
+    '</section>',
+    '',
+  ].join('\n');
+};
+
+export const buildPackageStructuredData = (
+  metadataLocal: PackageMetadataLocal,
+  topics: Topic[],
+): StructuredData[] => {
+  const displayName = getLocalePackageDisplayName(metadataLocal);
+  const description = getLocalePackageDescription(metadataLocal);
+  const packageUrl = getPackageDetailPageUrl(metadataLocal.name);
+  const topicNames = topics.map((topic) => topic.name);
+  const softwareApplication: StructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: displayName || metadataLocal.name,
+    alternateName: metadataLocal.name,
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Unity',
+    description,
+    url: packageUrl,
+    codeRepository: metadataLocal.repoUrl,
+    author: metadataLocal.owner
+      ? {
+          '@type': 'Organization',
+          name: metadataLocal.owner,
+          url: metadataLocal.ownerUrl,
+        }
+      : undefined,
+    keywords: topicNames.length ? topicNames.join(', ') : undefined,
+    image: metadataLocal.image || undefined,
+    license: metadataLocal.licenseSpdxId || metadataLocal.licenseName || undefined,
+    dateCreated: toIsoString(metadataLocal.createdAt),
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+  };
+  const breadcrumbs: StructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Packages',
+        item: `${OPENUPM_ORIGIN}${getPackageListPagePath()}`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: displayName || metadataLocal.name,
+        item: packageUrl,
+      },
+    ],
+  };
+  return [softwareApplication, breadcrumbs];
+};
+
+export const buildUnityNuGetStructuredData = (entry: {
+  nugetId: string;
+  packageName: string;
+  version: string;
+}): StructuredData[] => {
+  const packageUrl = getPackageDetailPageUrl(entry.packageName);
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      name: entry.nugetId,
+      alternateName: entry.packageName,
+      applicationCategory: 'DeveloperApplication',
+      operatingSystem: 'Unity',
+      description: `${entry.nugetId} is available as ${entry.packageName} through the OpenUPM registry UnityNuGet uplink.`,
+      softwareVersion: entry.version,
+      url: packageUrl,
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Packages',
+        item: `${OPENUPM_ORIGIN}${getPackageListPagePath()}`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: entry.nugetId,
+          item: packageUrl,
+        },
+      ],
+    },
+  ];
+};
+
+export const structuredDataHead = (
+  structuredData: StructuredData[],
+): HeadConfig[] =>
+  structuredData.map((item) => [
+    'script',
+    { type: 'application/ld+json' },
+    JSON.stringify(item),
+  ] as HeadConfig);


### PR DESCRIPTION
## Summary
- add deterministic docs sitemap metadata for package, topic, docs, and blog pages
- add package and UnityNuGet structured data for generated package pages
- add hidden static crawl metadata for package list and topic pages without changing the live package grid
- preserve migrated blog cover metadata for social previews

## Validation
- npm run test -- seo.test.ts
- npm run test -- seoMetadata.spec.ts blog.spec.ts
- npm run build -- --filter=vuepress-plugin-openupm
- npm run docs:build:limit
- npm run lint -- --filter=vuepress-plugin-openupm --filter=@openupm/docs
- npm run lint