### PR TITLE
Split docs route layout bundles

### DIFF
--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -16,6 +16,19 @@ describe("docs runtime payload fetch behavior", () => {
     expect(source).toContain("isPackageListPath(path)");
     expect(source).toContain("store.fetchCachedSiteInfo()");
     expect(source).toContain("store.fetchCachedPackageListData()");
+    expect(source).toContain("defineAsyncComponent");
+    expect(source).toContain('import("@/layouts/PackageListLayout.vue")');
+    expect(source).toContain('import("@/layouts/PackageDetailLayout.vue")');
+    expect(source).toContain('import("@/layouts/NuGetPackageDetailLayout.vue")');
+    expect(source).not.toContain(
+      'import PackageListLayout from "@/layouts/PackageListLayout.vue";',
+    );
+    expect(source).not.toContain(
+      'import PackageDetailLayout from "@/layouts/PackageDetailLayout.vue";',
+    );
+    expect(source).not.toContain(
+      'import NuGetPackageDetailLayout from "@/layouts/NuGetPackageDetailLayout.vue";',
+    );
     expect(source).not.toContain("store.fetchCachedPackageMetadataRemoteDict();");
     expect(source).not.toContain("store.fetchCachedPackageMetadataLocalList();");
   });

--- a/apps/docs/docs/.vuepress/client.ts
+++ b/apps/docs/docs/.vuepress/client.ts
@@ -1,6 +1,6 @@
 import { createPinia } from "pinia";
 import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
-import { onMounted, watch } from "vue";
+import { defineAsyncComponent, onMounted, watch } from "vue";
 import { useRoute } from "vue-router";
 import { createI18n } from "vue-i18n";
 import { defineClientConfig } from "vuepress/client";
@@ -12,13 +12,24 @@ import { isPackageListPath } from "@openupm/common/build/urls.js";
 import { useDefaultStore } from "@/store";
 import { GlobalFilters } from "@/vue-plugins/global-filters";
 import Layout from "@/layouts/Layout.vue";
-import WideLayout from "@/layouts/WideLayout.vue";
-import PackageDetailLayout from "@/layouts/PackageDetailLayout.vue";
-import NuGetPackageDetailLayout from "@/layouts/NuGetPackageDetailLayout.vue";
-import PackageListLayout from "@/layouts/PackageListLayout.vue";
-import PackageAddLayout from "@/layouts/PackageAddLayout.vue";
-import HomeLayout from "@/layouts/HomeLayout.vue";
-import ContributorProfileLayout from "@/layouts/ContributorProfileLayout.vue";
+
+const WideLayout = defineAsyncComponent(() => import("@/layouts/WideLayout.vue"));
+const PackageDetailLayout = defineAsyncComponent(
+  () => import("@/layouts/PackageDetailLayout.vue"),
+);
+const NuGetPackageDetailLayout = defineAsyncComponent(
+  () => import("@/layouts/NuGetPackageDetailLayout.vue"),
+);
+const PackageListLayout = defineAsyncComponent(
+  () => import("@/layouts/PackageListLayout.vue"),
+);
+const PackageAddLayout = defineAsyncComponent(
+  () => import("@/layouts/PackageAddLayout.vue"),
+);
+const HomeLayout = defineAsyncComponent(() => import("@/layouts/HomeLayout.vue"));
+const ContributorProfileLayout = defineAsyncComponent(
+  () => import("@/layouts/ContributorProfileLayout.vue"),
+);
 
 export default defineClientConfig({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Summary:
- Register custom docs layouts through async components so route-specific package/list/detail code no longer inflates the initial app bundle.
- Keep the default shell layout static.
- Extend the runtime payload test to prevent static package-layout imports from returning.

Validation:
- npm run test -- runtimePayload.spec.ts
- npm run lint
- npm run docs:build:limit

Build comparison:
- Before: app JS was about 2.1 MB in the local docs build, with package layout/component dynamic-import warnings.
- After: app JS is about 936 KB; package/list/detail layouts are separate async chunks and those package component dynamic-import warnings are gone.