### PR TITLE
use regex scan + semver.clean for version extraction

### DIFF
--- a/apps/queue/__tests__/workers/buildPackage.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackage.spec.ts
@@ -37,6 +37,21 @@ describe('buildPackage.filterRemoteTags', () => {
     expect(names).toEqual([{ commit: '0000010', tag: '1.0.2-upm' }]);
   });
 
+  it('@ prefix', () => {
+    const names = filterRemoteTags({
+      remoteTags: [
+        { tag: 'com.example.package@1.0.0', commit: '10' },
+        { tag: 'com.example.package@2.0.0', commit: '11' },
+        { tag: 'com.other.package@1.0.0', commit: '12' },
+      ],
+      gitTagPrefix: 'com.example.package@',
+    });
+    expect(names).toEqual([
+      { tag: 'com.example.package@1.0.0', commit: '10' },
+      { tag: 'com.example.package@2.0.0', commit: '11' },
+    ]);
+  });
+
   it('prefix, ignore, minVersion', () => {
     const names = filterRemoteTags({
       remoteTags: [

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -122,7 +122,6 @@ export async function buildPackage(name: string): Promise<void> {
     pkg.name,
     validTags,
     pkg.trackingMode || 'git',
-    pkg.gitTagPrefix,
   );
   await probeMissingGitHubReleaseAssets(pkg, releases);
   await addReleaseJobs(releases);
@@ -137,10 +136,6 @@ export function isRepoUnavailableError(message: string): boolean {
   );
 }
 
-function stripTagPrefix(tag: string, prefix?: string): string {
-  return prefix && tag.startsWith(prefix) ? tag.slice(prefix.length) : tag;
-}
-
 export function filterRemoteTags(params: {
   remoteTags: RemoteTag[];
   gitTagIgnore?: string;
@@ -151,7 +146,7 @@ export function filterRemoteTags(params: {
   let tags = remoteTags;
 
   if (gitTagPrefix) tags = tags.filter((x) => x.tag.startsWith(gitTagPrefix));
-  tags = tags.filter((x) => getVersionFromTag(stripTagPrefix(x.tag, gitTagPrefix)) != null);
+  tags = tags.filter((x) => getVersionFromTag(x.tag) != null);
 
   if (gitTagIgnore) {
     const ignoreRe = new RegExp(gitTagIgnore, 'i');
@@ -160,12 +155,12 @@ export function filterRemoteTags(params: {
 
   const upmRe = /(^upm\/|(_|-)upm$)/i;
   const validTags = tags.filter((x) => upmRe.test(x.tag));
-  const versionSet = new Set(validTags.map((x) => getVersionFromTag(stripTagPrefix(x.tag, gitTagPrefix))));
+  const versionSet = new Set(validTags.map((x) => getVersionFromTag(x.tag)));
 
   if (minVersion) {
     try {
       tags = tags.filter((x) => {
-        const lhs = getVersionFromTag(stripTagPrefix(x.tag, gitTagPrefix));
+        const lhs = getVersionFromTag(x.tag);
         const rhs = getVersionFromTag(minVersion);
         if (!lhs || !rhs) return false;
         return compareVersions(lhs, rhs) >= 0;
@@ -176,7 +171,7 @@ export function filterRemoteTags(params: {
   }
 
   for (const element of tags) {
-    const version = getVersionFromTag(stripTagPrefix(element.tag, gitTagPrefix));
+    const version = getVersionFromTag(element.tag);
     if (!versionSet.has(version)) {
       versionSet.add(version);
       validTags.push(element);
@@ -205,7 +200,7 @@ export function getInvalidTags(params: {
   if (minVersion) {
     try {
       tags = tags.filter((x) => {
-        const lhs = getVersionFromTag(stripTagPrefix(x.tag, gitTagPrefix));
+        const lhs = getVersionFromTag(x.tag);
         const rhs = getVersionFromTag(minVersion);
         if (!lhs || !rhs) return false;
         return compareVersions(lhs, rhs) >= 0;
@@ -222,7 +217,6 @@ async function updateReleaseRecords(
   packageName: string,
   remoteTags: RemoteTag[],
   source: ReleaseModel['source'],
-  gitTagPrefix?: string,
 ): Promise<ReleaseModel[]> {
   const existing = await fetchAll(packageName);
   for (const rel of existing) {
@@ -247,7 +241,7 @@ async function updateReleaseRecords(
 
   const releases: ReleaseModel[] = [];
   for (const remoteTag of remoteTags) {
-    const version = getVersionFromTag(stripTagPrefix(remoteTag.tag, gitTagPrefix));
+    const version = getVersionFromTag(remoteTag.tag);
     if (!version) continue;
     let release = await fetchOne(packageName, version);
     if (!release) {

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -122,6 +122,7 @@ export async function buildPackage(name: string): Promise<void> {
     pkg.name,
     validTags,
     pkg.trackingMode || 'git',
+    pkg.gitTagPrefix,
   );
   await probeMissingGitHubReleaseAssets(pkg, releases);
   await addReleaseJobs(releases);
@@ -136,6 +137,10 @@ export function isRepoUnavailableError(message: string): boolean {
   );
 }
 
+function stripTagPrefix(tag: string, prefix?: string): string {
+  return prefix && tag.startsWith(prefix) ? tag.slice(prefix.length) : tag;
+}
+
 export function filterRemoteTags(params: {
   remoteTags: RemoteTag[];
   gitTagIgnore?: string;
@@ -146,7 +151,7 @@ export function filterRemoteTags(params: {
   let tags = remoteTags;
 
   if (gitTagPrefix) tags = tags.filter((x) => x.tag.startsWith(gitTagPrefix));
-  tags = tags.filter((x) => getVersionFromTag(x.tag) != null);
+  tags = tags.filter((x) => getVersionFromTag(stripTagPrefix(x.tag, gitTagPrefix)) != null);
 
   if (gitTagIgnore) {
     const ignoreRe = new RegExp(gitTagIgnore, 'i');
@@ -155,12 +160,12 @@ export function filterRemoteTags(params: {
 
   const upmRe = /(^upm\/|(_|-)upm$)/i;
   const validTags = tags.filter((x) => upmRe.test(x.tag));
-  const versionSet = new Set(validTags.map((x) => getVersionFromTag(x.tag)));
+  const versionSet = new Set(validTags.map((x) => getVersionFromTag(stripTagPrefix(x.tag, gitTagPrefix))));
 
   if (minVersion) {
     try {
       tags = tags.filter((x) => {
-        const lhs = getVersionFromTag(x.tag);
+        const lhs = getVersionFromTag(stripTagPrefix(x.tag, gitTagPrefix));
         const rhs = getVersionFromTag(minVersion);
         if (!lhs || !rhs) return false;
         return compareVersions(lhs, rhs) >= 0;
@@ -171,7 +176,7 @@ export function filterRemoteTags(params: {
   }
 
   for (const element of tags) {
-    const version = getVersionFromTag(element.tag);
+    const version = getVersionFromTag(stripTagPrefix(element.tag, gitTagPrefix));
     if (!versionSet.has(version)) {
       versionSet.add(version);
       validTags.push(element);
@@ -200,7 +205,7 @@ export function getInvalidTags(params: {
   if (minVersion) {
     try {
       tags = tags.filter((x) => {
-        const lhs = getVersionFromTag(x.tag);
+        const lhs = getVersionFromTag(stripTagPrefix(x.tag, gitTagPrefix));
         const rhs = getVersionFromTag(minVersion);
         if (!lhs || !rhs) return false;
         return compareVersions(lhs, rhs) >= 0;
@@ -217,6 +222,7 @@ async function updateReleaseRecords(
   packageName: string,
   remoteTags: RemoteTag[],
   source: ReleaseModel['source'],
+  gitTagPrefix?: string,
 ): Promise<ReleaseModel[]> {
   const existing = await fetchAll(packageName);
   for (const rel of existing) {
@@ -241,7 +247,7 @@ async function updateReleaseRecords(
 
   const releases: ReleaseModel[] = [];
   for (const remoteTag of remoteTags) {
-    const version = getVersionFromTag(remoteTag.tag);
+    const version = getVersionFromTag(stripTagPrefix(remoteTag.tag, gitTagPrefix));
     if (!version) continue;
     let release = await fetchOne(packageName, version);
     if (!release) {

--- a/packages/@openupm/common/__tests__/semver.spec.ts
+++ b/packages/@openupm/common/__tests__/semver.spec.ts
@@ -2,9 +2,11 @@ import { getVersionFromTag } from '../src/semver.js';
 
 describe('getVersionFromTag()', function () {
   it.each([
+    // bare versions
     ['1.2.3', '1.2.3'],
     ['v1.2.3', '1.2.3'],
     ['V1.2.3', '1.2.3'],
+    // pre-release identifiers
     ['1.2.3-alpha', '1.2.3-alpha'],
     ['1.2.3-alpha.1', '1.2.3-alpha.1'],
     ['1.2.3-beta', '1.2.3-beta'],
@@ -12,22 +14,39 @@ describe('getVersionFromTag()', function () {
     ['1.2.3-rc.1', '1.2.3-rc.1'],
     ['1.2.3-preview', '1.2.3-preview'],
     ['1.2.3-preview.1', '1.2.3-preview.1'],
-    ['upm/v1.2.3-beta.2', '1.2.3-beta.2'],
-    ['pkg-1.2.3-rc.1', '1.2.3-rc.1'],
-    ['pkg_1.2.3-preview.1', '1.2.3-preview.1'],
-    ['1.2.3-upm', '1.2.3'],
-    ['v1.2.3_upm', '1.2.3'],
+    // build metadata (stripped)
+    ['v2.0.2+002', '2.0.2'],
+    ['1.2.3+build.1', '1.2.3'],
+    // loose / non-standard versions
     ['0.10.7b', '0.10.7-b'],
     ['1.2.03', '1.2.3'],
-    ['v2.0.2+002', '2.0.2'],
+    // path-style prefixes (/)
+    ['upm/v1.2.3-beta.2', '1.2.3-beta.2'],
+    ['upm/1.0.0', '1.0.0'],
+    ['com.example.package/1.2.3', '1.2.3'],
+    ['releases/1.2.3', '1.2.3'],
+    // hyphen-style prefixes (-)
+    ['pkg-1.2.3-rc.1', '1.2.3-rc.1'],
+    // underscore-style prefixes (_)
+    ['pkg_1.2.3-preview.1', '1.2.3-preview.1'],
+    // @ prefix (e.g. com.company.package@1.0.0)
+    ['com.example.package@1.0.0', '1.0.0'],
+    ['com.example.package@1.2.3-beta.1', '1.2.3-beta.1'],
+    // upm/master suffix (stripped)
+    ['1.2.3-upm', '1.2.3'],
+    ['v1.2.3_upm', '1.2.3'],
+    ['1.2.3-master', '1.2.3'],
   ])('parses %s as %s', function (tag, version) {
     expect(getVersionFromTag(tag)).toEqual(version);
   });
 
-  it.each(['1.0.0.0', 'release', 'package/latest'])(
-    'returns null for %s',
-    function (tag) {
-      expect(getVersionFromTag(tag)).toEqual(null);
-    },
-  );
+  it.each([
+    '1.0.0.0',      // 4-part version, not valid semver
+    'release',      // no version at all
+    'main',         // no version at all
+    'latest',       // no version at all
+    'package/latest', // path with no version
+  ])('returns null for %s', function (tag) {
+    expect(getVersionFromTag(tag)).toEqual(null);
+  });
 });

--- a/packages/@openupm/common/src/semver.ts
+++ b/packages/@openupm/common/src/semver.ts
@@ -3,7 +3,7 @@
 import { clean } from 'semver';
 
 // Get version from git tag name.
-export function getVersionFromTag(tag): string | null {
+export function getVersionFromTag(tag: string): string | null {
   const parseVersion = function (seg: string): string | null {
     // Handle upm suffix.
     const upmRe = /(_|-)(upm|master)$/i;

--- a/packages/@openupm/common/src/semver.ts
+++ b/packages/@openupm/common/src/semver.ts
@@ -2,31 +2,19 @@
 
 import { clean } from 'semver';
 
+// Finds the start of a version-like pattern (X.Y.Z...) within a string.
+// Validation is delegated to semver.clean() rather than encoded in the regex.
+const SEMVER_RE = /v?\d+\.\d+\.\d+[^\s]*/i;
+
 // Get version from git tag name.
 export function getVersionFromTag(tag: string): string | null {
-  const parseVersion = function (seg: string): string | null {
-    // Handle upm suffix.
-    const upmRe = /(_|-)(upm|master)$/i;
-    seg = seg.replace(upmRe, '');
-    return clean(seg.toLowerCase(), { loose: true });
-  };
-  const parseSeg = function (tag: string, separator: string): string | null {
-    const segs = tag.split(separator);
-    for (let i = 0; i < segs.length; i++) {
-      const arr = segs.slice(segs.length - i - 1, segs.length);
-      const text = arr.join(separator);
-      version = parseVersion(text);
-      if (version) return version;
-    }
-    return null;
-  };
-  // Try parsing the tag.
-  let version = parseVersion(tag);
-  // Try parsing a path-like tag: prefix/{version}.
-  if (!version) version = parseSeg(tag, '/');
-  // Try parsing a hyphen-joined tag: prefix-{version}.
-  if (!version) version = parseSeg(tag, '-');
-  // Try parsing a underscore-joined tag: prefix_{version}.
-  if (!version) version = parseSeg(tag, '_');
-  return version;
+  // Strip upm/master suffix.
+  tag = tag.replace(/(_|-)(upm|master)$/i, '');
+  // Try the full string first (handles v-prefix, loose versions like 0.10.7b).
+  const direct = clean(tag.toLowerCase(), { loose: true });
+  if (direct) return direct;
+  // Scan for a semver pattern within the string, supporting arbitrary prefix
+  // characters including '@', '/', '-', and '_'.
+  const match = tag.match(SEMVER_RE);
+  return match ? clean(match[0].toLowerCase(), { loose: true }) : null;
 }


### PR DESCRIPTION
getVersionFromTag previously split tags on '/', '-', and '_' to find a version. This meant prefixes using any other character (e.g. '@' in com.example.package@1.0.0) caused tags to be silently dropped by the build pipeline — the version couldn't be extracted, so the job was never queued.

Replace the ad-hoc delimiter splitting with a simple regex that finds the start of a version-like pattern in the string, then delegates validation entirely to semver.clean(). This supports arbitrary prefix characters and keeps version validation in one place.

Expand the test suite to cover path, hyphen, underscore, and @ prefixes, build metadata stripping, loose versions, upm/master suffixes, and null cases including 4-part versions like 1.0.0.0.

Resolves https://github.com/openupm/openupm/issues/6483