### PR TITLE
[codex] Probe missing GitHub release assets

### DIFF
--- a/apps/docs/__tests__/vue/queueStatusView.spec.ts
+++ b/apps/docs/__tests__/vue/queueStatusView.spec.ts
@@ -138,6 +138,16 @@ describe("@/queueStatusView", () => {
       now,
     ).should.equal("yes, 3/3, exhausted");
     formatReleaseRetryable(
+      {
+        ...release,
+        reason: "GitHubReleaseAssetNotFound",
+        attempts: 3,
+        maxAttempts: 3,
+        retryState: "exhausted",
+      },
+      now,
+    ).should.equal("yes, waiting for GitHub Release asset");
+    formatReleaseRetryable(
       { ...release, retryState: "ready_to_requeue" },
       now,
     ).should.equal("yes, ready to requeue");

--- a/apps/docs/docs/.vuepress/queueStatusView.ts
+++ b/apps/docs/docs/.vuepress/queueStatusView.ts
@@ -177,6 +177,9 @@ export function formatReleaseRetryable(
     case "active":
       return `${prefix}, running`;
     case "exhausted":
+      if (release.reason === "GitHubReleaseAssetNotFound") {
+        return "yes, waiting for GitHub Release asset";
+      }
       return `${prefix}, exhausted`;
     case "ready_to_requeue":
     case undefined:

--- a/apps/docs/docs/docs/adding-upm-package.md
+++ b/apps/docs/docs/docs/adding-upm-package.md
@@ -142,6 +142,10 @@ By default, OpenUPM clones the repository at each discovered Git tag and runs
 set `trackingMode: githubRelease`. OpenUPM will still discover versions from
 Git tags, then find the GitHub Release whose tag name exactly matches the
 discovered Git tag and publish the attached `.tgz` or `.tar.gz` asset unchanged.
+Normal build failures are retried up to three times. If the matching GitHub
+Release exists but does not yet contain a publishable asset, OpenUPM checks for
+the asset again every 6 hours for up to 7 days from the first missing-asset
+failure. After 7 days, add the missing asset and request a rebuild.
 
 Set `githubReleaseAssetName` when the release has multiple assets or when you
 want to require a specific filename pattern. OpenUPM first looks for an exact

--- a/apps/docs/docs/docs/signing-upm-packages.md
+++ b/apps/docs/docs/docs/signing-upm-packages.md
@@ -124,6 +124,11 @@ githubReleaseAssetName: 'com.example.package-'
 filename prefix. The prefix should never contain a version number; otherwise the
 package metadata would need to change for every release. GitHub Release asset
 names are filenames only; do not include a directory path such as `dist/`.
+OpenUPM still discovers versions from Git tags in this mode. Normal build
+failures are retried up to three times. If the GitHub Release exists but the
+publishable asset is not attached yet, OpenUPM checks again every 6 hours for up
+to 7 days from the first missing-asset failure. After 7 days, attach the asset
+and request a rebuild.
 
 Signed release tarballs are often built from a package folder and may contain
 only the package payload plus the signing attestation. The README does not have

--- a/apps/docs/docs/docs/troubleshooting-build-errors.md
+++ b/apps/docs/docs/docs/troubleshooting-build-errors.md
@@ -34,6 +34,8 @@ OpenUPM categorizes these errors into two types: retryable errors and non-retrya
 
 - `E900` connection timeout: This error occurs when the build-pipelines failed to connect to resolve the registry server or the internet is not available.
 
+- `E905` GitHub Release asset not found: For packages using `trackingMode: githubRelease`, this means the matching GitHub Release exists but OpenUPM could not find a publishable `.tgz` or `.tar.gz` asset. After the normal retry attempts are exhausted, OpenUPM checks again every 6 hours for up to 7 days from the first missing-asset failure. After 7 days, attach the asset and request a rebuild.
+
 ## Non-retryable Errors
 
 **Non-retryable errors** are usually caused by specific issues that cannot be fixed automatically by a rebuild. In such cases, the package owner needs to address these errors manually.

--- a/apps/queue/__tests__/queueCliActions.spec.ts
+++ b/apps/queue/__tests__/queueCliActions.spec.ts
@@ -121,6 +121,9 @@ describe('queue-cli destructive actions', () => {
       commit: 'abc123',
       createdAt: 100,
       updatedAt: 200,
+      githubReleaseAssetMissingFirstSeenAt: 150,
+      githubReleaseAssetMissingLastProbeAt: 190,
+      githubReleaseAssetMissingProbeCount: 2,
     };
     fetchOneMock.mockResolvedValue(release);
     saveReleaseMock.mockImplementation(async (value) => ({
@@ -150,6 +153,9 @@ describe('queue-cli destructive actions', () => {
       state: ReleaseState.Pending,
       reason: ReleaseErrorCode.None,
       buildId: '',
+      githubReleaseAssetMissingFirstSeenAt: undefined,
+      githubReleaseAssetMissingLastProbeAt: undefined,
+      githubReleaseAssetMissingProbeCount: undefined,
     });
     expect(addJobMock).toHaveBeenCalledWith({
       queue: expect.anything(),

--- a/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
@@ -152,7 +152,7 @@ describe('buildPackage GitHub Release asset missing probes', () => {
     expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
   });
 
-  it('ignores non-target GitHub Release resolver errors during probes', async () => {
+  it('preserves the missing-asset probe for transient GitHub API errors', async () => {
     const { GitHubReleaseAssetError } = await import(
       '../../src/utils/githubReleaseAsset.js'
     );
@@ -167,7 +167,31 @@ describe('buildPackage GitHub Release asset missing probes', () => {
 
     expect(saveReleaseMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        reason: ReleaseErrorCode.GitHubReleaseApiError,
+        reason: ReleaseErrorCode.GitHubReleaseAssetNotFound,
+        githubReleaseAssetMissingLastProbeAt: Date.parse(
+          '2026-05-10T07:00:00.000Z',
+        ),
+        githubReleaseAssetMissingProbeCount: 1,
+      }),
+    );
+  });
+
+  it('persists actionable non-transient GitHub Release resolver errors', async () => {
+    const { GitHubReleaseAssetError } = await import(
+      '../../src/utils/githubReleaseAsset.js'
+    );
+    resolveGitHubReleaseAssetMock.mockRejectedValue(
+      new GitHubReleaseAssetError(
+        'GitHub Release asset selection was ambiguous',
+        ReleaseErrorCode.GitHubReleaseAssetAmbiguous,
+      ),
+    );
+
+    await expect(runBuildPackage(createRelease())).resolves.toBeUndefined();
+
+    expect(saveReleaseMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: ReleaseErrorCode.GitHubReleaseAssetAmbiguous,
         githubReleaseAssetMissingFirstSeenAt: undefined,
         githubReleaseAssetMissingLastProbeAt: undefined,
         githubReleaseAssetMissingProbeCount: undefined,

--- a/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
@@ -167,11 +167,38 @@ describe('buildPackage GitHub Release asset missing probes', () => {
 
     expect(saveReleaseMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        reason: ReleaseErrorCode.GitHubReleaseApiError,
+        githubReleaseAssetMissingFirstSeenAt: undefined,
+        githubReleaseAssetMissingLastProbeAt: undefined,
+        githubReleaseAssetMissingProbeCount: undefined,
+      }),
+    );
+  });
+
+  it('persists probe backoff when the asset is still missing', async () => {
+    const { GitHubReleaseAssetError } = await import(
+      '../../src/utils/githubReleaseAsset.js'
+    );
+    resolveGitHubReleaseAssetMock.mockRejectedValue(
+      new GitHubReleaseAssetError(
+        'GitHub Release asset not found',
+        ReleaseErrorCode.GitHubReleaseAssetNotFound,
+      ),
+    );
+
+    await runBuildPackage(
+      createRelease({
+        githubReleaseAssetMissingProbeCount: 2,
+      }),
+    );
+
+    expect(saveReleaseMock).toHaveBeenCalledWith(
+      expect.objectContaining({
         reason: ReleaseErrorCode.GitHubReleaseAssetNotFound,
         githubReleaseAssetMissingLastProbeAt: Date.parse(
           '2026-05-10T07:00:00.000Z',
         ),
-        githubReleaseAssetMissingProbeCount: 1,
+        githubReleaseAssetMissingProbeCount: 3,
       }),
     );
   });

--- a/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
@@ -165,7 +165,15 @@ describe('buildPackage GitHub Release asset missing probes', () => {
 
     await expect(runBuildPackage(createRelease())).resolves.toBeUndefined();
 
-    expect(saveReleaseMock).not.toHaveBeenCalled();
+    expect(saveReleaseMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: ReleaseErrorCode.GitHubReleaseAssetNotFound,
+        githubReleaseAssetMissingLastProbeAt: Date.parse(
+          '2026-05-10T07:00:00.000Z',
+        ),
+        githubReleaseAssetMissingProbeCount: 1,
+      }),
+    );
   });
 
   it('resets an exhausted release and enqueues a fresh job when the asset appears', async () => {

--- a/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReleaseErrorCode, ReleaseState, type ReleaseModel } from '@openupm/types';
+
+const loadPackageMetadataLocalMock = vi.fn();
+const packageMetadataLocalExistsMock = vi.fn();
+const gitListRemoteTagsMock = vi.fn();
+const fetchAllMock = vi.fn();
+const fetchOneMock = vi.fn();
+const saveReleaseMock = vi.fn();
+const removeReleaseMock = vi.fn();
+const addJobMock = vi.fn();
+const getQueueMock = vi.fn();
+const queueGetJobMock = vi.fn();
+const queueRemoveMock = vi.fn();
+const resolveGitHubReleaseAssetMock = vi.fn();
+const setInvalidTagsMock = vi.fn();
+const setRepoUnavailableMock = vi.fn();
+
+vi.mock('@openupm/local-data', () => ({
+  loadPackageMetadataLocal: loadPackageMetadataLocalMock,
+  packageMetadataLocalExists: packageMetadataLocalExistsMock,
+}));
+
+vi.mock('@openupm/server-common/build/models/release.js', () => ({
+  fetchAll: fetchAllMock,
+  fetchOne: fetchOneMock,
+  remove: removeReleaseMock,
+  save: saveReleaseMock,
+}));
+
+vi.mock('@openupm/server-common/build/models/packageExtra.js', () => ({
+  setInvalidTags: setInvalidTagsMock,
+  setRepoUnavailable: setRepoUnavailableMock,
+}));
+
+vi.mock('../../src/queues/core.js', () => ({
+  addJob: addJobMock,
+  getQueue: getQueueMock,
+}));
+
+vi.mock('../../src/utils/git.js', () => ({
+  gitListRemoteTags: gitListRemoteTagsMock,
+}));
+
+vi.mock('../../src/utils/githubReleaseAsset.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../src/utils/githubReleaseAsset.js')
+  >('../../src/utils/githubReleaseAsset.js');
+  return {
+    ...actual,
+    resolveGitHubReleaseAsset: resolveGitHubReleaseAssetMock,
+  };
+});
+
+function createRelease(
+  overrides: Partial<ReleaseModel> = {},
+): ReleaseModel {
+  return {
+    packageName: 'com.example.asset',
+    version: '1.0.0',
+    commit: 'abc123',
+    tag: 'upm/1.0.0',
+    state: ReleaseState.Failed,
+    buildId: 'build-123',
+    reason: ReleaseErrorCode.GitHubReleaseAssetNotFound,
+    createdAt: Date.parse('2026-05-01T00:00:00.000Z'),
+    updatedAt: Date.parse('2026-05-10T00:00:00.000Z'),
+    source: 'githubRelease',
+    signed: false,
+    githubReleaseAssetMissingFirstSeenAt: Date.parse(
+      '2026-05-10T00:00:00.000Z',
+    ),
+    ...overrides,
+  };
+}
+
+async function runBuildPackage(release: ReleaseModel): Promise<void> {
+  fetchAllMock.mockResolvedValue([release]);
+  fetchOneMock.mockResolvedValue(release);
+  const { buildPackage } = await import('../../src/workers/buildPackage.js');
+  await buildPackage('com.example.asset');
+}
+
+describe('buildPackage GitHub Release asset missing probes', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(Date, 'now').mockReturnValue(
+      Date.parse('2026-05-10T07:00:00.000Z'),
+    );
+    loadPackageMetadataLocalMock.mockResolvedValue({
+      name: 'com.example.asset',
+      repoUrl: 'https://github.com/example/asset',
+      trackingMode: 'githubRelease',
+      githubReleaseAssetName: 'com.example.asset-',
+    });
+    packageMetadataLocalExistsMock.mockReturnValue(true);
+    gitListRemoteTagsMock.mockResolvedValue([
+      { tag: 'upm/1.0.0', commit: 'abc123' },
+    ]);
+    saveReleaseMock.mockImplementation(async (value) => ({
+      ...value,
+      updatedAt: Date.now(),
+    }));
+    getQueueMock.mockReturnValue({
+      getJob: queueGetJobMock,
+      remove: queueRemoveMock,
+    });
+    queueGetJobMock.mockResolvedValue({
+      attemptsMade: 3,
+      opts: { attempts: 3 },
+      getState: vi.fn(async () => 'failed'),
+    });
+    queueRemoveMock.mockResolvedValue(1);
+    addJobMock.mockResolvedValue({ id: 'build-rel|com.example.asset|1.0.0' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips probes before the six hour interval elapses', async () => {
+    await runBuildPackage(
+      createRelease({
+        githubReleaseAssetMissingLastProbeAt: Date.parse(
+          '2026-05-10T02:00:00.000Z',
+        ),
+      }),
+    );
+
+    expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
+  });
+
+  it('stops probing after the seven day first-seen window', async () => {
+    await runBuildPackage(
+      createRelease({
+        githubReleaseAssetMissingFirstSeenAt: Date.parse(
+          '2026-05-02T06:59:59.000Z',
+        ),
+      }),
+    );
+
+    expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
+  });
+
+  it('does not probe non-target release errors', async () => {
+    await runBuildPackage(
+      createRelease({
+        reason: ReleaseErrorCode.GitHubReleaseApiError,
+      }),
+    );
+
+    expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-target GitHub Release resolver errors during probes', async () => {
+    const { GitHubReleaseAssetError } = await import(
+      '../../src/utils/githubReleaseAsset.js'
+    );
+    resolveGitHubReleaseAssetMock.mockRejectedValue(
+      new GitHubReleaseAssetError(
+        'GitHub Release API failed',
+        ReleaseErrorCode.GitHubReleaseApiError,
+      ),
+    );
+
+    await expect(runBuildPackage(createRelease())).resolves.toBeUndefined();
+
+    expect(saveReleaseMock).not.toHaveBeenCalled();
+  });
+
+  it('resets an exhausted release and enqueues a fresh job when the asset appears', async () => {
+    const release = createRelease({
+      githubReleaseAssetMissingProbeCount: 1,
+    });
+    resolveGitHubReleaseAssetMock.mockResolvedValue({
+      packageAssetName: 'com.example.asset-1.0.0.tgz',
+      packageAssetUrl: 'https://example.invalid/asset.tgz',
+    });
+
+    await runBuildPackage(release);
+
+    expect(resolveGitHubReleaseAssetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: 'https://github.com/example/asset',
+        releaseTag: 'upm/1.0.0',
+        githubReleaseAssetName: 'com.example.asset-',
+      }),
+    );
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.example.asset|1.0.0',
+      { removeChildren: true },
+    );
+    expect(saveReleaseMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageName: 'com.example.asset',
+        version: '1.0.0',
+        state: ReleaseState.Pending,
+        reason: ReleaseErrorCode.None,
+        buildId: '',
+      }),
+    );
+    expect(addJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'build-rel',
+        data: { name: 'com.example.asset', version: '1.0.0' },
+        opts: expect.objectContaining({
+          jobId: 'build-rel|com.example.asset|1.0.0',
+        }),
+      }),
+    );
+  });
+});

--- a/apps/queue/src/queueCli.ts
+++ b/apps/queue/src/queueCli.ts
@@ -698,6 +698,9 @@ async function releaseRequeue(
     state: ReleaseState.Pending,
     reason: ReleaseErrorCode.None,
     buildId: '',
+    githubReleaseAssetMissingFirstSeenAt: undefined,
+    githubReleaseAssetMissingLastProbeAt: undefined,
+    githubReleaseAssetMissingProbeCount: undefined,
   });
   const job = await addJob({
     queue,

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -307,7 +307,17 @@ async function probeMissingGitHubReleaseAssets(
       });
     } catch (error) {
       if (error instanceof GitHubReleaseAssetError) {
-        await save(release);
+        const saved =
+          error.reason === ReleaseErrorCode.GitHubReleaseAssetNotFound
+            ? await save(release)
+            : await save({
+                ...release,
+                reason: error.reason,
+                githubReleaseAssetMissingFirstSeenAt: undefined,
+                githubReleaseAssetMissingLastProbeAt: undefined,
+                githubReleaseAssetMissingProbeCount: undefined,
+              });
+        Object.assign(release, saved);
         continue;
       }
       throw error;

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -29,10 +29,16 @@ import { addJob, getQueue } from '../queues/core.js';
 import { createJobId } from '../queues/jobId.js';
 import { cleanupMissingPackage } from '../jobs/cleanupMissingPackage.js';
 import { gitListRemoteTags, RemoteTag } from '../utils/git.js';
+import {
+  GitHubReleaseAssetError,
+  resolveGitHubReleaseAsset,
+} from '../utils/githubReleaseAsset.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
 const logger = createLogger('@openupm/queue/buildPackage');
+const githubReleaseAssetProbeIntervalMs = 6 * 60 * 60 * 1000;
+const githubReleaseAssetProbeWindowMs = 7 * 24 * 60 * 60 * 1000;
 
 function parseGitHubRepo(
   url: string,
@@ -117,6 +123,7 @@ export async function buildPackage(name: string): Promise<void> {
     validTags,
     pkg.trackingMode || 'git',
   );
+  await probeMissingGitHubReleaseAssets(pkg, releases);
   await addReleaseJobs(releases);
 }
 
@@ -274,4 +281,93 @@ async function addReleaseJobs(releases: ReleaseModel[]): Promise<void> {
     });
     i++;
   }
+}
+
+async function probeMissingGitHubReleaseAssets(
+  pkg: Awaited<ReturnType<typeof loadPackageMetadataLocal>>,
+  releases: ReleaseModel[],
+): Promise<void> {
+  if (!pkg || (pkg.trackingMode || 'git') !== 'githubRelease') return;
+
+  for (const release of releases) {
+    if (!(await shouldProbeMissingGitHubReleaseAsset(release))) continue;
+
+    const now = Date.now();
+    release.githubReleaseAssetMissingFirstSeenAt ??= release.updatedAt;
+    release.githubReleaseAssetMissingLastProbeAt = now;
+    release.githubReleaseAssetMissingProbeCount =
+      (release.githubReleaseAssetMissingProbeCount || 0) + 1;
+
+    try {
+      await resolveGitHubReleaseAsset({
+        config,
+        repoUrl: pkg.repoUrl,
+        releaseTag: release.tag,
+        githubReleaseAssetName: pkg.githubReleaseAssetName,
+      });
+    } catch (error) {
+      if (
+        error instanceof GitHubReleaseAssetError &&
+        error.reason === ReleaseErrorCode.GitHubReleaseAssetNotFound
+      ) {
+        await save(release);
+        continue;
+      }
+      if (error instanceof GitHubReleaseAssetError) continue;
+      throw error;
+    }
+
+    const jobConfig = config.jobs.buildRelease;
+    const queue = getQueue(jobConfig.queue);
+    const jobId = createJobId(jobConfig.name, release.packageName, release.version);
+    await queue.remove(jobId, { removeChildren: true });
+    const resetRelease = await save({
+      ...release,
+      state: ReleaseState.Pending,
+      reason: ReleaseErrorCode.None,
+      buildId: '',
+      signed: false,
+      publishedVersion: undefined,
+      githubReleaseAssetMissingFirstSeenAt: undefined,
+      githubReleaseAssetMissingLastProbeAt: undefined,
+      githubReleaseAssetMissingProbeCount: undefined,
+    });
+    Object.assign(release, resetRelease);
+    logger.info(
+      { rel: `${release.packageName}@${release.version}` },
+      'GitHub Release asset is available; release requeued',
+    );
+  }
+}
+
+async function shouldProbeMissingGitHubReleaseAsset(
+  release: ReleaseModel,
+): Promise<boolean> {
+  if (
+    release.state !== ReleaseState.Failed ||
+    release.reason !== ReleaseErrorCode.GitHubReleaseAssetNotFound
+  ) {
+    return false;
+  }
+
+  const firstSeenAt =
+    release.githubReleaseAssetMissingFirstSeenAt || release.updatedAt;
+  const now = Date.now();
+  if (now - firstSeenAt > githubReleaseAssetProbeWindowMs) return false;
+
+  const lastProbeAt = release.githubReleaseAssetMissingLastProbeAt;
+  if (lastProbeAt && now - lastProbeAt < githubReleaseAssetProbeIntervalMs) {
+    return false;
+  }
+
+  const jobConfig = config.jobs.buildRelease;
+  const queue = getQueue(jobConfig.queue);
+  const job = await queue.getJob(
+    createJobId(jobConfig.name, release.packageName, release.version),
+  );
+  if (!job) return false;
+
+  const state = await job.getState();
+  const maxAttempts = job.opts?.attempts ?? 1;
+  return state === 'failed' && job.attemptsMade >= maxAttempts;
 }

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -306,14 +306,10 @@ async function probeMissingGitHubReleaseAssets(
         githubReleaseAssetName: pkg.githubReleaseAssetName,
       });
     } catch (error) {
-      if (
-        error instanceof GitHubReleaseAssetError &&
-        error.reason === ReleaseErrorCode.GitHubReleaseAssetNotFound
-      ) {
+      if (error instanceof GitHubReleaseAssetError) {
         await save(release);
         continue;
       }
-      if (error instanceof GitHubReleaseAssetError) continue;
       throw error;
     }
 

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -308,7 +308,8 @@ async function probeMissingGitHubReleaseAssets(
     } catch (error) {
       if (error instanceof GitHubReleaseAssetError) {
         const saved =
-          error.reason === ReleaseErrorCode.GitHubReleaseAssetNotFound
+          error.reason === ReleaseErrorCode.GitHubReleaseAssetNotFound ||
+          error.reason === ReleaseErrorCode.GitHubReleaseApiError
             ? await save(release)
             : await save({
                 ...release,

--- a/packages/@openupm/server-common/__tests__/models/release.spec.ts
+++ b/packages/@openupm/server-common/__tests__/models/release.spec.ts
@@ -10,7 +10,7 @@ import {
   remove,
   save,
 } from '../../src/models/release.js';
-import { ReleaseState } from '@openupm/types';
+import { ReleaseErrorCode, ReleaseState } from '@openupm/types';
 
 const SAMPLE_PACKAGE_NAME = 'sample-package';
 
@@ -97,6 +97,35 @@ describeWithRedis('save', function () {
     await remove(obj2!.packageName, obj2!.version);
     const obj3 = await fetchOne(obj.packageName, obj.version);
     expect(obj3).toBeNull();
+  });
+
+  it('tracks and clears GitHub Release asset missing probe metadata', async () => {
+    const failed = await save({
+      packageName: SAMPLE_PACKAGE_NAME,
+      version: '1.0.0',
+      state: ReleaseState.Failed,
+      reason: ReleaseErrorCode.GitHubReleaseAssetNotFound,
+    });
+    expect(failed.githubReleaseAssetMissingFirstSeenAt).toBeGreaterThan(0);
+
+    const firstSeenAt = failed.githubReleaseAssetMissingFirstSeenAt;
+    const repeated = await save({
+      ...failed,
+      buildId: 'retry-build',
+      reason: ReleaseErrorCode.GitHubReleaseAssetNotFound,
+    });
+    expect(repeated.githubReleaseAssetMissingFirstSeenAt).toEqual(firstSeenAt);
+
+    const succeeded = await save({
+      ...repeated,
+      state: ReleaseState.Succeeded,
+      reason: ReleaseErrorCode.None,
+      githubReleaseAssetMissingLastProbeAt: Date.now(),
+      githubReleaseAssetMissingProbeCount: 2,
+    });
+    expect(succeeded.githubReleaseAssetMissingFirstSeenAt).toBeUndefined();
+    expect(succeeded.githubReleaseAssetMissingLastProbeAt).toBeUndefined();
+    expect(succeeded.githubReleaseAssetMissingProbeCount).toBeUndefined();
   });
 });
 

--- a/packages/@openupm/server-common/src/models/release.ts
+++ b/packages/@openupm/server-common/src/models/release.ts
@@ -8,7 +8,12 @@
  */
 
 import { pick } from 'lodash-es';
-import { ReleaseModel, releaseModelFields, ReleaseState } from '@openupm/types';
+import {
+  ReleaseErrorCode,
+  ReleaseModel,
+  releaseModelFields,
+  ReleaseState,
+} from '@openupm/types';
 
 import redis from '../redis.js';
 
@@ -135,6 +140,13 @@ export async function save(
     signed: false,
   };
   Object.assign(record, pick(obj, releaseModelFields));
+  if (record.reason === ReleaseErrorCode.GitHubReleaseAssetNotFound) {
+    record.githubReleaseAssetMissingFirstSeenAt ??= now;
+  } else {
+    record.githubReleaseAssetMissingFirstSeenAt = undefined;
+    record.githubReleaseAssetMissingLastProbeAt = undefined;
+    record.githubReleaseAssetMissingProbeCount = undefined;
+  }
   record.updatedAt = now;
   const jsonText = JSON.stringify(record, null, 0);
   const key = getRedisKeyForRelease(record.packageName);

--- a/packages/@openupm/types/src/model-types.ts
+++ b/packages/@openupm/types/src/model-types.ts
@@ -11,6 +11,9 @@ export interface ReleaseModel {
   source?: 'git' | 'githubRelease';
   signed?: boolean;
   publishedVersion?: string;
+  githubReleaseAssetMissingFirstSeenAt?: number;
+  githubReleaseAssetMissingLastProbeAt?: number;
+  githubReleaseAssetMissingProbeCount?: number;
 }
 
 export const releaseModelFields: (keyof ReleaseModel)[] = [
@@ -26,6 +29,9 @@ export const releaseModelFields: (keyof ReleaseModel)[] = [
   'source',
   'signed',
   'publishedVersion',
+  'githubReleaseAssetMissingFirstSeenAt',
+  'githubReleaseAssetMissingLastProbeAt',
+  'githubReleaseAssetMissingProbeCount',
 ];
 
 export interface InvalidTag {


### PR DESCRIPTION
## Summary
- persist first-seen and probe metadata for GitHub Release asset-missing failures
- have package scans probe exhausted GitHubReleaseAssetNotFound releases every 6 hours for up to 7 days, then requeue when the asset appears
- clarify queue status text and docs for GitHub Release asset waiting behavior

## Validation
- npm run test --workspace=@openupm/queue -- buildPackageGithubReleaseAssetProbe.spec.ts queueCliActions.spec.ts buildRelease.spec.ts
- npm run test --workspace=@openupm/server-common -- release.spec.ts
- npm run test --workspace=@openupm/web -- __tests__/routers/packages.spec.ts __tests__/status/queueStatus.spec.ts
- npm run test --workspace=@openupm/docs -- queueStatusView.spec.ts
- npm run build -- --filter=@openupm/types --filter=@openupm/queue --filter=@openupm/web
- npm run lint