### PR TITLE
Improve docs SEO content and breadcrumbs

### DIFF
--- a/apps/docs/__tests__/seoContentLinks.spec.ts
+++ b/apps/docs/__tests__/seoContentLinks.spec.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const docsRoot = resolve(__dirname, "../docs");
+
+const readDocsFile = (relativePath: string): string =>
+  readFileSync(resolve(docsRoot, relativePath), "utf8");
+
+describe("docs SEO content links", () => {
+  it("adds the scoped registry troubleshooting page to the docs sidebar", () => {
+    const config = readDocsFile(".vuepress/config-us.ts");
+
+    expect(config).toContain("/docs/scoped-registry-troubleshooting");
+  });
+
+  it("links high-intent docs pages to scoped registry troubleshooting", () => {
+    const linkedDocs = [
+      "docs/index.md",
+      "docs/getting-started.md",
+      "docs/getting-started-cli.md",
+      "docs/adding-upm-package.md",
+      "docs/host-private-upm-registry-15-minutes.md",
+      "nuget/index.md",
+    ];
+
+    for (const relativePath of linkedDocs) {
+      expect(readDocsFile(relativePath)).toContain(
+        "scoped-registry-troubleshooting",
+      );
+    }
+  });
+
+  it("keeps the troubleshooting page indexable and connected to package paths", () => {
+    const page = readDocsFile("docs/scoped-registry-troubleshooting.md");
+
+    expect(page).not.toContain("noindex");
+    expect(page).not.toContain("nofollow");
+    expect(page).toContain("/packages/com.cysharp.unitask/");
+    expect(page).toContain("/packages/org.nuget.newtonsoft.json/");
+    expect(page).not.toContain("Publishing and Metadata Issues");
+  });
+});

--- a/apps/docs/__tests__/vue/breadcrumb.spec.ts
+++ b/apps/docs/__tests__/vue/breadcrumb.spec.ts
@@ -41,6 +41,13 @@ describe("site breadcrumbs", () => {
     expect(source).toContain('path === "/contributors/"');
   });
 
+  it("renders the current page breadcrumb as non-link text", () => {
+    const source = readFileSync(breadcrumbPath, "utf8");
+
+    expect(source).toContain('<span v-else aria-current="page">');
+    expect(source).not.toContain('href="#"');
+  });
+
   it("renders breadcrumbs in the default layout for docs and blog pages", () => {
     const source = readFileSync(layoutPath, "utf8");
 

--- a/apps/docs/__tests__/vue/breadcrumb.spec.ts
+++ b/apps/docs/__tests__/vue/breadcrumb.spec.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const breadcrumbPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/SiteBreadcrumb.vue",
+    import.meta.url,
+  ),
+);
+
+const layoutPath = fileURLToPath(
+  new URL("../../docs/.vuepress/layouts/Layout.vue", import.meta.url),
+);
+
+const packageListLayoutPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/layouts/PackageListLayout.vue",
+    import.meta.url,
+  ),
+);
+
+const packageDetailLayoutPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/layouts/PackageDetailLayout.vue",
+    import.meta.url,
+  ),
+);
+
+describe("site breadcrumbs", () => {
+  it("infers breadcrumbs for docs, blog, package, topic, and static pages", () => {
+    const source = readFileSync(breadcrumbPath, "utf8");
+
+    expect(source).toContain('path.startsWith("/docs/")');
+    expect(source).toContain('path.startsWith("/blog/")');
+    expect(source).toContain('path.startsWith("/packages/topics/")');
+    expect(source).toContain('path.startsWith("/packages/")');
+    expect(source).toContain('path === "/nuget/"');
+    expect(source).toContain('path === "/support/"');
+    expect(source).toContain('path === "/contributors/"');
+  });
+
+  it("renders breadcrumbs in the default layout for docs and blog pages", () => {
+    const source = readFileSync(layoutPath, "utf8");
+
+    expect(source).toContain("<SiteBreadcrumb />");
+    expect(source).toContain("<AdsenseDisplayForContentTop");
+  });
+
+  it("passes exact package list and topic breadcrumb items", () => {
+    const source = readFileSync(packageListLayoutPath, "utf8");
+
+    expect(source).toContain("const breadcrumbItems = computed");
+    expect(source).toContain('{ text: "Packages", link: "/packages/" }');
+    expect(source).toContain('<SiteBreadcrumb :items="breadcrumbItems" />');
+  });
+
+  it("passes exact OpenUPM package detail breadcrumb items", () => {
+    const source = readFileSync(packageDetailLayoutPath, "utf8");
+
+    expect(source).toContain("const breadcrumbItems = computed");
+    expect(source).toContain("packageMetadata.value.displayName");
+    expect(source).toContain('<SiteBreadcrumb :items="breadcrumbItems" />');
+  });
+});

--- a/apps/docs/docs/.vuepress/components/SiteBreadcrumb.vue
+++ b/apps/docs/docs/.vuepress/components/SiteBreadcrumb.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed, PropType } from "vue";
+import { useRoute } from "vue-router";
+import { usePageData } from "@vuepress/client";
+
+type BreadcrumbItem = {
+  link?: string;
+  text: string;
+};
+
+const props = defineProps({
+  items: {
+    type: Array as PropType<BreadcrumbItem[]>,
+    default: () => [],
+  },
+});
+
+const route = useRoute();
+const page = usePageData();
+
+const normalizeTitle = (title: string): string =>
+  title
+    .replace(/\s+\|\s+OpenUPM(?:\s+Unity Package)?$/, "")
+    .replace(/^OpenUPM\s+/, "")
+    .trim();
+
+const inferItems = (): BreadcrumbItem[] => {
+  const path = route.path;
+  const title = normalizeTitle(page.value.title || "");
+
+  if (path === "/") return [];
+  if (path === "/packages/") return [{ text: "Packages" }];
+  if (path.startsWith("/packages/topics/")) {
+    return [
+      { text: "Packages", link: "/packages/" },
+      { text: title.replace(/\s+Unity Packages$/, "") || "Topic" },
+    ];
+  }
+  if (path.startsWith("/packages/")) {
+    return [{ text: "Packages", link: "/packages/" }, { text: title }];
+  }
+  if (path === "/blog/") return [{ text: "Blog" }];
+  if (path.startsWith("/blog/")) {
+    return [{ text: "Blog", link: "/blog/" }, { text: title }];
+  }
+  if (path === "/docs/") return [{ text: "Docs" }];
+  if (path.startsWith("/docs/")) {
+    return [{ text: "Docs", link: "/docs/" }, { text: title }];
+  }
+  if (path === "/nuget/") return [{ text: "NuGet Packages" }];
+  if (path === "/contributors/") return [{ text: "Contributors" }];
+  if (path === "/support/") return [{ text: "Support" }];
+
+  return title ? [{ text: title }] : [];
+};
+
+const breadcrumbItems = computed(() =>
+  props.items.length ? props.items : inferItems(),
+);
+</script>
+
+<template>
+  <nav v-if="breadcrumbItems.length" aria-label="Breadcrumb" class="site-breadcrumb">
+    <ul class="breadcrumb">
+      <li
+        v-for="(item, index) in breadcrumbItems"
+        :key="`${item.text}-${index}`"
+        class="breadcrumb-item"
+      >
+        <RouterLink v-if="item.link" :to="item.link">{{ item.text }}</RouterLink>
+        <a v-else href="#">{{ item.text }}</a>
+      </li>
+    </ul>
+  </nav>
+</template>
+
+<style lang="scss" scoped>
+.site-breadcrumb {
+  margin-bottom: 0.4rem;
+
+  .breadcrumb {
+    margin: 0;
+  }
+}
+</style>

--- a/apps/docs/docs/.vuepress/components/SiteBreadcrumb.vue
+++ b/apps/docs/docs/.vuepress/components/SiteBreadcrumb.vue
@@ -68,7 +68,7 @@ const breadcrumbItems = computed(() =>
         class="breadcrumb-item"
       >
         <RouterLink v-if="item.link" :to="item.link">{{ item.text }}</RouterLink>
-        <a v-else href="#">{{ item.text }}</a>
+        <span v-else aria-current="page">{{ item.text }}</span>
       </li>
     </ul>
   </nav>

--- a/apps/docs/docs/.vuepress/config-us.ts
+++ b/apps/docs/docs/.vuepress/config-us.ts
@@ -96,6 +96,7 @@ const docSideBar = function (): any {
         "/docs/",
         "/docs/getting-started",
         "/docs/getting-started-cli",
+        "/docs/scoped-registry-troubleshooting",
         "/docs/faq",
       ],
     },

--- a/apps/docs/docs/.vuepress/layouts/Layout.vue
+++ b/apps/docs/docs/.vuepress/layouts/Layout.vue
@@ -26,6 +26,7 @@ const showContentTopAd = computed(() => {
 <template>
   <ParentLayout>
     <template #page-content-top>
+      <SiteBreadcrumb />
       <AdsenseDisplayForContentTop v-if="showContentTopAd" />
     </template>
 

--- a/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageDetailLayout.vue
@@ -332,6 +332,11 @@ const topics = computed(() => {
   });
 });
 
+const breadcrumbItems = computed(() => [
+  { text: "Packages", link: "/packages/" },
+  { text: packageMetadata.value.displayName || packageMetadata.value.name },
+]);
+
 // Hooks
 onMounted(() => {
   fetchAllData();
@@ -512,6 +517,7 @@ const buildRouterLinkQuery = function (subPage: string): Record<string, string> 
       <ClientOnly>
         <div class="columns columns-contentview">
           <div class="column col-8 col-xl-8 col-lg-8 col-md-12 col-sm-12">
+            <SiteBreadcrumb :items="breadcrumbItems" />
             <div v-if="packageMetadata.repoUnavailable" class="custom-container warning">
               <p class="custom-container-title">{{ $t("repository-is-unavailable-title") }}</p>
               <p>{{ $t("repository-is-unavailable-desc") }}</p>

--- a/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
@@ -181,6 +181,17 @@ const addPackageLink = computed(() => {
   };
 });
 
+const breadcrumbItems = computed(() => {
+  const currentTopic = (topicsWithAll as Topic[]).find(
+    (topic) => topic.slug === topicSlug.value,
+  );
+  if (!currentTopic || !currentTopic.slug) return [{ text: "Packages" }];
+  return [
+    { text: "Packages", link: "/packages/" },
+    { text: currentTopic.name },
+  ];
+});
+
 /* #region Grid layout */
 const gridWrapperElement = ref(null);
 
@@ -364,6 +375,7 @@ watch(() => topicSlug.value, () => {
       </ClientOnly>
     </template>
     <template #page-content-top>
+      <SiteBreadcrumb :items="breadcrumbItems" />
       <ClientOnly>
         <div class="columns">
           <div class="column col-12">
@@ -551,7 +563,7 @@ watch(() => topicSlug.value, () => {
     }
 
     .grid {
-      padding-top: 0.85rem;
+      padding-top: 0;
       display: grid;
       grid-gap: $package-grid-column-hgap;
       place-items: start stretch;

--- a/apps/docs/docs/docs/adding-upm-package.md
+++ b/apps/docs/docs/docs/adding-upm-package.md
@@ -46,6 +46,8 @@ OpenUPM requires packages to meet the following criteria:
 
 By adhering to these guidelines, package maintainers can contribute to a thriving ecosystem of Unity packages on OpenUPM, benefiting developers and users alike. Packages that do not meet these criteria will be rejected or removed from the OpenUPM platform.
 
+If you are submitting a package because Unity cannot resolve it from a scoped registry, first verify the project setup with [Unity Scoped Registry Troubleshooting](./scoped-registry-troubleshooting.md). That page covers the registry URL, scope matching, UnityNuGet packages, and private registry overlap.
+
 ## Repository Folder Structures
 
 There are two typical folder structures for UPM repositories, and OpenUPM build pipelines can handle both of them:

--- a/apps/docs/docs/docs/getting-started-cli.md
+++ b/apps/docs/docs/docs/getting-started-cli.md
@@ -103,3 +103,5 @@ $ cat Packages/manifest.json
 The openupm-cli adds `com.littlebigfun.addressable-importer` to dependencies. It also modified the scopedRegistries to link the `com.littlebigfun.addressable-importer` namespace with the openupm registry.
 
 Please visit the [openupm-cli readme](https://github.com/openupm/openupm-cli#openupm-cli) for more usages.
+
+If Unity cannot resolve the package after `openupm add`, compare the generated `scopedRegistries` entry with [Unity Scoped Registry Troubleshooting](./scoped-registry-troubleshooting.md).

--- a/apps/docs/docs/docs/getting-started.md
+++ b/apps/docs/docs/docs/getting-started.md
@@ -62,3 +62,5 @@ Behind the scenes, Unity records a few changes in the `Packages/manifest.json` f
 ```
 
 If you find the process a bit verbose, you can learn more about the [openupm-cli](./getting-started-cli.md) to simplify the process.
+
+If Unity does not show the package after the manifest changes, check the package name, registry URL, and scope list with [Unity Scoped Registry Troubleshooting](./scoped-registry-troubleshooting.md).

--- a/apps/docs/docs/docs/host-private-upm-registry-15-minutes.md
+++ b/apps/docs/docs/docs/host-private-upm-registry-15-minutes.md
@@ -26,6 +26,8 @@ When it comes to hosting our registry, [DigitalOcean](https://m.do.co/c/50e7f986
 
 If you don't need to host your registry in the cloud, you can simply run Verdaccio on your local machine or on a server in your local network.
 
+Private registries use the same Unity scoped registry matching rules as OpenUPM. If packages do not appear in Unity after setup, compare your private scope and registry URL with [Unity Scoped Registry Troubleshooting](./scoped-registry-troubleshooting.md).
+
 ## Prerequisites
 
 Before we dive into the setup, you'll need a DigitalOcean account. Good news! By using this affiliate link: [DigitalOcean](https://m.do.co/c/50e7f9860fa9), you'll snag *$200 in credits valid for 60 days* (new user only). We'll only be using a small portion of these credits for this demo. After the initial 60 days, maintaining your registry should cost as little as $6 per month in most scenarios.

--- a/apps/docs/docs/docs/index.md
+++ b/apps/docs/docs/docs/index.md
@@ -83,3 +83,5 @@ You can get started with OpenUPM by following the links below:
 - [Getting Started with CLI](./getting-started-cli.md)
 
 You can also read [Frequently Asked Questions](./faq.md) and learn about how to [Adding UPM Package](./adding-upm-package.md).
+
+If a package does not appear in Unity after setup, use [Unity Scoped Registry Troubleshooting](./scoped-registry-troubleshooting.md) to check the registry URL, package scope, and lock-file state.

--- a/apps/docs/docs/docs/scoped-registry-troubleshooting.md
+++ b/apps/docs/docs/docs/scoped-registry-troubleshooting.md
@@ -1,0 +1,58 @@
+---
+title: Unity Scoped Registry Troubleshooting
+description: Fix common Unity Package Manager scoped registry issues when using OpenUPM, openupm-cli, UnityNuGet packages, and private UPM registries.
+---
+# Unity Scoped Registry Troubleshooting
+
+Use this guide when Unity does not show an OpenUPM package, cannot resolve a package from `https://package.openupm.com`, or installs a different package source than expected.
+
+## Check the Registry Entry
+
+Open `Packages/manifest.json` and verify that `scopedRegistries` contains the OpenUPM registry:
+
+```json
+{
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "com.example.package"
+      ]
+    }
+  ]
+}
+```
+
+The `url` must be exactly `https://package.openupm.com` for public OpenUPM packages. The `scopes` list should include the package name or a safe parent namespace that only contains packages you intend to resolve through OpenUPM.
+
+For a full setup walkthrough, see [Getting Started with Unity Editor](./getting-started.md). To let the CLI edit the manifest for you, use [Getting Started with openupm-cli](./getting-started-cli.md).
+
+## Match the Package Name and Scope
+
+Unity chooses a scoped registry by matching the package name prefix against the registry's scopes. If the package is `com.cysharp.unitask`, then `com.cysharp.unitask` is the most precise scope. A broader scope such as `com.cysharp` can work, but it may route other packages under the same namespace to OpenUPM too.
+
+If Unity shows "No packages found" or the package never appears in the Package Manager window:
+
+- Confirm the package page exists on OpenUPM, for example [UniTask](/packages/com.cysharp.unitask/).
+- Confirm the package name in `dependencies` exactly matches the OpenUPM package name.
+- Remove accidental whitespace or trailing slashes from the registry URL.
+- Restart Unity after editing `Packages/manifest.json` outside the editor.
+
+## Resolve Cached or Locked Versions
+
+Unity may keep an older resolved version in `Packages/packages-lock.json`. If the manifest is correct but Unity still resolves an old package, close Unity and inspect the lock file entry for that package. In many projects, deleting the single stale lock-file entry and reopening Unity is enough for the Package Manager to resolve again.
+
+For package build failures after OpenUPM accepts a package, see [Troubleshooting Build Errors](./troubleshooting-build-errors.md).
+
+## UnityNuGet Packages
+
+UnityNuGet packages use the `org.nuget` scope and are available through OpenUPM's registry uplink. For example, Newtonsoft.Json is available as [org.nuget.newtonsoft.json](/packages/org.nuget.newtonsoft.json/).
+
+If a UnityNuGet package is missing from normal topic browsing, search for the `org.nuget` package name or visit the generated package page directly. UnityNuGet packages are searchable and installable, but they are listed separately from the normal OpenUPM package grid. See [NuGet Packages](/nuget/) for details.
+
+## Private Registries
+
+Private UPM registries use the same scoped registry mechanism as OpenUPM. Use a separate `scopedRegistries` entry for your private registry and choose private scopes that do not overlap with OpenUPM packages unless you intentionally want the private registry to win.
+
+For a complete private registry walkthrough, see [Host Your Private Unity Scoped Registry in Just 15 Minutes](./host-private-upm-registry-15-minutes.md).

--- a/apps/docs/docs/nuget/index.md
+++ b/apps/docs/docs/nuget/index.md
@@ -38,6 +38,8 @@ To demonstrate the uplinks feature, we have created a staging package at [https:
 
 If you install a package via openupm-cli, the uplink is used by default— all packages under the `org.nuget` scope are resolved directly from the OpenUPM registry.
 
+If Unity cannot find an `org.nuget` package after you add it to the manifest, check the `org.nuget` scope and registry entry with [Unity Scoped Registry Troubleshooting](/docs/scoped-registry-troubleshooting.html).
+
 ## Using UnityNuGet Directly
 
 In general, we recommend using the uplink feature to take advantage of the CDN and openupm-cli. If you prefer to query UnityNuGet directly, you can add the UnityNuGet registry as a scoped registry in your `manifest.json`:

--- a/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
@@ -9,6 +9,7 @@ import {
   buildPackageListDescription,
   buildPackageListTitle,
   buildRelatedPackageSummaries,
+  buildRelatedPackageSummaryIndex,
   buildPackageStructuredData,
   getLatestPackageLastModified,
   getPackageLastModified,
@@ -98,7 +99,7 @@ describe('SEO metadata helpers', () => {
   });
 
   it('builds related package summaries from shared topics and owner', () => {
-    const related = buildRelatedPackageSummaries(packageMetadata, [
+    const metadataList = [
       packageMetadata,
       {
         ...packageMetadata,
@@ -113,7 +114,10 @@ describe('SEO metadata helpers', () => {
         topics: ['rendering'],
         owner: 'other',
       },
-    ]);
+    ];
+    const related = buildRelatedPackageSummaries(packageMetadata, metadataList);
+    const getRelatedPackageSummaries =
+      buildRelatedPackageSummaryIndex(metadataList);
 
     expect(related).toEqual([
       {
@@ -123,6 +127,7 @@ describe('SEO metadata helpers', () => {
         title: 'Example AI Tools',
       },
     ]);
+    expect(getRelatedPackageSummaries(packageMetadata)).toEqual(related);
   });
 
   it('builds hidden package detail fallback content with install, topic, related, and owner links', () => {

--- a/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
@@ -2,7 +2,13 @@ import { PackageMetadataLocal, Topic } from '@openupm/types';
 
 import {
   buildCrawlablePackageSummaries,
+  buildPackageDetailContent,
+  buildPackageDetailDescription,
+  buildPackageDetailTitle,
+  buildPackageListContent,
   buildPackageListDescription,
+  buildPackageListTitle,
+  buildRelatedPackageSummaries,
   buildPackageStructuredData,
   getLatestPackageLastModified,
   getPackageLastModified,
@@ -47,6 +53,13 @@ describe('SEO metadata helpers', () => {
     expect(buildPackageListDescription(topic)).toContain('machine learning');
   });
 
+  it('builds specific package list titles', () => {
+    expect(buildPackageListTitle(topic)).toBe('AI Unity Packages | OpenUPM');
+    expect(buildPackageListTitle({ ...topic, slug: '' })).toBe(
+      'Unity Packages for OpenUPM',
+    );
+  });
+
   it('builds crawlable package summaries with stable package links', () => {
     expect(buildCrawlablePackageSummaries(topic, [packageMetadata])).toEqual([
       {
@@ -56,6 +69,85 @@ describe('SEO metadata helpers', () => {
         title: 'Example AI',
       },
     ]);
+  });
+
+  it('builds package detail titles and descriptions without empty snippets', () => {
+    expect(buildPackageDetailTitle(packageMetadata)).toBe(
+      'Example AI (com.example.ai) | OpenUPM Unity Package',
+    );
+    expect(buildPackageDetailDescription(packageMetadata)).toContain(
+      'Install Example AI by example from the OpenUPM Unity package registry',
+    );
+  });
+
+  it('builds hidden topic fallback content without affecting the package grid design', () => {
+    const content = buildPackageListContent(topic, [
+      {
+        description: 'AI helpers for Unity projects.',
+        name: 'com.example.ai',
+        path: '/packages/com.example.ai/',
+        title: 'Example AI',
+      },
+    ]);
+
+    expect(content).toContain(
+      '<section class="package-list-crawl-metadata" hidden>',
+    );
+    expect(content).not.toContain('Useful docs');
+    expect(content).toContain('/packages/com.example.ai/');
+  });
+
+  it('builds related package summaries from shared topics and owner', () => {
+    const related = buildRelatedPackageSummaries(packageMetadata, [
+      packageMetadata,
+      {
+        ...packageMetadata,
+        name: 'com.example.ai.tools',
+        displayName: 'Example AI Tools',
+        description: 'Extra AI tooling.',
+      },
+      {
+        ...packageMetadata,
+        name: 'com.other.rendering',
+        displayName: 'Rendering',
+        topics: ['rendering'],
+        owner: 'other',
+      },
+    ]);
+
+    expect(related).toEqual([
+      {
+        description: 'Extra AI tooling.',
+        name: 'com.example.ai.tools',
+        path: '/packages/com.example.ai.tools/',
+        title: 'Example AI Tools',
+      },
+    ]);
+  });
+
+  it('builds hidden package detail fallback content with install, topic, related, and owner links', () => {
+    const content = buildPackageDetailContent(packageMetadata, {
+      relatedPackages: [
+        {
+          description: 'Extra AI tooling.',
+          name: 'com.example.ai.tools',
+          path: '/packages/com.example.ai.tools/',
+          title: 'Example AI Tools',
+        },
+      ],
+      topics: [topic],
+    });
+
+    expect(content).not.toContain('noindex');
+    expect(content).not.toContain('nofollow');
+    expect(content).toContain(
+      '<section class="package-detail-crawl-metadata" hidden>',
+    );
+    expect(content).toContain('/docs/getting-started-cli.html');
+    expect(content).toContain('/docs/scoped-registry-troubleshooting.html');
+    expect(content).toContain('/packages/topics/ai/');
+    expect(content).toContain('/packages/com.example.ai.tools/');
+    expect(content).toContain('https://github.com/example');
   });
 
   it('builds SoftwareApplication and breadcrumb JSON-LD for package pages', () => {

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -56,7 +56,7 @@ import {
   buildPackageListDescription,
   buildPackageListTitle,
   buildPackageStructuredData,
-  buildRelatedPackageSummaries,
+  buildRelatedPackageSummaryIndex,
   buildUnityNuGetStructuredData,
   getLatestPackageLastModified,
   getPackageLastModified,
@@ -257,6 +257,8 @@ const createDetailPages = async function (app: App): Promise<Page[]> {
   const pages: Page[] = [];
   const { metadataLocalList, packageLastModifiedMap, topicsWithAll } =
     PLUGIN_DATA;
+  const getRelatedPackageSummaries =
+    buildRelatedPackageSummaryIndex(metadataLocalList);
   for (const metadataLocal of metadataLocalList) {
     const topics = topicsWithAll.filter(
       (x) => x.slug && metadataLocal.topics.includes(x.slug),
@@ -286,10 +288,7 @@ const createDetailPages = async function (app: App): Promise<Page[]> {
       path: getPackageDetailPagePath(metadataLocal.name),
       frontmatter,
       content: buildPackageDetailContent(metadataLocal, {
-        relatedPackages: buildRelatedPackageSummaries(
-          metadataLocal,
-          metadataLocalList,
-        ),
+        relatedPackages: getRelatedPackageSummaries(metadataLocal),
         topics,
       }),
     };

--- a/packages/vuepress-plugin-openupm/src/index.ts
+++ b/packages/vuepress-plugin-openupm/src/index.ts
@@ -25,8 +25,6 @@ import {
 } from '@openupm/local-data';
 import {
   getPackageNamespace,
-  getLocalePackageDisplayName,
-  getLocalePackageDescription,
 } from '@openupm/common/build/utils.js';
 import {
   getContributorProfilePagePath,
@@ -51,9 +49,14 @@ import {
 import { writePublicGen } from './utils/write-file.js';
 import {
   buildCrawlablePackageSummaries,
+  buildPackageDetailContent,
+  buildPackageDetailDescription,
+  buildPackageDetailTitle,
   buildPackageListContent,
   buildPackageListDescription,
+  buildPackageListTitle,
   buildPackageStructuredData,
+  buildRelatedPackageSummaries,
   buildUnityNuGetStructuredData,
   getLatestPackageLastModified,
   getPackageLastModified,
@@ -255,11 +258,11 @@ const createDetailPages = async function (app: App): Promise<Page[]> {
   const { metadataLocalList, packageLastModifiedMap, topicsWithAll } =
     PLUGIN_DATA;
   for (const metadataLocal of metadataLocalList) {
-    const displayName = getLocalePackageDisplayName(metadataLocal);
-    const title = metadataLocal.displayName
-      ? `${displayName} | ${metadataLocal.name} | Unity Package Manager (UPM)`
-      : `${metadataLocal.name} | Unity Package Manager (UPM)`;
-    const description = getLocalePackageDescription(metadataLocal);
+    const topics = topicsWithAll.filter(
+      (x) => x.slug && metadataLocal.topics.includes(x.slug),
+    );
+    const title = buildPackageDetailTitle(metadataLocal);
+    const description = buildPackageDetailDescription(metadataLocal);
     const cover = metadataLocal.image;
     const author = metadataLocal.owner;
     const tags = metadataLocal.topics;
@@ -273,23 +276,22 @@ const createDetailPages = async function (app: App): Promise<Page[]> {
       author,
       tags,
       head: structuredDataHead(
-        buildPackageStructuredData(
-          metadataLocal,
-          topicsWithAll.filter(
-            (x) => x.slug && metadataLocal.topics.includes(x.slug),
-          ),
-        ),
+        buildPackageStructuredData(metadataLocal, topics),
       ),
       lastmod: getPackageLastModified(metadataLocal, packageLastModifiedMap),
       metadataLocal: metadataLocal,
-      topics: topicsWithAll.filter(
-        (x) => x.slug && metadataLocal.topics.includes(x.slug),
-      ),
+      topics,
     };
     const pageOptions = {
       path: getPackageDetailPagePath(metadataLocal.name),
       frontmatter,
-      content: '',
+      content: buildPackageDetailContent(metadataLocal, {
+        relatedPackages: buildRelatedPackageSummaries(
+          metadataLocal,
+          metadataLocalList,
+        ),
+        topics,
+      }),
     };
     const page = await createPage(app, pageOptions);
     pages.push(page);
@@ -348,7 +350,7 @@ const createListPages = async function (app: App): Promise<Page[]> {
       layout: 'PackageListLayout',
       // Hack: use an empty element to show sidebar
       sidebar: [{ text: '', children: [] }],
-      title: topic.slug ? `Packages - ${topic.name}` : 'Packages',
+      title: buildPackageListTitle(topic),
       description: buildPackageListDescription(topic),
       lastmod: getLatestPackageLastModified(
         topicMetadataLocalList,

--- a/packages/vuepress-plugin-openupm/src/seo.ts
+++ b/packages/vuepress-plugin-openupm/src/seo.ts
@@ -20,6 +20,11 @@ export interface CrawlablePackageSummary {
   title: string;
 }
 
+export interface PackageDetailContentOptions {
+  relatedPackages: CrawlablePackageSummary[];
+  topics: Topic[];
+}
+
 export type PackageLastModifiedMap = Record<string, number | undefined>;
 
 export const OPENUPM_FALLBACK_IMAGE = '/images/openupm-twitter.png';
@@ -93,6 +98,38 @@ export const buildPackageListDescription = (topic: Topic): string => {
   return `Browse OpenUPM Unity packages tagged ${topic.name}, with package details, repository links, install instructions, and related package metadata.${keywords}`;
 };
 
+export const buildPackageListTitle = (topic: Topic): string =>
+  topic.slug
+    ? `${topic.name} Unity Packages | OpenUPM`
+    : 'Unity Packages for OpenUPM';
+
+export const buildPackageDetailTitle = (
+  metadataLocal: PackageMetadataLocal,
+): string => {
+  const displayName = getLocalePackageDisplayName(metadataLocal);
+  if (displayName && displayName !== metadataLocal.name) {
+    return `${displayName} (${metadataLocal.name}) | OpenUPM Unity Package`;
+  }
+  return `${metadataLocal.name} | OpenUPM Unity Package`;
+};
+
+export const buildPackageDetailDescription = (
+  metadataLocal: PackageMetadataLocal,
+): string => {
+  const displayName = getLocalePackageDisplayName(metadataLocal);
+  const packageLabel = displayName || metadataLocal.name;
+  const description = truncateText(
+    getLocalePackageDescription(metadataLocal),
+    118,
+  );
+  const owner = metadataLocal.owner ? ` by ${metadataLocal.owner}` : '';
+  const prefix = description ? `${description} ` : '';
+  return truncateText(
+    `${prefix}Install ${packageLabel}${owner} from the OpenUPM Unity package registry, with repository metadata, dependencies, versions, and setup instructions.`,
+    165,
+  );
+};
+
 export const buildCrawlablePackageSummaries = (
   topic: Topic,
   metadataLocalList: PackageMetadataLocal[],
@@ -116,6 +153,39 @@ export const buildCrawlablePackageSummaries = (
       title: getLocalePackageDisplayName(metadataLocal) || metadataLocal.name,
     }));
 
+export const buildRelatedPackageSummaries = (
+  metadataLocal: PackageMetadataLocal,
+  metadataLocalList: PackageMetadataLocal[],
+  limit = 6,
+): CrawlablePackageSummary[] => {
+  const topicSet = new Set(metadataLocal.topics);
+  return metadataLocalList
+    .filter((candidate) => candidate.name !== metadataLocal.name)
+    .filter((candidate) => !candidate.excludedFromList)
+    .map((candidate) => ({
+      candidate,
+      sharedTopicCount: candidate.topics.filter((topic) => topicSet.has(topic))
+        .length,
+      sameOwner:
+        Boolean(metadataLocal.owner) && candidate.owner === metadataLocal.owner,
+    }))
+    .filter((entry) => entry.sharedTopicCount > 0 || entry.sameOwner)
+    .sort((a, b) => {
+      if (a.sameOwner !== b.sameOwner) return a.sameOwner ? -1 : 1;
+      if (a.sharedTopicCount !== b.sharedTopicCount) {
+        return b.sharedTopicCount - a.sharedTopicCount;
+      }
+      return a.candidate.name.localeCompare(b.candidate.name);
+    })
+    .slice(0, limit)
+    .map(({ candidate }) => ({
+      description: truncateText(getLocalePackageDescription(candidate), 160),
+      name: candidate.name,
+      path: getPackageDetailPagePath(candidate.name),
+      title: getLocalePackageDisplayName(candidate) || candidate.name,
+    }));
+};
+
 export const buildPackageListContent = (
   topic: Topic,
   summaries: CrawlablePackageSummary[],
@@ -134,6 +204,49 @@ export const buildPackageListContent = (
     `<h1>${escapeHtml(heading)}</h1>`,
     `<p>${escapeHtml(buildPackageListDescription(topic))}</p>`,
     summaryItems ? `<ul>${summaryItems}</ul>` : '',
+    '</section>',
+    '',
+  ].join('\n');
+};
+
+export const buildPackageDetailContent = (
+  metadataLocal: PackageMetadataLocal,
+  options: PackageDetailContentOptions,
+): string => {
+  const displayName = getLocalePackageDisplayName(metadataLocal);
+  const title = displayName || metadataLocal.name;
+  const description = getLocalePackageDescription(metadataLocal);
+  const topicLinks = options.topics
+    .map(
+      (topic) =>
+        `<li><a href="${escapeHtml(topic.urlPath)}">${escapeHtml(topic.name)}</a></li>`,
+    )
+    .join('');
+  const relatedPackageLinks = options.relatedPackages
+    .map(
+      (summary) =>
+        `<li><a href="${escapeHtml(summary.path)}">${escapeHtml(summary.title)}</a> ` +
+        `<span>${escapeHtml(summary.name)}</span></li>`,
+    )
+    .join('');
+  const ownerHref = metadataLocal.ownerUrl || metadataLocal.repoUrl;
+  const owner = metadataLocal.owner
+    ? ownerHref
+      ? `<p>Owner: <a href="${escapeHtml(ownerHref)}">${escapeHtml(metadataLocal.owner)}</a>.</p>`
+      : `<p>Owner: ${escapeHtml(metadataLocal.owner)}.</p>`
+    : '';
+  return [
+    '<section class="package-detail-crawl-metadata" hidden>',
+    `<h1>${escapeHtml(title)}</h1>`,
+    `<p><code>${escapeHtml(metadataLocal.name)}</code> is an OpenUPM Unity package. ${escapeHtml(description)}</p>`,
+    '<p>Install this package from the OpenUPM scoped registry with the instructions on this page, or use <a href="/docs/getting-started-cli.html">openupm-cli</a> to update <code>Packages/manifest.json</code>.</p>',
+    `<p>Repository: <a href="${escapeHtml(metadataLocal.repoUrl)}">${escapeHtml(metadataLocal.repoUrl)}</a>.</p>`,
+    owner,
+    topicLinks ? `<h2>Topics</h2><ul>${topicLinks}</ul>` : '',
+    relatedPackageLinks
+      ? `<h2>Related Unity Packages</h2><ul>${relatedPackageLinks}</ul>`
+      : '',
+    '<p>For registry setup problems, see <a href="/docs/scoped-registry-troubleshooting.html">Unity scoped registry troubleshooting</a>.</p>',
     '</section>',
     '',
   ].join('\n');

--- a/packages/vuepress-plugin-openupm/src/seo.ts
+++ b/packages/vuepress-plugin-openupm/src/seo.ts
@@ -25,6 +25,12 @@ export interface PackageDetailContentOptions {
   topics: Topic[];
 }
 
+interface RelatedPackageScore {
+  candidate: PackageMetadataLocal;
+  sameOwner: boolean;
+  sharedTopicCount: number;
+}
+
 export type PackageLastModifiedMap = Record<string, number | undefined>;
 
 export const OPENUPM_FALLBACK_IMAGE = '/images/openupm-twitter.png';
@@ -157,33 +163,74 @@ export const buildRelatedPackageSummaries = (
   metadataLocal: PackageMetadataLocal,
   metadataLocalList: PackageMetadataLocal[],
   limit = 6,
-): CrawlablePackageSummary[] => {
-  const topicSet = new Set(metadataLocal.topics);
-  return metadataLocalList
-    .filter((candidate) => candidate.name !== metadataLocal.name)
-    .filter((candidate) => !candidate.excludedFromList)
-    .map((candidate) => ({
-      candidate,
-      sharedTopicCount: candidate.topics.filter((topic) => topicSet.has(topic))
-        .length,
-      sameOwner:
-        Boolean(metadataLocal.owner) && candidate.owner === metadataLocal.owner,
-    }))
-    .filter((entry) => entry.sharedTopicCount > 0 || entry.sameOwner)
-    .sort((a, b) => {
-      if (a.sameOwner !== b.sameOwner) return a.sameOwner ? -1 : 1;
-      if (a.sharedTopicCount !== b.sharedTopicCount) {
-        return b.sharedTopicCount - a.sharedTopicCount;
+): CrawlablePackageSummary[] =>
+  buildRelatedPackageSummaryIndex(metadataLocalList)(metadataLocal, limit);
+
+export const buildRelatedPackageSummaryIndex = (
+  metadataLocalList: PackageMetadataLocal[],
+): ((
+  metadataLocal: PackageMetadataLocal,
+  limit?: number,
+) => CrawlablePackageSummary[]) => {
+  const ownerPackages = new Map<string, PackageMetadataLocal[]>();
+  const topicPackages = new Map<string, PackageMetadataLocal[]>();
+
+  for (const metadataLocal of metadataLocalList) {
+    if (metadataLocal.excludedFromList) continue;
+
+    if (metadataLocal.owner) {
+      const packages = ownerPackages.get(metadataLocal.owner) || [];
+      packages.push(metadataLocal);
+      ownerPackages.set(metadataLocal.owner, packages);
+    }
+
+    for (const topic of metadataLocal.topics) {
+      const packages = topicPackages.get(topic) || [];
+      packages.push(metadataLocal);
+      topicPackages.set(topic, packages);
+    }
+  }
+
+  return (metadataLocal, limit = 6): CrawlablePackageSummary[] => {
+    const candidateMap = new Map<string, PackageMetadataLocal>();
+    const topicSet = new Set(metadataLocal.topics);
+
+    for (const candidate of ownerPackages.get(metadataLocal.owner) || []) {
+      candidateMap.set(candidate.name, candidate);
+    }
+    for (const topic of topicSet) {
+      for (const candidate of topicPackages.get(topic) || []) {
+        candidateMap.set(candidate.name, candidate);
       }
-      return a.candidate.name.localeCompare(b.candidate.name);
-    })
-    .slice(0, limit)
-    .map(({ candidate }) => ({
-      description: truncateText(getLocalePackageDescription(candidate), 160),
-      name: candidate.name,
-      path: getPackageDetailPagePath(candidate.name),
-      title: getLocalePackageDisplayName(candidate) || candidate.name,
-    }));
+    }
+
+    return Array.from(candidateMap.values())
+      .filter((candidate) => candidate.name !== metadataLocal.name)
+      .map<RelatedPackageScore>((candidate) => ({
+        candidate,
+        sharedTopicCount: candidate.topics.filter((topic) =>
+          topicSet.has(topic),
+        ).length,
+        sameOwner:
+          Boolean(metadataLocal.owner) &&
+          candidate.owner === metadataLocal.owner,
+      }))
+      .filter((entry) => entry.sharedTopicCount > 0 || entry.sameOwner)
+      .sort((a, b) => {
+        if (a.sameOwner !== b.sameOwner) return a.sameOwner ? -1 : 1;
+        if (a.sharedTopicCount !== b.sharedTopicCount) {
+          return b.sharedTopicCount - a.sharedTopicCount;
+        }
+        return a.candidate.name.localeCompare(b.candidate.name);
+      })
+      .slice(0, limit)
+      .map(({ candidate }) => ({
+        description: truncateText(getLocalePackageDescription(candidate), 160),
+        name: candidate.name,
+        path: getPackageDetailPagePath(candidate.name),
+        title: getLocalePackageDisplayName(candidate) || candidate.name,
+      }));
+  };
 };
 
 export const buildPackageListContent = (


### PR DESCRIPTION
## Summary
- Improve generated package list and package detail SEO titles, descriptions, structured crawl metadata, and related package links.
- Add scoped registry troubleshooting docs and connect high-intent docs/NuGet pages to it.
- Add shared breadcrumbs across docs, blog, package list, and OpenUPM package detail pages, with package-list spacing adjusted for the new breadcrumb.

## Validation
- npm run test -- seo.test.ts
- npm run test -- seoContentLinks.spec.ts breadcrumb.spec.ts
- npm run lint
- npm run docs:build:limit