### PR TITLE
fix(docs): repair footer RSS links

### DIFF
--- a/apps/docs/__tests__/vue/footer.spec.ts
+++ b/apps/docs/__tests__/vue/footer.spec.ts
@@ -20,6 +20,17 @@ describe("Footer", () => {
     expect(source).not.toContain("position: absolute;");
   });
 
+  it("links footer RSS feeds to concrete feed URLs", () => {
+    const packageUpdatesIndex = source.indexOf('text: t("package-updates")');
+    const blogRssIndex = source.indexOf('text: t("blog-rss")');
+
+    expect(source).toContain('link: `${getAPIBaseUrl()}/feeds/updates/rss`');
+    expect(source).not.toContain('link: `{getAPIBaseUrl()}/feeds/updates/rss`');
+    expect(source).toContain('link: "https://openupm.com/blog/rss.xml"');
+    expect(packageUpdatesIndex).toBeGreaterThan(-1);
+    expect(blogRssIndex).toBeGreaterThan(packageUpdatesIndex);
+  });
+
   it("removes inherited page bottom padding only when the site footer is present", () => {
     const layoutSource = readFileSync(layoutPath, "utf8");
 

--- a/apps/docs/docs/.vuepress/components/Footer.vue
+++ b/apps/docs/docs/.vuepress/components/Footer.vue
@@ -1,7 +1,10 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { computed } from 'vue';
-import { OpenUPMGitHubRepoUrl } from '@openupm/common/build/urls.js';
+import {
+  OpenUPMGitHubRepoUrl,
+  getAPIBaseUrl,
+} from '@openupm/common/build/urls.js';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
@@ -54,8 +57,15 @@ const connectLinks = computed(() => {
       iconLeft: true
     },
     {
-      link: `{getAPIBaseUrl()}/feeds/updates/rss`,
+      link: `${getAPIBaseUrl()}/feeds/updates/rss`,
       text: t("package-updates"),
+      icon: "fa fa-rss-square",
+      raw: true,
+      iconLeft: true
+    },
+    {
+      link: "https://openupm.com/blog/rss.xml",
+      text: t("blog-rss"),
       icon: "fa fa-rss-square",
       raw: true,
       iconLeft: true

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -121,6 +121,7 @@ package-name-manual-verification: Major tech company package names require manua
 package-name: Package name
 package-page-results: Package page results
 package-updates: Package Updates
+blog-rss: Blog RSS
 openupm-packages: OpenUPM Packages
 unitynuget-packages: UnityNuGet Packages
 packages: packages


### PR DESCRIPTION
## Summary
- fix the docs footer Package Updates RSS link so it resolves to the API feed URL
- add a Blog RSS footer link after Package Updates
- cover both footer RSS links with a regression test

## Validation
- npm run test -- footer.spec.ts
- npm run lint
- npm run docs:build:limit