### PR TITLE
[codex] Show retry detail for recent failed releases

### DIFF
--- a/apps/docs/__tests__/vue/queueStatusView.spec.ts
+++ b/apps/docs/__tests__/vue/queueStatusView.spec.ts
@@ -6,6 +6,7 @@ import {
   PublicQueueStatus,
   formatCountdown,
   formatDuration,
+  formatReleaseRetryable,
   formatRelativeTime,
   isQueueStatusEmpty,
   packageUrl,
@@ -99,6 +100,51 @@ describe("@/queueStatusView", () => {
     packageUrl("com.example/package").should.equal(
       "/packages/com.example%2Fpackage/",
     );
+  });
+
+  it("formats retryable release cells with retry state details", () => {
+    const now = new Date("2026-05-14T10:00:00.000Z").getTime();
+    const release = {
+      package: "com.example.retry",
+      version: "1.0.0",
+      state: "Failed",
+      reason: "BuildTimeout",
+      updatedAt: "2026-05-14T09:59:00.000Z",
+      source: "git" as const,
+      signed: false,
+      retryable: true,
+    };
+
+    formatReleaseRetryable(
+      {
+        ...release,
+        attempts: 1,
+        maxAttempts: 3,
+        nextRetryAt: "2026-05-14T10:00:18.000Z",
+        retryState: "scheduled",
+      },
+      now,
+    ).should.equal("yes, 1/3, next in 18s");
+    formatReleaseRetryable(
+      { ...release, attempts: 1, maxAttempts: 3, retryState: "waiting" },
+      now,
+    ).should.equal("yes, 1/3, waiting");
+    formatReleaseRetryable(
+      { ...release, attempts: 2, maxAttempts: 3, retryState: "active" },
+      now,
+    ).should.equal("yes, 2/3, running");
+    formatReleaseRetryable(
+      { ...release, attempts: 3, maxAttempts: 3, retryState: "exhausted" },
+      now,
+    ).should.equal("yes, 3/3, exhausted");
+    formatReleaseRetryable(
+      { ...release, retryState: "ready_to_requeue" },
+      now,
+    ).should.equal("yes, ready to requeue");
+    formatReleaseRetryable(
+      { ...release, retryable: false, retryState: "not_retryable" },
+      now,
+    ).should.equal("no");
   });
 
   it("represents api error state as a non-empty absence of data", () => {

--- a/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
+++ b/apps/docs/docs/.vuepress/components/QueueStatusPage.vue
@@ -203,7 +203,7 @@
             </a>
             <span v-else>{{ releaseReasonText(release) }}</span>
           </td>
-          <td>{{ release.retryable ? "yes" : "no" }}</td>
+          <td>{{ formatReleaseRetryable(release, nowMs) }}</td>
         </tr>
       </QueueStatusTable>
 
@@ -247,6 +247,7 @@ import {
   PublicReleaseSummary,
   formatCountdown,
   formatDuration,
+  formatReleaseRetryable,
   formatRelativeTime,
   isQueueStatusEmpty,
   packageUrl,

--- a/apps/docs/docs/.vuepress/queueStatusView.ts
+++ b/apps/docs/docs/.vuepress/queueStatusView.ts
@@ -20,6 +20,16 @@ export interface PublicReleaseSummary {
   source: "git" | "githubRelease";
   signed: boolean;
   retryable?: boolean;
+  attempts?: number;
+  maxAttempts?: number;
+  nextRetryAt?: string;
+  retryState?:
+    | "not_retryable"
+    | "scheduled"
+    | "waiting"
+    | "active"
+    | "exhausted"
+    | "ready_to_requeue";
 }
 
 export interface PublicQueueStatus {
@@ -128,6 +138,52 @@ export function formatCountdown(value: string | null, nowMs = Date.now()): strin
     return `Next scan in ${Math.floor(remaining / minute)}m`;
   }
   return `Next scan in ${formatDuration(remaining)}`;
+}
+
+function formatRetryAttempts(release: PublicReleaseSummary): string {
+  if (
+    typeof release.attempts !== "number" ||
+    typeof release.maxAttempts !== "number"
+  ) {
+    return "yes";
+  }
+  return `yes, ${release.attempts}/${release.maxAttempts}`;
+}
+
+function formatNextRetry(value: string | undefined, nowMs: number): string {
+  if (!value) return "soon";
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return "soon";
+  const remaining = Math.max(0, timestamp - nowMs);
+  if (remaining <= 0) return "soon";
+  if (remaining < 60 * 1000) return `${Math.ceil(remaining / 1000)}s`;
+  return formatDuration(remaining);
+}
+
+export function formatReleaseRetryable(
+  release: PublicReleaseSummary,
+  nowMs = Date.now(),
+): string {
+  if (release.retryable !== true || release.retryState === "not_retryable") {
+    return "no";
+  }
+
+  const prefix = formatRetryAttempts(release);
+  switch (release.retryState) {
+    case "scheduled":
+      return `${prefix}, next in ${formatNextRetry(release.nextRetryAt, nowMs)}`;
+    case "waiting":
+      return `${prefix}, waiting`;
+    case "active":
+      return `${prefix}, running`;
+    case "exhausted":
+      return `${prefix}, exhausted`;
+    case "ready_to_requeue":
+    case undefined:
+      return "yes, ready to requeue";
+    case "not_retryable":
+      return "no";
+  }
 }
 
 export function packageUrl(packageName: string): string {

--- a/apps/web/__tests__/status/queueStatus.spec.ts
+++ b/apps/web/__tests__/status/queueStatus.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ReleaseErrorCode, ReleaseState } from '@openupm/types';
+import { ReleaseErrorCode, ReleaseModel, ReleaseState } from '@openupm/types';
 
 import {
   buildPublicQueueStatus,
@@ -17,6 +17,7 @@ function createJob(params: {
   finishedOn?: number;
   attemptsMade?: number;
   attempts?: number;
+  delay?: number;
   failedReason?: string;
 }) {
   return {
@@ -24,6 +25,7 @@ function createJob(params: {
     name: 'job',
     data: params.data ?? {},
     attemptsMade: params.attemptsMade ?? 0,
+    delay: params.delay,
     opts: { attempts: params.attempts ?? 3 },
     timestamp: params.timestamp ?? 1_700_000_000_000,
     processedOn: params.processedOn,
@@ -232,6 +234,7 @@ describe('buildPublicQueueStatus', () => {
     expect(status.recentFailedReleases[0]).toMatchObject({
       reason: 'BuildTimeout',
       buildId: '12345',
+      retryState: 'ready_to_requeue',
     });
     expect(JSON.stringify(status)).not.toContain('/srv/private/path');
   });
@@ -282,6 +285,144 @@ describe('buildPublicQueueStatus', () => {
     expect(status.recentSuccessfulReleases).toHaveLength(2);
     expect(packageQueue.getJobs).toHaveBeenCalledWith(['failed'], 0, 1, false);
     expect(packageQueue.getJobs).toHaveBeenCalledWith(['waiting'], 0, 0, true);
+    expect(releaseQueue.getJobs).toHaveBeenCalledWith(['delayed'], 0, 1, true);
+  });
+
+  it('adds retry state details to recent failed releases', async () => {
+    const now = Date.parse('2026-05-14T10:00:00.000Z');
+    const packageQueue = createQueue({
+      counts: { waiting: 0, active: 0, delayed: 0, failed: 0 },
+    });
+    const releaseQueue = createQueue({
+      counts: { waiting: 1, active: 1, delayed: 1, failed: 1 },
+      jobs: {
+        delayed: [
+          createJob({
+            id: 'build-rel|com.retry.scheduled|1.0.0',
+            state: 'delayed',
+            timestamp: now,
+            delay: 18_000,
+            attemptsMade: 1,
+            attempts: 3,
+          }),
+        ],
+        waiting: [
+          createJob({
+            id: 'build-rel|com.retry.waiting|1.0.0',
+            state: 'waiting',
+            attemptsMade: 1,
+            attempts: 3,
+          }),
+        ],
+        active: [
+          createJob({
+            id: 'build-rel|com.retry.running|1.0.0',
+            state: 'active',
+            attemptsMade: 2,
+            attempts: 3,
+          }),
+        ],
+        failed: [
+          createJob({
+            id: 'build-rel|com.retry.exhausted|1.0.0',
+            state: 'failed',
+            attemptsMade: 3,
+            attempts: 3,
+          }),
+          createJob({
+            id: 'build-rel|com.retry.not-exhausted|1.0.0',
+            state: 'failed',
+            attemptsMade: 1,
+            attempts: 3,
+          }),
+        ],
+      },
+    });
+    const release = (
+      packageName: string,
+      reason: ReleaseErrorCode,
+    ): ReleaseModel => ({
+      packageName,
+      version: '1.0.0',
+      state: ReleaseState.Failed,
+      reason,
+      commit: '',
+      tag: '',
+      buildId: '',
+      createdAt: now,
+      updatedAt: now,
+      source: 'git',
+      signed: false,
+    });
+
+    const status = await buildPublicQueueStatus(
+      {
+        packageQueue,
+        releaseQueue,
+        getRecentSuccessfulReleases: async () => [],
+        getRecentFailedReleases: async () => [
+          release('com.retry.scheduled', ReleaseErrorCode.BuildTimeout),
+          release('com.retry.waiting', ReleaseErrorCode.ConnectionTimeout),
+          release(
+            'com.retry.running',
+            ReleaseErrorCode.GitHubReleaseApiError,
+          ),
+          release('com.retry.exhausted', ReleaseErrorCode.BuildTimeout),
+          release('com.retry.ready', ReleaseErrorCode.ConnectionTimeout),
+          release('com.retry.not-exhausted', ReleaseErrorCode.BuildTimeout),
+          release('com.no.retry', ReleaseErrorCode.PackageNotFound),
+        ],
+        now: () => now,
+      },
+      { jobLimit: 20, releaseLimit: 20 },
+    );
+
+    expect(status.recentFailedReleases).toMatchObject([
+      {
+        package: 'com.retry.scheduled',
+        retryable: true,
+        retryState: 'scheduled',
+        attempts: 1,
+        maxAttempts: 3,
+        nextRetryAt: '2026-05-14T10:00:18.000Z',
+      },
+      {
+        package: 'com.retry.waiting',
+        retryable: true,
+        retryState: 'waiting',
+        attempts: 1,
+        maxAttempts: 3,
+      },
+      {
+        package: 'com.retry.running',
+        retryable: true,
+        retryState: 'active',
+        attempts: 2,
+        maxAttempts: 3,
+      },
+      {
+        package: 'com.retry.exhausted',
+        retryable: true,
+        retryState: 'exhausted',
+        attempts: 3,
+        maxAttempts: 3,
+      },
+      {
+        package: 'com.retry.ready',
+        retryable: true,
+        retryState: 'ready_to_requeue',
+      },
+      {
+        package: 'com.retry.not-exhausted',
+        retryable: true,
+        retryState: 'ready_to_requeue',
+      },
+      {
+        package: 'com.no.retry',
+        retryable: false,
+        retryState: 'not_retryable',
+      },
+    ]);
   });
 });
 

--- a/apps/web/__tests__/status/queueStatus.spec.ts
+++ b/apps/web/__tests__/status/queueStatus.spec.ts
@@ -54,6 +54,13 @@ function createQueue(params: {
         : [...jobs].sort((a, b) => b.timestamp - a.timestamp);
       return sorted.slice(0, (end ?? sorted.length - 1) + 1);
     }),
+    getJob: vi.fn(async (jobId: string) => {
+      return (
+        Object.values(params.jobs ?? {})
+          .flat()
+          .find((job) => `${job.id ?? ''}` === jobId) ?? null
+      );
+    }),
     client: Promise.resolve({
       zscore: vi.fn(async (_key: string, member: string) => {
         const score = params.delayedScores?.[member];
@@ -291,7 +298,6 @@ describe('buildPublicQueueStatus', () => {
     expect(status.recentSuccessfulReleases).toHaveLength(2);
     expect(packageQueue.getJobs).toHaveBeenCalledWith(['failed'], 0, 1, false);
     expect(packageQueue.getJobs).toHaveBeenCalledWith(['waiting'], 0, 0, true);
-    expect(releaseQueue.getJobs).toHaveBeenCalledWith(['delayed'], 0, 1, true);
   });
 
   it('adds retry state details to recent failed releases', async () => {
@@ -300,9 +306,16 @@ describe('buildPublicQueueStatus', () => {
       counts: { waiting: 0, active: 0, delayed: 0, failed: 0 },
     });
     const releaseQueue = createQueue({
-      counts: { waiting: 1, active: 1, delayed: 1, failed: 1 },
+      counts: { waiting: 1, active: 1, delayed: 2, failed: 1 },
       jobs: {
         delayed: [
+          createJob({
+            id: 'build-rel|com.other.delayed|1.0.0',
+            state: 'delayed',
+            timestamp: now - 600_000,
+            attemptsMade: 1,
+            attempts: 3,
+          }),
           createJob({
             id: 'build-rel|com.retry.scheduled|1.0.0',
             state: 'delayed',
@@ -343,6 +356,7 @@ describe('buildPublicQueueStatus', () => {
         ],
       },
       delayedScores: {
+        'build-rel|com.other.delayed|1.0.0': (now + 60_000) * 0x1000,
         'build-rel|com.retry.scheduled|1.0.0': (now + 18_000) * 0x1000,
       },
     });
@@ -382,7 +396,7 @@ describe('buildPublicQueueStatus', () => {
         ],
         now: () => now,
       },
-      { jobLimit: 20, releaseLimit: 20 },
+      { jobLimit: 1, releaseLimit: 20 },
     );
 
     expect(status.recentFailedReleases).toMatchObject([

--- a/apps/web/__tests__/status/queueStatus.spec.ts
+++ b/apps/web/__tests__/status/queueStatus.spec.ts
@@ -17,7 +17,6 @@ function createJob(params: {
   finishedOn?: number;
   attemptsMade?: number;
   attempts?: number;
-  delay?: number;
   failedReason?: string;
 }) {
   return {
@@ -25,7 +24,6 @@ function createJob(params: {
     name: 'job',
     data: params.data ?? {},
     attemptsMade: params.attemptsMade ?? 0,
-    delay: params.delay,
     opts: { attempts: params.attempts ?? 3 },
     timestamp: params.timestamp ?? 1_700_000_000_000,
     processedOn: params.processedOn,
@@ -39,6 +37,7 @@ function createQueue(params: {
   counts: Record<string, number>;
   workers?: unknown[];
   jobs?: Record<string, ReturnType<typeof createJob>[]>;
+  delayedScores?: Record<string, number>;
 }) {
   return {
     getJobCounts: vi.fn(async (...types: string[]) => {
@@ -55,6 +54,13 @@ function createQueue(params: {
         : [...jobs].sort((a, b) => b.timestamp - a.timestamp);
       return sorted.slice(0, (end ?? sorted.length - 1) + 1);
     }),
+    client: Promise.resolve({
+      zscore: vi.fn(async (_key: string, member: string) => {
+        const score = params.delayedScores?.[member];
+        return typeof score === 'number' ? `${score}` : null;
+      }),
+    }),
+    toKey: vi.fn((type: string) => `queue:${type}`),
   };
 }
 
@@ -300,8 +306,7 @@ describe('buildPublicQueueStatus', () => {
           createJob({
             id: 'build-rel|com.retry.scheduled|1.0.0',
             state: 'delayed',
-            timestamp: now,
-            delay: 18_000,
+            timestamp: now - 300_000,
             attemptsMade: 1,
             attempts: 3,
           }),
@@ -336,6 +341,9 @@ describe('buildPublicQueueStatus', () => {
             attempts: 3,
           }),
         ],
+      },
+      delayedScores: {
+        'build-rel|com.retry.scheduled|1.0.0': (now + 18_000) * 0x1000,
       },
     });
     const release = (

--- a/apps/web/src/status/queueStatus.ts
+++ b/apps/web/src/status/queueStatus.ts
@@ -34,6 +34,16 @@ export interface PublicReleaseSummary {
   source: 'git' | 'githubRelease';
   signed: boolean;
   retryable?: boolean;
+  attempts?: number;
+  maxAttempts?: number;
+  nextRetryAt?: string;
+  retryState?:
+    | 'not_retryable'
+    | 'scheduled'
+    | 'waiting'
+    | 'active'
+    | 'exhausted'
+    | 'ready_to_requeue';
 }
 
 export interface PublicQueueStatus {
@@ -87,6 +97,7 @@ interface QueueJobLike {
   name: string;
   data: unknown;
   attemptsMade: number;
+  delay?: number;
   opts?: { attempts?: number };
   timestamp: number;
   processedOn?: number;
@@ -191,6 +202,70 @@ function parsePackageJobName(job: Pick<QueueJobLike, 'id' | 'data'>): string {
   return parts[1] || `${job.id ?? ''}`;
 }
 
+type ReleaseRetryState = NonNullable<PublicReleaseSummary['retryState']>;
+
+interface ReleaseRetryMetadata {
+  attempts?: number;
+  maxAttempts?: number;
+  nextRetryAt?: string;
+  retryState: ReleaseRetryState;
+}
+
+function releaseIdentityKey(packageName: string, version: string): string {
+  return `${packageName}\0${version}`;
+}
+
+function delayedJobNextRetryAt(job: Job | QueueJobLike): string | undefined {
+  if (typeof job.delay !== 'number' || job.delay <= 0) return undefined;
+  return toIso(job.timestamp + job.delay);
+}
+
+function retryMetadataFromJob(
+  job: Job | QueueJobLike,
+  retryState: Exclude<ReleaseRetryState, 'not_retryable' | 'ready_to_requeue'>,
+): ReleaseRetryMetadata {
+  return {
+    attempts: job.attemptsMade,
+    maxAttempts: job.opts?.attempts ?? 1,
+    nextRetryAt:
+      retryState === 'scheduled' ? delayedJobNextRetryAt(job) : undefined,
+    retryState,
+  };
+}
+
+function buildReleaseRetryMetadata(
+  jobs: {
+    delayed: Array<Job | QueueJobLike>;
+    waiting: Array<Job | QueueJobLike>;
+    active: Array<Job | QueueJobLike>;
+    failed: Array<Job | QueueJobLike>;
+  },
+): Map<string, ReleaseRetryMetadata> {
+  const metadata = new Map<string, ReleaseRetryMetadata>();
+  const addJob = (
+    job: Job | QueueJobLike,
+    retryState: Exclude<
+      ReleaseRetryState,
+      'not_retryable' | 'ready_to_requeue'
+    >,
+  ): void => {
+    const release = parseReleaseJobIdentity(job);
+    if (!release.packageName || !release.version) return;
+    const key = releaseIdentityKey(release.packageName, release.version);
+    if (metadata.has(key)) return;
+    metadata.set(key, retryMetadataFromJob(job, retryState));
+  };
+
+  for (const job of jobs.delayed) addJob(job, 'scheduled');
+  for (const job of jobs.waiting) addJob(job, 'waiting');
+  for (const job of jobs.active) addJob(job, 'active');
+  for (const job of jobs.failed) {
+    const maxAttempts = job.opts?.attempts ?? 1;
+    if (job.attemptsMade >= maxAttempts) addJob(job, 'exhausted');
+  }
+  return metadata;
+}
+
 async function summarizeJob(
   job: Job | QueueJobLike,
   type: 'package' | 'release',
@@ -247,6 +322,7 @@ async function getLimitedJobs(
 function summarizeRelease(
   release: ReleaseModel,
   includeRetryable: boolean,
+  retryMetadata?: ReleaseRetryMetadata,
 ): PublicReleaseSummary {
   const summary: PublicReleaseSummary = {
     package: release.packageName,
@@ -259,7 +335,18 @@ function summarizeRelease(
     signed: release.signed === true,
   };
   if (includeRetryable) {
-    summary.retryable = RetryableReleaseErrorCodes.includes(release.reason);
+    const retryable = RetryableReleaseErrorCodes.includes(release.reason);
+    summary.retryable = retryable;
+    if (!retryable) {
+      summary.retryState = 'not_retryable';
+    } else if (retryMetadata) {
+      summary.attempts = retryMetadata.attempts;
+      summary.maxAttempts = retryMetadata.maxAttempts;
+      summary.nextRetryAt = retryMetadata.nextRetryAt;
+      summary.retryState = retryMetadata.retryState;
+    } else {
+      summary.retryState = 'ready_to_requeue';
+    }
   }
   return summary;
 }
@@ -323,6 +410,7 @@ export async function buildPublicQueueStatus(
     oldestWaitingPackageJobs,
     activeReleaseJobs,
     waitingReleaseJobs,
+    delayedReleaseJobs,
     failedReleaseJobs,
     recentSuccessfulReleases,
     recentFailedReleases,
@@ -331,6 +419,7 @@ export async function buildPublicQueueStatus(
     getLimitedJobs(sources.packageQueue, ['waiting'], 1, true),
     getLimitedJobs(sources.releaseQueue, ['active'], jobLimit),
     getLimitedJobs(sources.releaseQueue, ['waiting'], jobLimit, true),
+    getLimitedJobs(sources.releaseQueue, ['delayed'], jobLimit, true),
     getLimitedJobs(sources.releaseQueue, ['failed'], jobLimit),
     (
       sources.getRecentSuccessfulReleases ??
@@ -359,6 +448,12 @@ export async function buildPublicQueueStatus(
   const packageFailed = countValue(packageCounts, 'failed');
   const releaseFailed = countValue(releaseCounts, 'failed');
   const releaseWaiting = countValue(releaseCounts, 'waiting');
+  const releaseRetryMetadata = buildReleaseRetryMetadata({
+    delayed: delayedReleaseJobs,
+    waiting: waitingReleaseJobs,
+    active: activeReleaseJobs,
+    failed: failedReleaseJobs,
+  });
 
   return {
     generatedAt: new Date(now).toISOString(),
@@ -405,7 +500,15 @@ export async function buildPublicQueueStatus(
       .map((release) => summarizeRelease(release, false)),
     recentFailedReleases: recentFailedReleases
       .slice(0, releaseLimit)
-      .map((release) => summarizeRelease(release, true)),
+      .map((release) =>
+        summarizeRelease(
+          release,
+          true,
+          releaseRetryMetadata.get(
+            releaseIdentityKey(release.packageName, release.version),
+          ),
+        ),
+      ),
     retainedFailedReleaseJobs: await Promise.all(
       failedReleaseJobs.map(async (job) => await summarizeJob(job, 'release')),
     ),

--- a/apps/web/src/status/queueStatus.ts
+++ b/apps/web/src/status/queueStatus.ts
@@ -90,6 +90,10 @@ interface QueueLike {
     end?: number,
     asc?: boolean,
   ) => Promise<Array<Job | QueueJobLike>>;
+  client?: Promise<{
+    zscore: (key: string, member: string) => Promise<string | null>;
+  }>;
+  toKey?: (type: string) => string;
 }
 
 interface QueueJobLike {
@@ -97,7 +101,6 @@ interface QueueJobLike {
   name: string;
   data: unknown;
   attemptsMade: number;
-  delay?: number;
   opts?: { attempts?: number };
   timestamp: number;
   processedOn?: number;
@@ -215,53 +218,68 @@ function releaseIdentityKey(packageName: string, version: string): string {
   return `${packageName}\0${version}`;
 }
 
-function delayedJobNextRetryAt(job: Job | QueueJobLike): string | undefined {
-  if (typeof job.delay !== 'number' || job.delay <= 0) return undefined;
-  return toIso(job.timestamp + job.delay);
+async function delayedJobNextRetryAt(
+  queue: QueueLike,
+  job: Job | QueueJobLike,
+): Promise<string | undefined> {
+  if (!job.id || !queue.client || !queue.toKey) return undefined;
+  try {
+    const client = await queue.client;
+    const score = await client.zscore(queue.toKey('delayed'), `${job.id}`);
+    if (!score) return undefined;
+    const delayedAt = Math.floor(Number(score) / 0x1000);
+    return Number.isFinite(delayedAt) ? toIso(delayedAt) : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
-function retryMetadataFromJob(
+async function retryMetadataFromJob(
+  queue: QueueLike,
   job: Job | QueueJobLike,
   retryState: Exclude<ReleaseRetryState, 'not_retryable' | 'ready_to_requeue'>,
-): ReleaseRetryMetadata {
+): Promise<ReleaseRetryMetadata> {
   return {
     attempts: job.attemptsMade,
     maxAttempts: job.opts?.attempts ?? 1,
     nextRetryAt:
-      retryState === 'scheduled' ? delayedJobNextRetryAt(job) : undefined,
+      retryState === 'scheduled'
+        ? await delayedJobNextRetryAt(queue, job)
+        : undefined,
     retryState,
   };
 }
 
-function buildReleaseRetryMetadata(
+async function buildReleaseRetryMetadata(
+  releaseQueue: QueueLike,
   jobs: {
     delayed: Array<Job | QueueJobLike>;
     waiting: Array<Job | QueueJobLike>;
     active: Array<Job | QueueJobLike>;
     failed: Array<Job | QueueJobLike>;
   },
-): Map<string, ReleaseRetryMetadata> {
+): Promise<Map<string, ReleaseRetryMetadata>> {
   const metadata = new Map<string, ReleaseRetryMetadata>();
-  const addJob = (
+  const addJob = async (
     job: Job | QueueJobLike,
     retryState: Exclude<
       ReleaseRetryState,
       'not_retryable' | 'ready_to_requeue'
     >,
-  ): void => {
+  ): Promise<void> => {
     const release = parseReleaseJobIdentity(job);
     if (!release.packageName || !release.version) return;
     const key = releaseIdentityKey(release.packageName, release.version);
     if (metadata.has(key)) return;
-    metadata.set(key, retryMetadataFromJob(job, retryState));
+    metadata.set(key, await retryMetadataFromJob(releaseQueue, job, retryState));
   };
 
-  for (const job of jobs.delayed) addJob(job, 'scheduled');
-  for (const job of jobs.waiting) addJob(job, 'waiting');
-  for (const job of jobs.active) addJob(job, 'active');
+  for (const job of jobs.delayed) await addJob(job, 'scheduled');
+  for (const job of jobs.waiting) await addJob(job, 'waiting');
+  for (const job of jobs.active) await addJob(job, 'active');
   for (const job of jobs.failed) {
     const maxAttempts = job.opts?.attempts ?? 1;
-    if (job.attemptsMade >= maxAttempts) addJob(job, 'exhausted');
+    if (job.attemptsMade >= maxAttempts) await addJob(job, 'exhausted');
   }
   return metadata;
 }
@@ -448,12 +466,15 @@ export async function buildPublicQueueStatus(
   const packageFailed = countValue(packageCounts, 'failed');
   const releaseFailed = countValue(releaseCounts, 'failed');
   const releaseWaiting = countValue(releaseCounts, 'waiting');
-  const releaseRetryMetadata = buildReleaseRetryMetadata({
-    delayed: delayedReleaseJobs,
-    waiting: waitingReleaseJobs,
-    active: activeReleaseJobs,
-    failed: failedReleaseJobs,
-  });
+  const releaseRetryMetadata = await buildReleaseRetryMetadata(
+    sources.releaseQueue,
+    {
+      delayed: delayedReleaseJobs,
+      waiting: waitingReleaseJobs,
+      active: activeReleaseJobs,
+      failed: failedReleaseJobs,
+    },
+  );
 
   return {
     generatedAt: new Date(now).toISOString(),

--- a/apps/web/src/status/queueStatus.ts
+++ b/apps/web/src/status/queueStatus.ts
@@ -90,6 +90,7 @@ interface QueueLike {
     end?: number,
     asc?: boolean,
   ) => Promise<Array<Job | QueueJobLike>>;
+  getJob?: (jobId: string) => Promise<Job | QueueJobLike | null | undefined>;
   client?: Promise<{
     zscore: (key: string, member: string) => Promise<string | null>;
   }>;
@@ -218,6 +219,18 @@ function releaseIdentityKey(packageName: string, version: string): string {
   return `${packageName}\0${version}`;
 }
 
+function createQueueJobId(...parts: string[]): string {
+  return parts.map((part) => encodeURIComponent(part)).join('|');
+}
+
+function createReleaseJobId(packageName: string, version: string): string {
+  return createQueueJobId(
+    config.jobs?.buildRelease?.name || 'build-rel',
+    packageName,
+    version,
+  );
+}
+
 async function delayedJobNextRetryAt(
   queue: QueueLike,
   job: Job | QueueJobLike,
@@ -250,37 +263,52 @@ async function retryMetadataFromJob(
   };
 }
 
+async function getReleaseRetryMetadata(
+  releaseQueue: QueueLike,
+  release: ReleaseModel,
+): Promise<ReleaseRetryMetadata | undefined> {
+  if (!releaseQueue.getJob) return undefined;
+  const job = await releaseQueue.getJob(
+    createReleaseJobId(release.packageName, release.version),
+  );
+  if (!job) return undefined;
+
+  const state = await job.getState();
+  if (state === 'delayed') {
+    return await retryMetadataFromJob(releaseQueue, job, 'scheduled');
+  }
+  if (state === 'waiting') {
+    return await retryMetadataFromJob(releaseQueue, job, 'waiting');
+  }
+  if (state === 'active') {
+    return await retryMetadataFromJob(releaseQueue, job, 'active');
+  }
+  const maxAttempts = job.opts?.attempts ?? 1;
+  if (state === 'failed' && job.attemptsMade >= maxAttempts) {
+    return await retryMetadataFromJob(releaseQueue, job, 'exhausted');
+  }
+  return undefined;
+}
+
 async function buildReleaseRetryMetadata(
   releaseQueue: QueueLike,
-  jobs: {
-    delayed: Array<Job | QueueJobLike>;
-    waiting: Array<Job | QueueJobLike>;
-    active: Array<Job | QueueJobLike>;
-    failed: Array<Job | QueueJobLike>;
-  },
+  releases: ReleaseModel[],
 ): Promise<Map<string, ReleaseRetryMetadata>> {
   const metadata = new Map<string, ReleaseRetryMetadata>();
-  const addJob = async (
-    job: Job | QueueJobLike,
-    retryState: Exclude<
-      ReleaseRetryState,
-      'not_retryable' | 'ready_to_requeue'
-    >,
-  ): Promise<void> => {
-    const release = parseReleaseJobIdentity(job);
-    if (!release.packageName || !release.version) return;
-    const key = releaseIdentityKey(release.packageName, release.version);
-    if (metadata.has(key)) return;
-    metadata.set(key, await retryMetadataFromJob(releaseQueue, job, retryState));
-  };
-
-  for (const job of jobs.delayed) await addJob(job, 'scheduled');
-  for (const job of jobs.waiting) await addJob(job, 'waiting');
-  for (const job of jobs.active) await addJob(job, 'active');
-  for (const job of jobs.failed) {
-    const maxAttempts = job.opts?.attempts ?? 1;
-    if (job.attemptsMade >= maxAttempts) await addJob(job, 'exhausted');
-  }
+  await Promise.all(
+    releases.map(async (release) => {
+      const retryMetadata = await getReleaseRetryMetadata(
+        releaseQueue,
+        release,
+      );
+      if (retryMetadata) {
+        metadata.set(
+          releaseIdentityKey(release.packageName, release.version),
+          retryMetadata,
+        );
+      }
+    }),
+  );
   return metadata;
 }
 
@@ -428,7 +456,6 @@ export async function buildPublicQueueStatus(
     oldestWaitingPackageJobs,
     activeReleaseJobs,
     waitingReleaseJobs,
-    delayedReleaseJobs,
     failedReleaseJobs,
     recentSuccessfulReleases,
     recentFailedReleases,
@@ -437,7 +464,6 @@ export async function buildPublicQueueStatus(
     getLimitedJobs(sources.packageQueue, ['waiting'], 1, true),
     getLimitedJobs(sources.releaseQueue, ['active'], jobLimit),
     getLimitedJobs(sources.releaseQueue, ['waiting'], jobLimit, true),
-    getLimitedJobs(sources.releaseQueue, ['delayed'], jobLimit, true),
     getLimitedJobs(sources.releaseQueue, ['failed'], jobLimit),
     (
       sources.getRecentSuccessfulReleases ??
@@ -468,12 +494,7 @@ export async function buildPublicQueueStatus(
   const releaseWaiting = countValue(releaseCounts, 'waiting');
   const releaseRetryMetadata = await buildReleaseRetryMetadata(
     sources.releaseQueue,
-    {
-      delayed: delayedReleaseJobs,
-      waiting: waitingReleaseJobs,
-      active: activeReleaseJobs,
-      failed: failedReleaseJobs,
-    },
+    recentFailedReleases.slice(0, releaseLimit),
   );
 
   return {


### PR DESCRIPTION
## Summary

- Add retry metadata to recent failed release status rows, including retry state, attempts, maximum attempts, and delayed retry time.
- Match recent failed releases against delayed, waiting, active, and failed release queue jobs.
- Render the docs queue status Retryable cell as scheduled, waiting, running, exhausted, ready to requeue, or no while keeping the Time column unchanged.

## Validation

- `npm run build -- --filter=@openupm/types --filter=@openupm/common --filter=@openupm/server-common`
- `npm run build -- --filter=@openupm/ads`
- `npm run test -- __tests__/status/queueStatus.spec.ts`
- `npm run test -- queueStatus.spec.ts`
- `npm run test -- queueStatusView.spec.ts`
- `npm run lint` in `apps/web`
- `npm run lint` in `apps/docs`
- `npm run build` in `apps/web`
- `git diff --check`