### PR TITLE
[codex] Fix dark theme modal backgrounds

### DIFF
--- a/apps/docs/docs/.vuepress/components/Modal.vue
+++ b/apps/docs/docs/.vuepress/components/Modal.vue
@@ -65,6 +65,6 @@ onUnmounted(() => {
 }
 
 :global(:is(.dark, [data-theme='dark']) .modal-container) {
-  background-color: var(--c-bg);
+  background-color: var(--c-bg-lighter);
 }
 </style>

--- a/apps/docs/docs/.vuepress/styles/index.scss
+++ b/apps/docs/docs/.vuepress/styles/index.scss
@@ -422,6 +422,25 @@ div[class*=language-] {
     color: var(--c-text);
   }
 
+  .modal {
+    .modal-container {
+      background: var(--c-bg-lighter);
+      color: var(--c-text);
+      box-shadow: 0 0.2rem 0.8rem rgba(0, 0, 0, 0.45);
+    }
+
+    .modal-header,
+    .modal-title,
+    .modal-body,
+    .modal-footer {
+      color: var(--c-text);
+    }
+
+    .modal-overlay {
+      background: rgba(0, 0, 0, 0.6);
+    }
+  }
+
   .divider {
     border-top-color: var(--c-bg-dark) !important;
   }


### PR DESCRIPTION
## Summary

Fix dark-theme modal surfaces so package setup and release-error dialogs no longer render with bright light backgrounds.

## Root Cause

Spectre modal styles still supplied light defaults for modal containers and overlay surfaces. The shared modal component only overrode the container background locally, so dark theme coverage was incomplete across modal implementations.

## Changes

- Add global dark-theme modal styling for container, header/body/footer text, shadow, and overlay.
- Align the shared `Modal.vue` dark background token with the elevated dark surface used by global modal styles.

## Validation

- `npm run lint` from `apps/docs`
- `npm run docs:build:limit` from `apps/docs`
- Staged locally and reviewed over LAN