### PR TITLE
[codex] Improve package grid readability

### DIFF
--- a/apps/docs/docs/.vuepress/components/PackageCard.vue
+++ b/apps/docs/docs/.vuepress/components/PackageCard.vue
@@ -152,14 +152,16 @@ const imageErrorMessage = computed(() => {
 @use '@/styles/palette' as *;
 
 .package-card {
-  --card-content-padding-lr: 0.4rem;
+  --card-content-padding-lr: 0.6rem;
   font-size: $font-size-md;
 
   .card-inner {
-    box-shadow: 0 .25rem .5rem var(--c-border);
+    background-color: var(--c-bg);
+    border: 1px solid transparent;
+    box-shadow: 0 0.35rem 0.9rem rgba(34, 48, 74, 0.1);
 
     .card-header {
-      padding: 0.3rem var(--card-content-padding-lr) 0;
+      padding: 0.55rem var(--card-content-padding-lr) 0;
 
       .h5 {
         white-space: nowrap;
@@ -177,15 +179,16 @@ const imageErrorMessage = computed(() => {
     }
 
     .card-body {
-      padding: 0 var(--card-content-padding-lr) 0.5rem;
-      padding-top: 0rem;
-      height: 1.8rem;
+      box-sizing: border-box;
+      padding: 0.05rem var(--card-content-padding-lr) 0.15rem;
+      height: 2rem;
       overflow: hidden;
       display: -webkit-box;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       text-overflow: -o-ellipsis-lastline;
       font-size: $font-size-sm;
+      line-height: 0.9rem;
     }
 
     .card-image-wrapper {
@@ -229,7 +232,7 @@ const imageErrorMessage = computed(() => {
 
     .card-footer {
       height: 3.2rem;
-      padding: 0 var(--card-content-padding-lr);
+      padding: 0.1rem var(--card-content-padding-lr) 0;
       box-sizing: border-box;
 
       .chip {
@@ -260,8 +263,9 @@ const imageErrorMessage = computed(() => {
 :is(.dark, [data-theme='dark']) {
   .package-card {
     .card-inner {
-      box-shadow: none;
       background-color: var(--c-bg-light);
+      border-color: var(--c-border);
+      box-shadow: 0 0.35rem 0.9rem rgba(0, 0, 0, 0.2);
     }
 
     .card-footer {

--- a/apps/docs/docs/.vuepress/components/UnityAssetAdPlacementForPackageList.vue
+++ b/apps/docs/docs/.vuepress/components/UnityAssetAdPlacementForPackageList.vue
@@ -59,8 +59,11 @@ const hasDiscount = computed(() => {
 @use '@/styles/palette' as *;
 
 .ad-placement {
+  background-color: var(--c-bg);
+  border: 1px solid transparent;
+  box-shadow: 0 0.35rem 0.9rem rgba(34, 48, 74, 0.1);
+  box-sizing: border-box;
   position: relative;
-  box-shadow: 0 .25rem .5rem var(--c-border);
 }
 
 .ad-mark {
@@ -84,13 +87,13 @@ const hasDiscount = computed(() => {
 }
 
 .ad-link-container {
-  --card-content-padding-lr: 0.4rem;
-  height: 4.17rem;
-  padding: 0.3rem var(--card-content-padding-lr) 0;
+  --card-content-padding-lr: 0.6rem;
+  height: 4.42rem;
+  padding: 0.5rem var(--card-content-padding-lr) 0;
 
   .h5 {
     font-size: $font-size-md;
-    margin-bottom: 0.2rem;
+    margin-bottom: 0.25rem;
     max-height: 2.2rem;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -112,8 +115,9 @@ const hasDiscount = computed(() => {
 }
 
 :global(:is(.dark, [data-theme='dark']) .ad-placement) {
-  box-shadow: none;
   background-color: var(--c-bg-light);
+  border-color: var(--c-border);
+  box-shadow: 0 0.35rem 0.9rem rgba(0, 0, 0, 0.2);
 }
 
 :global(:is(.dark, [data-theme='dark']) .ad-placement .chip) {

--- a/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
@@ -446,6 +446,7 @@ watch(() => topicSlug.value, () => {
 
 .package-list {
   :is(.page, .vp-page) {
+    background: #f6f8fb;
     padding-bottom: 0;
     padding-left: calc(var(--sidebar-width) + (100vw - var(--sidebar-width) - #{$package-grid-4c-width} - #{$scrollbar-width}*2)/2);
 
@@ -488,6 +489,14 @@ watch(() => topicSlug.value, () => {
         padding: 0 0.5rem;
         margin-top: $navbar-height-mobile;
       }
+    }
+  }
+}
+
+:is(.dark, [data-theme='dark']) {
+  .package-list {
+    :is(.page, .vp-page) {
+      background: var(--c-bg);
     }
   }
 }
@@ -567,7 +576,8 @@ watch(() => topicSlug.value, () => {
     .grid {
       padding-top: 0;
       display: grid;
-      grid-gap: $package-grid-column-hgap;
+      column-gap: $package-grid-column-hgap;
+      row-gap: 12px;
       place-items: start stretch;
       box-sizing: content-box;
       grid-template-columns: $package-grid-column-width $package-grid-column-width $package-grid-column-width $package-grid-column-width;
@@ -605,12 +615,23 @@ watch(() => topicSlug.value, () => {
       margin-right: 0.2rem;
       padding: 0 0.2rem;
 
+      .nav-link {
+        white-space: nowrap;
+      }
+
       strong {
         color: var(--c-text-accent-strong);
       }
 
       .active {
-        background-color: var(--c-bg-dark);
+        background-color: var(--c-text-accent);
+        border-radius: 0;
+        box-shadow: 0 0 0 0.1rem var(--c-text-accent);
+        color: #fff;
+
+        strong {
+          color: inherit;
+        }
       }
     }
   }

--- a/apps/docs/docs/.vuepress/styles/palette.scss
+++ b/apps/docs/docs/.vuepress/styles/palette.scss
@@ -35,7 +35,7 @@ $theme-default-content-margin-top-mobile: $navbar-height-mobile + 2.2rem;
 // The unit below is in pixels, not rems, because it will be used in a media query later.
 // The rem unit in a media query is based on the initial font size of 16 pixels, which is different from the rem unit in spectre.css (20px).
 $package-grid-column-width: 294px;
-$package-grid-column-hgap: 8px;
+$package-grid-column-hgap: 12px;
 $package-grid-1c-width: $package-grid-column-width;
 $package-grid-2c-width: $package-grid-column-width*2 + $package-grid-column-hgap;
 $package-grid-3c-width: $package-grid-column-width*3 + $package-grid-column-hgap*2;


### PR DESCRIPTION
## Summary

- Increase package card breathing room and grid spacing for easier scanning.
- Improve contrast between the package grid background and package/ad cards while preserving the shadow-first light theme.
- Align package-list ad placements with package card surfaces and improve the active topic filter highlight.

## Validation

- `npm run lint`
- `npm run docs:build:limit`
