### PR TITLE
Fix hidden package detail markdown content

### DIFF
--- a/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
@@ -155,6 +155,26 @@ describe('SEO metadata helpers', () => {
     expect(content).toContain('https://github.com/example');
   });
 
+  it('normalizes markdown-like package descriptions in hidden detail content', () => {
+    const content = buildPackageDetailContent(
+      {
+        ...packageMetadata,
+        description:
+          'Expose easily your methods as buttons in editor and runtime.\n\n* It includes an Overlay Toolbar',
+      },
+      {
+        relatedPackages: [],
+        topics: [],
+      },
+    );
+
+    expect(content).toContain(
+      'Expose easily your methods as buttons in editor and runtime. * It includes an Overlay Toolbar',
+    );
+    expect(content).not.toContain('<ul>');
+    expect(content).not.toContain('</p></li>');
+  });
+
   it('builds SoftwareApplication and breadcrumb JSON-LD for package pages', () => {
     const structuredData = buildPackageStructuredData(packageMetadata, [topic]);
 

--- a/packages/vuepress-plugin-openupm/src/seo.ts
+++ b/packages/vuepress-plugin-openupm/src/seo.ts
@@ -262,7 +262,7 @@ export const buildPackageDetailContent = (
 ): string => {
   const displayName = getLocalePackageDisplayName(metadataLocal);
   const title = displayName || metadataLocal.name;
-  const description = getLocalePackageDescription(metadataLocal);
+  const description = cleanText(getLocalePackageDescription(metadataLocal));
   const topicLinks = options.topics
     .map(
       (topic) =>


### PR DESCRIPTION
## Summary
- Normalize package descriptions before embedding them in hidden package-detail crawl metadata.
- Add a regression test for multiline Markdown-like descriptions that previously generated invalid Vue template HTML.

## Root cause
The full website build failed on the generated page for com.dteruel.toolnity.custombuttons because its package description contains a blank line followed by a Markdown bullet. VuePress processed that bullet inside the generated raw HTML paragraph, producing malformed SFC output.

## Validation
- npm run test -- seo.test.ts
- npm run build -- --filter=vuepress-plugin-openupm
- npm run lint
- OPENUPM_DATA_PATH=<data checkout> VITE_OPENUPM_REGION=us npm run docs:build