### PR TITLE
Normalize S3 client config for AWS SDK v3

### DIFF
--- a/packages/@openupm/server-common/__tests__/utils/s3.spec.ts
+++ b/packages/@openupm/server-common/__tests__/utils/s3.spec.ts
@@ -1,0 +1,44 @@
+import { normalizeS3ClientConfig } from '../../src/utils/s3.js';
+
+describe('normalizeS3ClientConfig()', function () {
+  it('converts legacy top-level credentials to AWS SDK v3 credentials', function () {
+    const result = normalizeS3ClientConfig({
+      endpoint: 'https://sfo2.digitaloceanspaces.com',
+      region: 'sfo2',
+      accessKeyId: 'key',
+      secretAccessKey: 'secret',
+      sessionToken: 'session',
+      s3ForcePathStyle: true,
+      sslEnabled: false,
+    });
+
+    expect(result).toEqual({
+      endpoint: 'https://sfo2.digitaloceanspaces.com',
+      region: 'sfo2',
+      credentials: {
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+        sessionToken: 'session',
+      },
+      forcePathStyle: true,
+      tls: false,
+    });
+  });
+
+  it('clones nested credentials from immutable config objects', function () {
+    const credentials = Object.freeze({
+      accessKeyId: 'key',
+      secretAccessKey: 'secret',
+    });
+    const rawConfig = Object.freeze({
+      endpoint: 'https://sfo2.digitaloceanspaces.com',
+      region: 'sfo2',
+      credentials,
+    });
+
+    const result = normalizeS3ClientConfig(rawConfig);
+
+    expect(result.credentials).toEqual(credentials);
+    expect(result.credentials).not.toBe(credentials);
+  });
+});

--- a/packages/@openupm/server-common/src/utils/s3.ts
+++ b/packages/@openupm/server-common/src/utils/s3.ts
@@ -8,17 +8,71 @@ import {
   PutObjectCommandInput,
   PutObjectCommandOutput,
   S3Client,
+  S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
 
+type OpenUPMS3ClientConfig = S3ClientConfig & {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  s3ForcePathStyle?: boolean;
+  sslEnabled?: boolean;
+};
+
+/**
+ * Convert node-config and legacy AWS SDK v2 style options to a mutable AWS SDK
+ * v3 S3ClientConfig.
+ */
+export const normalizeS3ClientConfig = (
+  rawConfig: OpenUPMS3ClientConfig,
+): S3ClientConfig => {
+  const {
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+    credentials,
+    ...restConfig
+  } = rawConfig;
+  const s3ForcePathStyle = restConfig.s3ForcePathStyle;
+  const sslEnabled = restConfig.sslEnabled;
+  delete restConfig.s3ForcePathStyle;
+  delete restConfig.sslEnabled;
+  const clientConfig: S3ClientConfig = { ...restConfig };
+
+  if (credentials) {
+    clientConfig.credentials =
+      typeof credentials === 'function' ? credentials : { ...credentials };
+  } else if (accessKeyId && secretAccessKey) {
+    clientConfig.credentials = {
+      accessKeyId,
+      secretAccessKey,
+      ...(sessionToken ? { sessionToken } : {}),
+    };
+  }
+
+  if (
+    clientConfig.forcePathStyle === undefined &&
+    s3ForcePathStyle !== undefined
+  ) {
+    clientConfig.forcePathStyle = s3ForcePathStyle;
+  }
+
+  if (clientConfig.tls === undefined && sslEnabled !== undefined) {
+    clientConfig.tls = sslEnabled;
+  }
+
+  return clientConfig;
+};
+
 /**
  * Get S3 client.
  */
 export const getS3Client = (): S3Client => {
-  return new S3Client(config.s3.config);
+  return new S3Client(normalizeS3ClientConfig(config.s3.config));
 };
 
 /**


### PR DESCRIPTION
## Summary
- clone node-config S3 settings before passing them to AWS SDK v3
- translate legacy top-level accessKeyId/secretAccessKey into the v3 credentials object
- translate legacy s3ForcePathStyle into forcePathStyle

## Validation
- npm run build -- --filter=@openupm/types --filter=@openupm/common --filter=@openupm/local-data --filter=@openupm/server-common
- npm run lint --workspace @openupm/server-common
- npm exec -- vitest run --config vitest.config.js __tests__/utils/s3.spec.ts __tests__/utils/media.spec.ts
- git diff --check

## Notes
- Full @openupm/server-common test run was attempted but Redis-backed release model tests timed out in this local environment.
- This is needed because node-config returns immutable objects, and AWS SDK v3 mutates/annotates the credentials object while resolving credentials.