### PR TITLE
[codex] Reduce docs runtime metadata fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,6 @@ npm run docs:build:limit
 ```
 
 The docs app includes Node 22 compatibility aliases in `apps/docs/docs/.vuepress/config.ts`. Keep those in place unless the VuePress / Vue I18n dependency stack is upgraded and revalidated.
+
+Docs app architecture notes, including runtime data loading rules, live in
+`apps/docs/ARCHITECTURE.md`.

--- a/apps/docs/ARCHITECTURE.md
+++ b/apps/docs/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# Docs Site Architecture
+
+This file records implementation-level decisions for the VuePress docs app.
+It is intended for contributors changing `apps/docs`, not for public site
+content.
+
+## Runtime Data Loading
+
+The docs site is a static VuePress app with a small client-side data layer.
+Generated page frontmatter should carry page-specific data that is needed for
+SSR and SEO. Larger cross-page datasets should be fetched in the browser only
+when a route or layout actually needs them.
+
+The default Pinia store in `docs/.vuepress/store.ts` owns these shared runtime
+datasets:
+
+- `siteInfo`: global site stats, such as GitHub stars.
+- `packageMetadataRemoteDict`: registry/API package metadata keyed by package
+  name.
+- `packageMetadataLocalList`: generated local package metadata used for list,
+  dependency, and package-existence checks.
+- `recentPackages`: recent package data.
+
+Cached fetch actions use a five-minute freshness window. In-flight promise
+dedupe is scoped per store instance through a `WeakMap`, not module-level
+globals, so concurrent Pinia instances do not accidentally share a fetch result
+without mutating their own state.
+
+## Route-Level Fetch Rules
+
+The global client setup in `docs/.vuepress/client.ts` should stay route-aware:
+
+- Fetch `siteInfo` on mount and route changes.
+- Fetch full package-list metadata only for package list routes matched by
+  `isPackageListPath(path)`.
+- Do not globally fetch package metadata for every page.
+
+Layouts are responsible for the datasets their rendered UI needs:
+
+- `PackageListLayout.vue` fetches full package-list data because sorting,
+  filtering, topic pages, and NuGet search suggestions need both local and
+  remote metadata.
+- `PackageDetailLayout.vue` fetches remote metadata and local metadata because
+  package details use remote fields and dependency status uses package
+  existence checks.
+- `NuGetPackageDetailLayout.vue` fetches local metadata because dependency
+  rendering needs package existence checks, even though NuGet package identity
+  comes from its own packument/frontmatter path.
+- `HomeLayout.vue` fetches remote metadata for the package count, but should
+  not fetch the local metadata list.
+
+When adding a layout or changing route behavior, fetch the smallest shared
+dataset that the visible UI needs. Avoid moving layout-specific fetches into
+the global client hook unless the data is genuinely needed by most routes.
+
+## Validation
+
+Runtime payload behavior is covered by
+`__tests__/vue/runtimePayload.spec.ts`. Update that test when changing route
+fetch rules, shared store cache behavior, or layout-level metadata ownership.
+
+For focused validation from `apps/docs`, run:
+
+```bash
+npm run test -- runtimePayload.spec.ts
+npm run lint
+```
+
+For higher confidence after broader docs changes, also run the relevant focused
+Vue tests and `npm run docs:build:limit`.

--- a/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
+++ b/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
@@ -86,6 +86,9 @@ describe("NuGet package detail UI", () => {
     expect(source).toContain("const requestedPackageName = packageName.value");
     expect(source).toContain("getPackumentUrl(requestedPackageName)");
     expect(source).toContain("getPackageAdPlacementUrl(requestedPackageName)");
+    expect(source).toContain("const store = useDefaultStore()");
+    expect(source).toContain("fetchPackageDependencyMetadata()");
+    expect(source).toContain("store.fetchCachedPackageMetadataLocalList()");
     expect(source).toContain("isCurrentRequest");
     expect(source).toContain("requestId === latestRequestId");
     expect(source).toContain("<UnityAssetAdPlacement");

--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -57,5 +57,8 @@ describe("docs runtime payload fetch behavior", () => {
     expect(source).toContain("const fetchCurrentSubPageData = (): void => {");
     expect(source).toContain("currentSubPageSlug.value === SubPageSlug.related");
     expect(source).toContain("if (state.__sameScopePackagesFetched) return;");
+    expect(source).toContain(
+      "count: state.__sameScopePackagesFetched ? relatedPackages.value.length : undefined",
+    );
   });
 });

--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const vuepressFile = (path: string): string =>
+  fileURLToPath(new URL(`../../docs/.vuepress/${path}`, import.meta.url));
+
+const readVuepressFile = (path: string): string =>
+  readFileSync(vuepressFile(path), "utf8");
+
+describe("docs runtime payload fetch behavior", () => {
+  it("keeps global client fetches route-aware", () => {
+    const source = readVuepressFile("client.ts");
+
+    expect(source).toContain("isPackageListPath(path)");
+    expect(source).toContain("store.fetchCachedSiteInfo()");
+    expect(source).toContain("store.fetchCachedPackageListData()");
+    expect(source).not.toContain("store.fetchCachedPackageMetadataRemoteDict();");
+    expect(source).not.toContain("store.fetchCachedPackageMetadataLocalList();");
+  });
+
+  it("hydrates full package-list metadata only from routes and layouts that need it", () => {
+    const storeSource = readVuepressFile("store.ts");
+    const packageListSource = readVuepressFile("layouts/PackageListLayout.vue");
+    const homeSource = readVuepressFile("layouts/HomeLayout.vue");
+
+    expect(storeSource).toContain("async fetchCachedPackageListData()");
+    expect(storeSource).toContain("Promise.all([");
+    expect(packageListSource).toContain("store.fetchCachedPackageListData()");
+    expect(homeSource).toContain("store.fetchCachedPackageMetadataRemoteDict()");
+    expect(homeSource).not.toContain("store.fetchCachedPackageMetadataLocalList()");
+  });
+
+  it("loads package detail payloads without a serial all-data waterfall", () => {
+    const source = readVuepressFile("layouts/PackageDetailLayout.vue");
+
+    expect(source).toContain("await Promise.all([");
+    expect(source).toContain("fetchPackageInfo()");
+    expect(source).toContain("fetchPackument()");
+    expect(source).toContain("fetchMonthlyDownloads()");
+    expect(source).toContain("const fetchCurrentSubPageData = (): void => {");
+    expect(source).toContain("currentSubPageSlug.value === SubPageSlug.deps");
+    expect(source).toContain("currentSubPageSlug.value === SubPageSlug.related");
+    expect(source).toContain("if (state.__sameScopePackagesFetched) return;");
+  });
+});

--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -25,6 +25,18 @@ describe("docs runtime payload fetch behavior", () => {
     const packageListSource = readVuepressFile("layouts/PackageListLayout.vue");
     const homeSource = readVuepressFile("layouts/HomeLayout.vue");
 
+    expect(storeSource).toContain(
+      "const storeFetchPromises = new WeakMap<object, StoreFetchPromises>();",
+    );
+    expect(storeSource).toContain("getStoreFetchPromises(this)");
+    expect(storeSource).not.toContain(
+      "let packageMetadataRemoteDictFetchPromise",
+    );
+    expect(storeSource).not.toContain(
+      "let packageMetadataLocalListFetchPromise",
+    );
+    expect(storeSource).not.toContain("let packageListDataFetchPromise");
+    expect(storeSource).not.toContain("let siteInfoFetchPromise");
     expect(storeSource).toContain("async fetchCachedPackageListData()");
     expect(storeSource).toContain("Promise.all([");
     expect(packageListSource).toContain("store.fetchCachedPackageListData()");

--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -39,8 +39,8 @@ describe("docs runtime payload fetch behavior", () => {
     expect(source).toContain("fetchPackageInfo()");
     expect(source).toContain("fetchPackument()");
     expect(source).toContain("fetchMonthlyDownloads()");
+    expect(source).toContain("fetchPackageDependencyMetadata()");
     expect(source).toContain("const fetchCurrentSubPageData = (): void => {");
-    expect(source).toContain("currentSubPageSlug.value === SubPageSlug.deps");
     expect(source).toContain("currentSubPageSlug.value === SubPageSlug.related");
     expect(source).toContain("if (state.__sameScopePackagesFetched) return;");
   });

--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -39,7 +39,9 @@ describe("docs runtime payload fetch behavior", () => {
     expect(source).toContain("fetchPackageInfo()");
     expect(source).toContain("fetchPackument()");
     expect(source).toContain("fetchMonthlyDownloads()");
-    expect(source).toContain("fetchPackageDependencyMetadata()");
+    expect(source).toContain("fetchPackageMetadata()");
+    expect(source).toContain("store.fetchCachedPackageMetadataRemoteDict()");
+    expect(source).toContain("store.fetchCachedPackageMetadataLocalList()");
     expect(source).toContain("const fetchCurrentSubPageData = (): void => {");
     expect(source).toContain("currentSubPageSlug.value === SubPageSlug.related");
     expect(source).toContain("if (state.__sameScopePackagesFetched) return;");

--- a/apps/docs/docs/.vuepress/client.ts
+++ b/apps/docs/docs/.vuepress/client.ts
@@ -7,6 +7,7 @@ import { defineClientConfig } from "vuepress/client";
 import messages from "@intlify/unplugin-vue-i18n/messages";
 import { Breakpoints, Vue3Mq } from "vue3-mq";
 import ScriptX from "vue-scriptx";
+import { isPackageListPath } from "@openupm/common/build/urls.js";
 
 import { useDefaultStore } from "@/store";
 import { GlobalFilters } from "@/vue-plugins/global-filters";
@@ -65,17 +66,18 @@ export default defineClientConfig({
     });
   },
   setup() {
-    const fetchSiteData = (): void => {
+    const fetchSiteData = (path: string): void => {
       const store = useDefaultStore();
       store.fetchCachedSiteInfo();
-      store.fetchCachedPackageMetadataRemoteDict();
-      store.fetchCachedPackageMetadataLocalList();
+      if (isPackageListPath(path)) {
+        store.fetchCachedPackageListData();
+      }
     };
-    onMounted(() => fetchSiteData());
     const route = useRoute();
+    onMounted(() => fetchSiteData(route.path));
     watch(
       () => route.path,
-      () => fetchSiteData(),
+      (path) => fetchSiteData(path),
     );
   },
   layouts: {

--- a/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onMounted } from "vue";
 import { usePageFrontmatter } from "@vuepress/client";
 
 import ParentLayout from "@/layouts/WideLayout.vue";
@@ -120,6 +120,10 @@ const discoveredPackages = computed(() => {
 
 const isLoading = computed(() => {
   return !metadataLocalList.value.length;
+});
+
+onMounted(() => {
+  store.fetchCachedPackageMetadataLocalList();
 });
 </script>
 

--- a/apps/docs/docs/.vuepress/layouts/HomeLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/HomeLayout.vue
@@ -2,7 +2,7 @@
 import { capitalize, template } from 'lodash-es';
 import { useI18n } from 'vue-i18n';
 import numeral from 'numeral';
-import { computed } from 'vue';
+import { computed, onMounted } from 'vue';
 
 import ParentLayout from "@/layouts/WideLayout.vue";
 import { useDefaultStore } from '@/store';
@@ -43,6 +43,10 @@ const features = computed(() => {
       desc: template(item.desc)({ package_count: readyPackageCount.value }),
     };
   });
+});
+
+onMounted(() => {
+  store.fetchCachedPackageMetadataRemoteDict();
 });
 </script>
 

--- a/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
@@ -10,6 +10,7 @@ import PackageDependenciesView from "@/components/PackageDependenciesView.vue";
 import PackageSetup from "@/components/PackageSetup.vue";
 import PackageVersionsView from "@/components/PackageVersionsView.vue";
 import UnityAssetAdPlacement from "@/components/UnityAssetAdPlacement.vue";
+import { useDefaultStore } from "@/store";
 import {
   getLatestNuGetVersion,
   getNuGetDependencies,
@@ -28,6 +29,7 @@ import {
 
 const route = useRoute();
 const frontmatter = usePageFrontmatter<NuGetPackageFrontmatter>();
+const store = useDefaultStore();
 
 const packagesLink = {
   text: "Packages",
@@ -133,7 +135,12 @@ const fetchAdPlacementData = async (): Promise<void> => {
 
 const fetchAllData = async (): Promise<void> => {
   fetchAdPlacementData();
+  fetchPackageDependencyMetadata();
   await fetchPackument();
+};
+
+const fetchPackageDependencyMetadata = (): void => {
+  store.fetchCachedPackageMetadataLocalList();
 };
 
 onMounted(() => {

--- a/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
@@ -579,6 +579,8 @@ const metadata = computed(() => {
 
 // Hooks
 onMounted(() => {
+  // Fetch existing package names.
+  store.fetchCachedPackageMetadataLocalList();
   // Fetch blocked scopes.
   fetchBlockedScopes();
   // Fetch licenses.

--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -295,7 +295,7 @@ const subPages = computed(() => {
       text: capitalize(t("related-packages")),
       slug: SubPageSlug.related,
       visible: true,
-      count: relatedPackages.value.length,
+      count: state.__sameScopePackagesFetched ? relatedPackages.value.length : undefined,
       component: PackageRelatedView,
       props: {
         relatedPackages: relatedPackages.value,

--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -358,6 +358,7 @@ watch(currentSubPageSlug, () => {
  */
 const fetchAllData = async (): Promise<void> => {
   fetchAdPlacementData();
+  fetchPackageDependencyMetadata();
   await Promise.all([
     fetchPackageInfo(),
     fetchPackument(),
@@ -366,12 +367,13 @@ const fetchAllData = async (): Promise<void> => {
 };
 
 const fetchCurrentSubPageData = (): void => {
-  if (currentSubPageSlug.value === SubPageSlug.deps) {
-    store.fetchCachedPackageMetadataLocalList();
-  }
   if (currentSubPageSlug.value === SubPageSlug.related) {
     fetchRelatedPackages();
   }
+};
+
+const fetchPackageDependencyMetadata = (): void => {
+  store.fetchCachedPackageMetadataLocalList();
 };
 
 /**

--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -335,6 +335,7 @@ const topics = computed(() => {
 // Hooks
 onMounted(() => {
   fetchAllData();
+  fetchCurrentSubPageData();
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -342,7 +343,12 @@ watch(() => route.path, (newPath, oldPath) => {
   if (isPackageDetailPath(newPath)) {
     resetState();
     fetchAllData();
+    fetchCurrentSubPageData();
   }
+});
+
+watch(currentSubPageSlug, () => {
+  fetchCurrentSubPageData();
 });
 
 // Methods
@@ -352,10 +358,20 @@ watch(() => route.path, (newPath, oldPath) => {
  */
 const fetchAllData = async (): Promise<void> => {
   fetchAdPlacementData();
-  await fetchPackageInfo();
-  await fetchPackument();
-  await fetchMonthlyDownloads();
-  await fetchRelatedPackages();
+  await Promise.all([
+    fetchPackageInfo(),
+    fetchPackument(),
+    fetchMonthlyDownloads(),
+  ]);
+};
+
+const fetchCurrentSubPageData = (): void => {
+  if (currentSubPageSlug.value === SubPageSlug.deps) {
+    store.fetchCachedPackageMetadataLocalList();
+  }
+  if (currentSubPageSlug.value === SubPageSlug.related) {
+    fetchRelatedPackages();
+  }
 };
 
 /**
@@ -422,6 +438,7 @@ const fetchPackument = async (): Promise<void> => {
  * Fetch related packages.
  */
 const fetchRelatedPackages = async (): Promise<void> => {
+  if (state.__sameScopePackagesFetched) return;
   try {
     let resp = await axios.get(
       getPackageRelatedPackagesPath(packageMetadata.value.name),

--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -358,7 +358,7 @@ watch(currentSubPageSlug, () => {
  */
 const fetchAllData = async (): Promise<void> => {
   fetchAdPlacementData();
-  fetchPackageDependencyMetadata();
+  fetchPackageMetadata();
   await Promise.all([
     fetchPackageInfo(),
     fetchPackument(),
@@ -372,7 +372,8 @@ const fetchCurrentSubPageData = (): void => {
   }
 };
 
-const fetchPackageDependencyMetadata = (): void => {
+const fetchPackageMetadata = (): void => {
+  store.fetchCachedPackageMetadataRemoteDict();
   store.fetchCachedPackageMetadataLocalList();
 };
 

--- a/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
@@ -270,6 +270,7 @@ const fetchAdPlacementData = async (): Promise<void> => {
 // Hooks
 onMounted(() => {
   parseQuery();
+  store.fetchCachedPackageListData();
   fetchAdPlacementData();
 });
 
@@ -296,6 +297,7 @@ watch(() => searchTerm.value, () => {
 });
 
 watch(() => topicSlug.value, () => {
+  store.fetchCachedPackageListData();
   fetchAdPlacementData();
 });
 </script>

--- a/apps/docs/docs/.vuepress/store.ts
+++ b/apps/docs/docs/.vuepress/store.ts
@@ -13,6 +13,11 @@ import { parsePackageMetadataRemote } from "@openupm/common/build/utils.js";
 import { METADATA_LOCAL_LIST_FILENAME } from "@openupm/types";
 import numeral from "numeral";
 
+let packageMetadataRemoteDictFetchPromise: Promise<void> | null = null;
+let packageMetadataLocalListFetchPromise: Promise<void> | null = null;
+let packageListDataFetchPromise: Promise<void> | null = null;
+let siteInfoFetchPromise: Promise<void> | null = null;
+
 export const useDefaultStore = defineStore("pinia-default", {
   persist: __VUEPRESS_SSR__ ? false : true,
   state() {
@@ -78,7 +83,14 @@ export const useDefaultStore = defineStore("pinia-default", {
       const timeElapsed =
         new Date().getTime() - (this.__packageMetadataRemoteDictFetchTime || 0);
       const cacheTime = 5 * 60 * 1000;
-      if (timeElapsed > cacheTime) await this.fetchPackageMetadataRemoteDict();
+      if (timeElapsed <= cacheTime) return;
+      if (!packageMetadataRemoteDictFetchPromise) {
+        packageMetadataRemoteDictFetchPromise =
+          this.fetchPackageMetadataRemoteDict().finally(() => {
+            packageMetadataRemoteDictFetchPromise = null;
+          });
+      }
+      await packageMetadataRemoteDictFetchPromise;
     },
     /**
      * Fetch package metadata local list into the store.
@@ -102,7 +114,28 @@ export const useDefaultStore = defineStore("pinia-default", {
       const timeElapsed =
         new Date().getTime() - (this.__packageMetadataLocalListFetchTime || 0);
       const cacheTime = 5 * 60 * 1000;
-      if (timeElapsed > cacheTime) await this.fetchPackageMetadataLocalList();
+      if (timeElapsed <= cacheTime) return;
+      if (!packageMetadataLocalListFetchPromise) {
+        packageMetadataLocalListFetchPromise =
+          this.fetchPackageMetadataLocalList().finally(() => {
+            packageMetadataLocalListFetchPromise = null;
+          });
+      }
+      await packageMetadataLocalListFetchPromise;
+    },
+    /**
+     * Fetch the package list data required by list/search views with cache.
+     */
+    async fetchCachedPackageListData() {
+      if (!packageListDataFetchPromise) {
+        packageListDataFetchPromise = Promise.all([
+          this.fetchCachedPackageMetadataRemoteDict(),
+          this.fetchCachedPackageMetadataLocalList(),
+        ]).then(() => undefined).finally(() => {
+          packageListDataFetchPromise = null;
+        });
+      }
+      await packageListDataFetchPromise;
     },
     /**
      * Fetch recent packages into the store.
@@ -140,7 +173,13 @@ export const useDefaultStore = defineStore("pinia-default", {
       const timeElapsed =
         new Date().getTime() - (this.__siteInfoFetchTime || 0);
       const cacheTime = 5 * 60 * 1000;
-      if (timeElapsed > cacheTime) await this.fetchSiteInfo();
+      if (timeElapsed <= cacheTime) return;
+      if (!siteInfoFetchPromise) {
+        siteInfoFetchPromise = this.fetchSiteInfo().finally(() => {
+          siteInfoFetchPromise = null;
+        });
+      }
+      await siteInfoFetchPromise;
     },
   },
 });

--- a/apps/docs/docs/.vuepress/store.ts
+++ b/apps/docs/docs/.vuepress/store.ts
@@ -13,10 +13,23 @@ import { parsePackageMetadataRemote } from "@openupm/common/build/utils.js";
 import { METADATA_LOCAL_LIST_FILENAME } from "@openupm/types";
 import numeral from "numeral";
 
-let packageMetadataRemoteDictFetchPromise: Promise<void> | null = null;
-let packageMetadataLocalListFetchPromise: Promise<void> | null = null;
-let packageListDataFetchPromise: Promise<void> | null = null;
-let siteInfoFetchPromise: Promise<void> | null = null;
+type StoreFetchPromises = {
+  packageMetadataRemoteDict?: Promise<void> | null;
+  packageMetadataLocalList?: Promise<void> | null;
+  packageListData?: Promise<void> | null;
+  siteInfo?: Promise<void> | null;
+};
+
+const storeFetchPromises = new WeakMap<object, StoreFetchPromises>();
+
+const getStoreFetchPromises = (store: object): StoreFetchPromises => {
+  let fetchPromises = storeFetchPromises.get(store);
+  if (!fetchPromises) {
+    fetchPromises = {};
+    storeFetchPromises.set(store, fetchPromises);
+  }
+  return fetchPromises;
+};
 
 export const useDefaultStore = defineStore("pinia-default", {
   persist: __VUEPRESS_SSR__ ? false : true,
@@ -84,13 +97,14 @@ export const useDefaultStore = defineStore("pinia-default", {
         new Date().getTime() - (this.__packageMetadataRemoteDictFetchTime || 0);
       const cacheTime = 5 * 60 * 1000;
       if (timeElapsed <= cacheTime) return;
-      if (!packageMetadataRemoteDictFetchPromise) {
-        packageMetadataRemoteDictFetchPromise =
+      const fetchPromises = getStoreFetchPromises(this);
+      if (!fetchPromises.packageMetadataRemoteDict) {
+        fetchPromises.packageMetadataRemoteDict =
           this.fetchPackageMetadataRemoteDict().finally(() => {
-            packageMetadataRemoteDictFetchPromise = null;
+            fetchPromises.packageMetadataRemoteDict = null;
           });
       }
-      await packageMetadataRemoteDictFetchPromise;
+      await fetchPromises.packageMetadataRemoteDict;
     },
     /**
      * Fetch package metadata local list into the store.
@@ -115,27 +129,29 @@ export const useDefaultStore = defineStore("pinia-default", {
         new Date().getTime() - (this.__packageMetadataLocalListFetchTime || 0);
       const cacheTime = 5 * 60 * 1000;
       if (timeElapsed <= cacheTime) return;
-      if (!packageMetadataLocalListFetchPromise) {
-        packageMetadataLocalListFetchPromise =
+      const fetchPromises = getStoreFetchPromises(this);
+      if (!fetchPromises.packageMetadataLocalList) {
+        fetchPromises.packageMetadataLocalList =
           this.fetchPackageMetadataLocalList().finally(() => {
-            packageMetadataLocalListFetchPromise = null;
+            fetchPromises.packageMetadataLocalList = null;
           });
       }
-      await packageMetadataLocalListFetchPromise;
+      await fetchPromises.packageMetadataLocalList;
     },
     /**
      * Fetch the package list data required by list/search views with cache.
      */
     async fetchCachedPackageListData() {
-      if (!packageListDataFetchPromise) {
-        packageListDataFetchPromise = Promise.all([
+      const fetchPromises = getStoreFetchPromises(this);
+      if (!fetchPromises.packageListData) {
+        fetchPromises.packageListData = Promise.all([
           this.fetchCachedPackageMetadataRemoteDict(),
           this.fetchCachedPackageMetadataLocalList(),
         ]).then(() => undefined).finally(() => {
-          packageListDataFetchPromise = null;
+          fetchPromises.packageListData = null;
         });
       }
-      await packageListDataFetchPromise;
+      await fetchPromises.packageListData;
     },
     /**
      * Fetch recent packages into the store.
@@ -174,12 +190,13 @@ export const useDefaultStore = defineStore("pinia-default", {
         new Date().getTime() - (this.__siteInfoFetchTime || 0);
       const cacheTime = 5 * 60 * 1000;
       if (timeElapsed <= cacheTime) return;
-      if (!siteInfoFetchPromise) {
-        siteInfoFetchPromise = this.fetchSiteInfo().finally(() => {
-          siteInfoFetchPromise = null;
+      const fetchPromises = getStoreFetchPromises(this);
+      if (!fetchPromises.siteInfo) {
+        fetchPromises.siteInfo = this.fetchSiteInfo().finally(() => {
+          fetchPromises.siteInfo = null;
         });
       }
-      await siteInfoFetchPromise;
+      await fetchPromises.siteInfo;
     },
   },
 });


### PR DESCRIPTION
## Summary

- make docs client metadata fetching route-aware so ordinary docs and blog pages avoid package-list payloads
- keep package-list, home, package-add, contributor profile, and package detail layouts responsible for the package metadata they directly need
- de-duplicate cached package metadata fetches and parallelize independent package-detail API requests
- add focused runtime-payload coverage for the route-aware fetch contracts

## Validation

- `npm run test -- runtimePayload.spec.ts search.spec.ts nugetPackageDetail.spec.ts packageRepositoryStatus.spec.ts`
- `npm run lint`
- `volta run npm run docs:build:limit` passed during branch validation before the final review-only metadata fetch adjustment; latest local rerun failed in VuePress theme dependency transform before reaching changed source files
- GitHub CI passed on the latest head
- staged locally and reviewed package list search, sort, topic navigation, package detail subpages, README rendering, and UnityNuGet search suggestions