### PR TITLE
Reduce homepage initial package data work

### DIFF
--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -53,8 +53,12 @@ describe("docs runtime payload fetch behavior", () => {
     expect(storeSource).toContain("async fetchCachedPackageListData()");
     expect(storeSource).toContain("Promise.all([");
     expect(packageListSource).toContain("store.fetchCachedPackageListData()");
-    expect(homeSource).toContain("store.fetchCachedPackageMetadataRemoteDict()");
+    expect(homeSource).toContain("readyPackageCountFallback");
+    expect(homeSource).not.toContain("store.fetchCachedPackageMetadataRemoteDict()");
     expect(homeSource).not.toContain("store.fetchCachedPackageMetadataLocalList()");
+    expect(storeSource).not.toContain('from "axios"');
+    expect(storeSource).not.toContain('from "lodash-es"');
+    expect(storeSource).not.toContain('from "url-join"');
   });
 
   it("loads package detail payloads without a serial all-data waterfall", () => {

--- a/apps/docs/docs/.vuepress/layouts/HomeLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/HomeLayout.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-import { capitalize, template } from 'lodash-es';
 import { useI18n } from 'vue-i18n';
-import numeral from 'numeral';
-import { computed, onMounted } from 'vue';
+import { computed } from 'vue';
 
 import ParentLayout from "@/layouts/WideLayout.vue";
 import { useDefaultStore } from '@/store';
@@ -13,10 +11,13 @@ const store = useDefaultStore();
 const frontmatter = usePageFrontmatter();
 const { t } = useI18n();
 
+const capitalizeText = (text: string): string =>
+  text ? text.charAt(0).toUpperCase() + text.slice(1) : text;
+
 const guideLink = computed(() => {
   return {
     link: "/docs/",
-    text: capitalize(t("guide")),
+    text: capitalizeText(t("guide")),
   };
 });
 
@@ -31,23 +32,28 @@ const githubLink = computed(() => {
 });
 
 const readyPackageCount = computed(() => {
-  const num = store.readyPackageCount;
-  return numeral(num).format("0,0");
+  const num = store.siteInfo.readyPackageCount || 0;
+  if (num > 0) return new Intl.NumberFormat("en-US").format(num);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fallback = (frontmatter.value as any).readyPackageCountFallback;
+  return typeof fallback === "string" ? fallback : "2,700+";
 });
 
 const features = computed(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const items = (frontmatter.value as any).features as { title: string, desc: string }[];
+  const items = (frontmatter.value as any).features as {
+    title: string;
+    desc: string;
+  }[];
   return items.map(item => {
     return {
       title: item.title,
-      desc: template(item.desc)({ package_count: readyPackageCount.value }),
+      desc: item.desc.replace(
+        /<%=\s*package_count\s*%>/g,
+        readyPackageCount.value,
+      ),
     };
   });
-});
-
-onMounted(() => {
-  store.fetchCachedPackageMetadataRemoteDict();
 });
 </script>
 

--- a/apps/docs/docs/.vuepress/store.ts
+++ b/apps/docs/docs/.vuepress/store.ts
@@ -1,6 +1,3 @@
-import { mapValues } from "lodash-es";
-import axios from "axios";
-import urlJoin from "url-join";
 import { defineStore } from "pinia";
 
 import { getAPIBaseUrl, getPublicGenPath } from "@openupm/common/build/urls.js";
@@ -9,9 +6,44 @@ import {
   PackageMetadataRemote,
   SiteInfo,
 } from "@openupm/types";
-import { parsePackageMetadataRemote } from "@openupm/common/build/utils.js";
 import { METADATA_LOCAL_LIST_FILENAME } from "@openupm/types";
-import numeral from "numeral";
+
+const joinApiPath = (baseUrl: string, path: string): string =>
+  `${baseUrl.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+
+const fetchJson = async <T>(url: string): Promise<T> => {
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}: ${url}`);
+  }
+  return (await response.json()) as T;
+};
+
+const parsePackageMetadataRemoteDict = async (
+  data: Record<string, unknown>,
+): Promise<Record<string, PackageMetadataRemote>> => {
+  const { parsePackageMetadataRemote } = await import(
+    "@openupm/common/build/utils.js"
+  );
+  return Object.fromEntries(
+    Object.entries(data).map(([name, value]) => [
+      name,
+      parsePackageMetadataRemote(value),
+    ]),
+  );
+};
+
+const formatCompactNumber = (value: number): string => {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1).replace(/\.0$/, "")}m`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(value >= 10_000 ? 0 : 1).replace(/\.0$/, "")}k`;
+  }
+  return value.toString();
+};
 
 type StoreFetchPromises = {
   packageMetadataRemoteDict?: Promise<void> | null;
@@ -39,7 +71,7 @@ export const useDefaultStore = defineStore("pinia-default", {
       packageMetadataLocalList: [] as PackageMetadataLocal[],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       recentPackages: [] as any[],
-      siteInfo: { stars: 0 } as SiteInfo,
+      siteInfo: { stars: 0, readyPackageCount: 0 } as SiteInfo,
       __packageMetadataRemoteDictFetchTime: 0,
       __packageMetadataLocalListFetchTime: 0,
       __siteInfoFetchTime: 0,
@@ -54,6 +86,9 @@ export const useDefaultStore = defineStore("pinia-default", {
       );
     },
     readyPackageCount: (state) => {
+      if (state.siteInfo.readyPackageCount) {
+        return state.siteInfo.readyPackageCount;
+      }
       let num = 0;
       for (const name in state.packageMetadataRemoteDict) {
         const metadata = state.packageMetadataRemoteDict[name];
@@ -66,7 +101,7 @@ export const useDefaultStore = defineStore("pinia-default", {
     formattedStars: (state) => {
       const value = Number(state.siteInfo.stars);
       if (isNaN(value) || value == 0) return "...";
-      return numeral(value).format("1.1a");
+      return formatCompactNumber(value);
     },
   },
 
@@ -77,13 +112,12 @@ export const useDefaultStore = defineStore("pinia-default", {
     async fetchPackageMetadataRemoteDict() {
       const apiBaseUrl = getAPIBaseUrl();
       try {
-        const resp = await axios.get(urlJoin(apiBaseUrl, "/packages/extra"), {
-          headers: { Accept: "application/json" },
-        });
+        const data = await fetchJson<Record<string, unknown>>(
+          joinApiPath(apiBaseUrl, "/packages/extra"),
+        );
         this.__packageMetadataRemoteDictFetchTime = new Date().getTime();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        this.packageMetadataRemoteDict = mapValues(resp.data, (value: any) =>
-          parsePackageMetadataRemote(value),
+        this.packageMetadataRemoteDict = await parsePackageMetadataRemoteDict(
+          data,
         );
       } catch (error) {
         console.error(error);
@@ -111,12 +145,10 @@ export const useDefaultStore = defineStore("pinia-default", {
      */
     async fetchPackageMetadataLocalList() {
       try {
-        const resp = await axios.get(
+        this.packageMetadataLocalList = await fetchJson<PackageMetadataLocal[]>(
           getPublicGenPath(METADATA_LOCAL_LIST_FILENAME),
-          { headers: { Accept: "application/json" } },
         );
         this.__packageMetadataLocalListFetchTime = new Date().getTime();
-        this.packageMetadataLocalList = resp.data as PackageMetadataLocal[];
       } catch (error) {
         console.error(error);
       }
@@ -159,10 +191,9 @@ export const useDefaultStore = defineStore("pinia-default", {
     async fetchRecentPackages() {
       const apiBaseUrl = getAPIBaseUrl();
       try {
-        const resp = await axios.get(urlJoin(apiBaseUrl, "/packages/recent"), {
-          headers: { Accept: "application/json" },
-        });
-        this.recentPackages = resp.data;
+        this.recentPackages = await fetchJson(
+          joinApiPath(apiBaseUrl, "/packages/recent"),
+        );
       } catch (error) {
         console.error(error);
       }
@@ -173,11 +204,11 @@ export const useDefaultStore = defineStore("pinia-default", {
     async fetchSiteInfo() {
       const apiBaseUrl = getAPIBaseUrl();
       try {
-        const resp = await axios.get(urlJoin(apiBaseUrl, "site/info"), {
-          headers: { Accept: "application/json" },
-        });
+        const siteInfo = await fetchJson<SiteInfo>(
+          joinApiPath(apiBaseUrl, "site/info"),
+        );
         this.__siteInfoFetchTime = new Date().getTime();
-        this.siteInfo = resp.data as SiteInfo;
+        this.siteInfo = siteInfo;
       } catch (error) {
         console.error(error);
       }

--- a/apps/docs/docs/index.md
+++ b/apps/docs/docs/index.md
@@ -5,6 +5,7 @@ editLink: false
 title: Open Source Unity Package Registry
 description: OpenUPM is a managed UPM registry with automatic build services for open-source Unity packages.
 heroText: Open Source Unity Package Registry
+readyPackageCountFallback: 2,700+
 features:
 - title: Open Source Packages
   desc: Hosts over <%= package_count %> open source packages, carefully curated by the community.

--- a/apps/jobs/src/jobs/aggregatePackageExtra.ts
+++ b/apps/jobs/src/jobs/aggregatePackageExtra.ts
@@ -13,6 +13,7 @@ import {
   setAggregatedExtraData,
 } from '@openupm/server-common/build/models/packageExtra.js';
 import { createLogger } from '@openupm/server-common/build/log.js';
+import { setReadyPackageCount } from '@openupm/server-common/build/models/siteInfo.js';
 
 const logger = createLogger('@openupm/jobs/aggregatePackageExtra');
 
@@ -31,6 +32,7 @@ type AggregatedEntry = {
 export async function aggregatePackageExtraJob(): Promise<void> {
   const packageNames = await loadPackageNames();
   const aggregated: Record<string, AggregatedEntry> = {};
+  let readyPackageCount = 0;
 
   for (const packageName of packageNames) {
     const pkg = await loadPackageMetadataLocal(packageName);
@@ -49,6 +51,7 @@ export async function aggregatePackageExtraJob(): Promise<void> {
     const repoUnavailable = await getRepoUnavailable(packageName);
     const repoArchived = await getRepoArchived(packageName);
     const dl30d = await getMonthlyDownloads(packageName);
+    if (version) readyPackageCount += 1;
 
     aggregated[packageName] = {
       stars: stars || 0,
@@ -64,4 +67,5 @@ export async function aggregatePackageExtraJob(): Promise<void> {
   }
 
   await setAggregatedExtraData(aggregated);
+  await setReadyPackageCount(readyPackageCount);
 }

--- a/apps/web/__tests__/routers/siteInfo.spec.ts
+++ b/apps/web/__tests__/routers/siteInfo.spec.ts
@@ -1,7 +1,10 @@
 /* eslint-disable jest/expect-expect */
 import request from 'supertest';
 
-import { setStars } from '@openupm/server-common/build/models/siteInfo.js';
+import {
+  setReadyPackageCount,
+  setStars,
+} from '@openupm/server-common/build/models/siteInfo.js';
 import redis from '@openupm/server-common/build/redis.js';
 
 import { app } from '../../src/apiServer.js';
@@ -12,10 +15,12 @@ describe('packages', () => {
   beforeEach(async () => {
     await app.ready();
     await setStars(STARS);
+    await setReadyPackageCount(1);
   });
 
   afterEach(async () => {
     await setStars(0);
+    await setReadyPackageCount(0);
   });
 
   afterAll(async () => {
@@ -30,5 +35,6 @@ describe('packages', () => {
       .expect('Content-Type', /json/);
     expect(response.body).not.toBeNull();
     expect(response.body.stars).toEqual(STARS);
+    expect(response.body.readyPackageCount).toEqual(1);
   });
 });

--- a/apps/web/src/routers/siteInfo.ts
+++ b/apps/web/src/routers/siteInfo.ts
@@ -1,12 +1,19 @@
 import { FastifyInstance } from 'fastify';
 
-import { getStars } from '@openupm/server-common/build/models/siteInfo.js';
+import {
+  getReadyPackageCount,
+  getStars,
+} from '@openupm/server-common/build/models/siteInfo.js';
 
 export default function router(server: FastifyInstance): void {
   server.get('/site/info', async function () {
-    const stars = await getStars();
+    const [stars, readyPackageCount] = await Promise.all([
+      getStars(),
+      getReadyPackageCount(),
+    ]);
     const data = {
       stars,
+      readyPackageCount,
     };
     return data;
   });

--- a/packages/@openupm/server-common/src/models/siteInfo.ts
+++ b/packages/@openupm/server-common/src/models/siteInfo.ts
@@ -3,6 +3,7 @@ import redis from '../redis.js';
 const siteInfoKey: string = 'site:info';
 const propKeys: { [key: string]: string } = {
   stars: 'stars',
+  readyPackageCount: 'readyPackageCount',
 };
 
 export const setStars = async function (stars: number): Promise<void> {
@@ -11,6 +12,17 @@ export const setStars = async function (stars: number): Promise<void> {
 
 export const getStars = async function (): Promise<number> {
   const text: string | null = await getValue(propKeys.stars);
+  return parseInt(text || '0');
+};
+
+export const setReadyPackageCount = async function (
+  count: number,
+): Promise<void> {
+  await setValue(propKeys.readyPackageCount, count.toString());
+};
+
+export const getReadyPackageCount = async function (): Promise<number> {
+  const text: string | null = await getValue(propKeys.readyPackageCount);
   return parseInt(text || '0');
 };
 

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -142,6 +142,8 @@ export interface PackageDependency {
 export interface SiteInfo {
   // GitHub repo stars
   stars: number;
+  // Packages with a published version, used by lightweight public site widgets
+  readyPackageCount?: number;
 }
 
 export interface GithubUserWithScore {


### PR DESCRIPTION
## Summary
- remove the homepage package metadata fetch used only for the displayed ready-package count
- expose a lightweight readyPackageCount value through site info and populate it from the aggregate package job
- replace initial docs store dependencies on axios, url-join, lodash-es, and numeral with native fetch and small local helpers

## Validation
- docs runtime payload test
- docs lint
- limited docs build
- web siteInfo route test with Redis
- web lint
- jobs lint
- package dependency builds
- generated asset inspection showed the app chunk shrink from roughly 933 KiB raw to roughly 868 KiB raw on the same base, with the homepage layout chunk at roughly 1.5 KiB

Draft until human staging review is complete because this changes the docs client site.