### PR TITLE
Add preconnect hints for homepage third-party chains

### DIFF
--- a/apps/docs/__tests__/vue/runtimePayload.spec.ts
+++ b/apps/docs/__tests__/vue/runtimePayload.spec.ts
@@ -10,6 +10,24 @@ const readVuepressFile = (path: string): string =>
   readFileSync(vuepressFile(path), "utf8");
 
 describe("docs runtime payload fetch behavior", () => {
+  it("keeps PageSpeed resource hints for Google font and script chains", () => {
+    const configSource = readVuepressFile("config.ts");
+    const regionConfigSource = readVuepressFile("config-us.ts");
+
+    expect(configSource).toContain('href: "https://fonts.googleapis.com"');
+    expect(configSource).toContain('href: "https://fonts.gstatic.com"');
+    expect(configSource).toContain('crossorigin: ""');
+    expect(regionConfigSource).toContain(
+      'href: "https://www.googletagmanager.com"',
+    );
+    expect(regionConfigSource).toContain(
+      'href: "https://pagead2.googlesyndication.com"',
+    );
+    expect(regionConfigSource).toContain(
+      'href: "https://fundingchoicesmessages.google.com"',
+    );
+  });
+
   it("keeps global client fetches route-aware", () => {
     const source = readVuepressFile("client.ts");
 

--- a/apps/docs/docs/.vuepress/config-us.ts
+++ b/apps/docs/docs/.vuepress/config-us.ts
@@ -49,6 +49,18 @@ export const config: any = {
           "openupm,open upm,upm,unity package manager,unity package,scoped registry,unity,open source,unity assets,asset store,unity store,free resource",
       },
     ],
+    ["link", { rel: "preconnect", href: "https://www.googletagmanager.com" }],
+    [
+      "link",
+      { rel: "preconnect", href: "https://pagead2.googlesyndication.com" },
+    ],
+    [
+      "link",
+      {
+        rel: "preconnect",
+        href: "https://fundingchoicesmessages.google.com",
+      },
+    ],
     // GA4
     [
       "script",

--- a/apps/docs/docs/.vuepress/config.ts
+++ b/apps/docs/docs/.vuepress/config.ts
@@ -90,6 +90,15 @@ const config: any = mergeWith(
         },
       ],
       ["meta", { name: "msapplication-TileColor", content: "#000000" }],
+      ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+      [
+        "link",
+        {
+          rel: "preconnect",
+          href: "https://fonts.gstatic.com",
+          crossorigin: "",
+        },
+      ],
       ["link", { rel: "manifest", href: "/manifest.json" }],
       [
         "link",


### PR DESCRIPTION
## Summary
- add preconnect hints for Google Fonts endpoints observed in the PageSpeed network dependency chain
- add preconnect hints for Google tag, AdSense, and funding choices script hosts so existing above-the-fold ad and analytics scripts can connect earlier
- cover the hints with a docs config regression test

## Validation
- docs runtime payload test
- docs lint
- limited docs build
- generated homepage head inspection
- built homepage visual smoke from a local static server

Draft until human staging review is complete because this changes the docs client site.