### PR TITLE
Improve docs index SEO metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,12 @@
 ## Docs App Notes
 
 - Docs commands run from `apps/docs`.
+- Keep operator-only SEO measurement tooling outside this application
+  repository. Use the standalone workspace sibling `openupm-seo-tools` for
+  Search Console, PageSpeed, CrUX, Lighthouse, baseline reports, API keys,
+  OAuth refresh tokens, and private measurement artifacts. Do not add root
+  package scripts, docs app scripts, workspace packages, public docs, or
+  generated site assets that reveal or depend on that tooling.
 - `npm run docs:build:limit` is the fastest full SSR build smoke test for the docs app.
 - If the shell is not already using the repo-pinned Node/npm versions, run docs
   commands through Volta, for example `volta run npm run lint`.

--- a/apps/docs/__tests__/seoContentLinks.spec.ts
+++ b/apps/docs/__tests__/seoContentLinks.spec.ts
@@ -34,6 +34,18 @@ describe("docs SEO content links", () => {
     }
   });
 
+  it("sets search-focused docs index metadata", () => {
+    const page = readDocsFile("docs/index.md");
+
+    expect(page).toContain(
+      "title: OpenUPM Unity Package Manager Registry Docs",
+    );
+    expect(page).toContain(
+      "description: Set up OpenUPM for Unity Package Manager packages",
+    );
+    expect(page).toContain("# OpenUPM Unity Package Manager Registry Docs");
+  });
+
   it("keeps the troubleshooting page indexable and connected to package paths", () => {
     const page = readDocsFile("docs/scoped-registry-troubleshooting.md");
 

--- a/apps/docs/docs/docs/index.md
+++ b/apps/docs/docs/docs/index.md
@@ -1,6 +1,8 @@
 ---
+title: OpenUPM Unity Package Manager Registry Docs
+description: Set up OpenUPM for Unity Package Manager packages, scoped registry configuration, CLI install commands, package publishing, UnityNuGet packages, and troubleshooting.
 ---
-# Introduction
+# OpenUPM Unity Package Manager Registry Docs
 
 Welcome to OpenUPM, your solution for open-source Unity Package Manager (UPM) packages. OpenUPM is a user-friendly service that hosts, manages, and automates the building of UPM packages. We're here to make it easy for you to find, share, and distribute open-source UPM packages.
 


### PR DESCRIPTION
Summary:\n- Add search-focused title and meta description for the docs index.\n- Update the docs index H1 to match the search-focused page topic.\n- Document that operator-only SEO measurement tooling belongs outside this application repository.\n\nValidation:\n- npm run test -- seoContentLinks.spec.ts\n- npm run lint\n- npm run docs:build:limit