### PR TITLE
Split docs route layout bundles

### DIFF
--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -16,6 +16,19 @@ describe("docs runtime payload fetch behavior", () => {
     expect(source).toContain("isPackageListPath(path)");
     expect(source).toContain("store.fetchCachedSiteInfo()");
     expect(source).toContain("store.fetchCachedPackageListData()");
+    expect(source).toContain("defineAsyncComponent");
+    expect(source).toContain('import("@/layouts/PackageListLayout.vue")');
+    expect(source).toContain('import("@/layouts/PackageDetailLayout.vue")');
+    expect(source).toContain('import("@/layouts/NuGetPackageDetailLayout.vue")');
+    expect(source).not.toContain(
+      'import PackageListLayout from "@/layouts/PackageListLayout.vue";',
+    );
+    expect(source).not.toContain(
+      'import PackageDetailLayout from "@/layouts/PackageDetailLayout.vue";',
+    );
+    expect(source).not.toContain(
+      'import NuGetPackageDetailLayout from "@/layouts/NuGetPackageDetailLayout.vue";',
+    );
     expect(source).not.toContain("store.fetchCachedPackageMetadataRemoteDict();");
     expect(source).not.toContain("store.fetchCachedPackageMetadataLocalList();");
   });

--- a/apps/docs/docs/.vuepress/client.ts
+++ b/apps/docs/docs/.vuepress/client.ts
@@ -1,6 +1,6 @@
 import { createPinia } from "pinia";
 import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
-import { onMounted, watch } from "vue";
+import { defineAsyncComponent, onMounted, watch } from "vue";
 import { useRoute } from "vue-router";
 import { createI18n } from "vue-i18n";
 import { defineClientConfig } from "vuepress/client";
@@ -12,13 +12,24 @@ import { isPackageListPath } from "@openupm/common/build/urls.js";
 import { useDefaultStore } from "@/store";
 import { GlobalFilters } from "@/vue-plugins/global-filters";
 import Layout from "@/layouts/Layout.vue";
-import WideLayout from "@/layouts/WideLayout.vue";
-import PackageDetailLayout from "@/layouts/PackageDetailLayout.vue";
-import NuGetPackageDetailLayout from "@/layouts/NuGetPackageDetailLayout.vue";
-import PackageListLayout from "@/layouts/PackageListLayout.vue";
-import PackageAddLayout from "@/layouts/PackageAddLayout.vue";
-import HomeLayout from "@/layouts/HomeLayout.vue";
-import ContributorProfileLayout from "@/layouts/ContributorProfileLayout.vue";
+
+const WideLayout = defineAsyncComponent(() => import("@/layouts/WideLayout.vue"));
+const PackageDetailLayout = defineAsyncComponent(
+  () => import("@/layouts/PackageDetailLayout.vue"),
+);
+const NuGetPackageDetailLayout = defineAsyncComponent(
+  () => import("@/layouts/NuGetPackageDetailLayout.vue"),
+);
+const PackageListLayout = defineAsyncComponent(
+  () => import("@/layouts/PackageListLayout.vue"),
+);
+const PackageAddLayout = defineAsyncComponent(
+  () => import("@/layouts/PackageAddLayout.vue"),
+);
+const HomeLayout = defineAsyncComponent(() => import("@/layouts/HomeLayout.vue"));
+const ContributorProfileLayout = defineAsyncComponent(
+  () => import("@/layouts/ContributorProfileLayout.vue"),
+);
 
 export default defineClientConfig({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Async-registers custom OpenUPM VuePress layouts so homepage, list, docs, and blog routes do not boot all package-detail UI in the app entry. Validation: runtime payload test, lint, limited docs build, and local browser visual smoke across representative routes. This is review-only for human staging approval before merge.