### PR TITLE
[codex] Fix docs footer flow

### DIFF
--- a/apps/docs/__tests__/vue/footer.spec.ts
+++ b/apps/docs/__tests__/vue/footer.spec.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const footerPath = fileURLToPath(
+  new URL("../../docs/.vuepress/components/Footer.vue", import.meta.url),
+);
+
+const layoutPath = fileURLToPath(
+  new URL("../../docs/.vuepress/layouts/Layout.vue", import.meta.url),
+);
+
+describe("Footer", () => {
+  const source = readFileSync(footerPath, "utf8");
+
+  it("renders as a full-bleed normal-flow section", () => {
+    expect(source).toContain("background-color: $primary-color;");
+    expect(source).not.toContain("100vw");
+    expect(source).not.toContain("position: absolute;");
+  });
+
+  it("removes inherited page bottom padding only when the site footer is present", () => {
+    const layoutSource = readFileSync(layoutPath, "utf8");
+
+    expect(layoutSource).toContain(
+      '<ParentLayout :class="{ \'has-page-footer\': showFooter }">',
+    );
+    expect(layoutSource).toContain('<Footer v-if="showFooter" />');
+    expect(layoutSource).toContain(".has-page-footer");
+    expect(layoutSource).toContain("padding-bottom: 0;");
+  });
+});

--- a/apps/docs/docs/.vuepress/components/Footer.vue
+++ b/apps/docs/docs/.vuepress/components/Footer.vue
@@ -131,6 +131,7 @@ const description = computed(() => t("site-desc"));
 
 .page-footer {
   --c-text-footer: #ccc;
+  background-color: $primary-color;
   color: var(--c-text-footer);
 
   a {
@@ -143,10 +144,6 @@ const description = computed(() => t("site-desc"));
   }
 
   .page-footer-box {
-    position: absolute;
-    left: 0;
-    right: 0;
-    background-color: $primary-color;
     padding: 1.5rem 0 1.5rem 2rem;
 
     h5 {
@@ -173,7 +170,7 @@ const description = computed(() => t("site-desc"));
   }
 }
 
-:global(:is(.dark, [data-theme='dark']) .page-footer .page-footer-box) {
+:global(:is(.dark, [data-theme='dark']) .page-footer) {
   background-color: var(--c-bg-light);
 }
 </style>

--- a/apps/docs/docs/.vuepress/layouts/Layout.vue
+++ b/apps/docs/docs/.vuepress/layouts/Layout.vue
@@ -24,7 +24,7 @@ const showContentTopAd = computed(() => {
 </script>
 
 <template>
-  <ParentLayout>
+  <ParentLayout :class="{ 'has-page-footer': showFooter }">
     <template #page-content-top>
       <SiteBreadcrumb />
       <AdsenseDisplayForContentTop v-if="showContentTopAd" />
@@ -34,11 +34,18 @@ const showContentTopAd = computed(() => {
       <slot :name="name" v-bind="slotData || {}" />
     </template>
 
-    <template #page-bottom>
-      <Footer v-if="showFooter" />
-      <ClientOnly>
-        <CookieConsent />
-      </ClientOnly>
-    </template>
   </ParentLayout>
+
+  <Footer v-if="showFooter" />
+  <ClientOnly>
+    <CookieConsent />
+  </ClientOnly>
 </template>
+
+<style lang="scss">
+:is(.theme-container, .vp-theme-container).has-page-footer {
+  :is(.page, .vp-page) {
+    padding-bottom: 0;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- make the docs footer full-width while keeping it in normal document flow
- remove the inherited VuePress page-bottom padding when the site footer is rendered
- add a focused source test for the footer layout contract

## Validation
- npm run test -- footer.spec.ts
- npm run lint
- npm run docs:build:limit
- staged locally and reviewed