### PR TITLE
Forward docs layout classes through footer wrapper

### DIFF
--- a/apps/docs/__tests__/vue/footer.spec.ts
+++ b/apps/docs/__tests__/vue/footer.spec.ts
@@ -24,10 +24,19 @@ describe("Footer", () => {
     const layoutSource = readFileSync(layoutPath, "utf8");
 
     expect(layoutSource).toContain(
-      '<ParentLayout :class="{ \'has-page-footer\': showFooter }">',
+      '<ParentLayout v-bind="parentLayoutAttrs" :class="parentLayoutClass">',
     );
     expect(layoutSource).toContain('<Footer v-if="showFooter" />');
     expect(layoutSource).toContain(".has-page-footer");
     expect(layoutSource).toContain("padding-bottom: 0;");
+  });
+
+  it("forwards inherited layout classes through the fragment wrapper", () => {
+    const layoutSource = readFileSync(layoutPath, "utf8");
+
+    expect(layoutSource).toContain("useAttrs");
+    expect(layoutSource).toContain("const parentLayoutAttrs = computed");
+    expect(layoutSource).toContain("const parentLayoutClass = computed");
+    expect(layoutSource).toContain("attrs.class");
   });
 });

--- a/apps/docs/docs/.vuepress/layouts/Layout.vue
+++ b/apps/docs/docs/.vuepress/layouts/Layout.vue
@@ -2,12 +2,13 @@
 <!-- Wrap default theme layout -->
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, useAttrs } from 'vue';
 import { usePageFrontmatter } from '@vuepress/client';
 
 import ParentLayout from '@vuepress/theme-default/layouts/Layout.vue';
 
 const frontmatter = usePageFrontmatter();
+const attrs = useAttrs();
 
 const showFooter = computed(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -21,10 +22,21 @@ const showContentTopAd = computed(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (frontmatter.value as any).showContentTopAd === true;
 });
+
+const parentLayoutAttrs = computed(() => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { class: className, ...rest } = attrs;
+  return rest;
+});
+
+const parentLayoutClass = computed(() => [
+  attrs.class,
+  { 'has-page-footer': showFooter.value },
+]);
 </script>
 
 <template>
-  <ParentLayout :class="{ 'has-page-footer': showFooter }">
+  <ParentLayout v-bind="parentLayoutAttrs" :class="parentLayoutClass">
     <template #page-content-top>
       <SiteBreadcrumb />
       <AdsenseDisplayForContentTop v-if="showContentTopAd" />


### PR DESCRIPTION
Summary:
- Forward inherited attrs/classes from the custom docs Layout wrapper to VuePress's parent layout after the footer was moved outside the page flow.
- Restore HomeLayout/WideLayout classes on the rendered theme container so homepage CSS applies again.
- Extend the footer test to cover class forwarding.

Validation:
- npm run test -- footer.spec.ts
- npm run lint
- npm run docs:build:limit
- Browser computed-style smoke check against local static output