### PR TITLE
Fix retained failed release requeue

### DIFF
--- a/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
@@ -177,6 +177,46 @@ describe('buildPackage GitHub Release pending probes', () => {
     expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
   });
 
+  it('keeps missing GitHub Release failures gated by the probe interval', async () => {
+    await runBuildPackage(
+      createRelease({
+        reason: ReleaseErrorCode.GitHubReleaseNotFound,
+        githubReleaseAssetMissingFirstSeenAt: Date.parse(
+          '2026-05-10T06:55:00.000Z',
+        ),
+      }),
+    );
+
+    expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
+    expect(queueRemoveMock).not.toHaveBeenCalled();
+    expect(addJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'build-rel',
+        data: { name: 'com.example.asset', version: '1.0.0' },
+      }),
+    );
+  });
+
+  it('keeps retryable failed releases retained until explicit reset', async () => {
+    await runBuildPackage(
+      createRelease({
+        reason: ReleaseErrorCode.BuildTimeout,
+        githubReleaseAssetMissingFirstSeenAt: undefined,
+        githubReleaseAssetMissingLastProbeAt: undefined,
+        githubReleaseAssetMissingProbeCount: undefined,
+      }),
+    );
+
+    expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
+    expect(queueRemoveMock).not.toHaveBeenCalled();
+    expect(addJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'build-rel',
+        data: { name: 'com.example.asset', version: '1.0.0' },
+      }),
+    );
+  });
+
   it('probes missing GitHub Releases after the early interval elapses', async () => {
     const { GitHubReleaseAssetError } = await import(
       '../../src/utils/githubReleaseAsset.js'
@@ -336,6 +376,37 @@ describe('buildPackage GitHub Release pending probes', () => {
         reason: ReleaseErrorCode.None,
         buildId: '',
       }),
+    );
+    expect(addJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'build-rel',
+        data: { name: 'com.example.asset', version: '1.0.0' },
+        opts: expect.objectContaining({
+          jobId: 'build-rel|com.example.asset|1.0.0',
+        }),
+      }),
+    );
+  });
+
+  it('removes a retained exhausted failed job before enqueueing a pending release', async () => {
+    await runBuildPackage(
+      createRelease({
+        state: ReleaseState.Pending,
+        reason: ReleaseErrorCode.None,
+        buildId: '',
+        githubReleaseAssetMissingFirstSeenAt: undefined,
+        githubReleaseAssetMissingLastProbeAt: undefined,
+        githubReleaseAssetMissingProbeCount: undefined,
+      }),
+    );
+
+    expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
+    expect(queueGetJobMock).toHaveBeenCalledWith(
+      'build-rel|com.example.asset|1.0.0',
+    );
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.example.asset|1.0.0',
+      { removeChildren: true },
     );
     expect(addJobMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -274,6 +274,9 @@ async function addReleaseJobs(releases: ReleaseModel[]): Promise<void> {
     }
 
     const jobId = createJobId(jobConfig.name, rel.packageName, rel.version);
+    if (rel.state === ReleaseState.Pending) {
+      await removeExhaustedFailedJob(queue, jobId);
+    }
     await addJob({
       queue,
       name: jobConfig.name,
@@ -282,6 +285,20 @@ async function addReleaseJobs(releases: ReleaseModel[]): Promise<void> {
     });
     i++;
   }
+}
+
+async function removeExhaustedFailedJob(
+  queue: ReturnType<typeof getQueue>,
+  jobId: string,
+): Promise<void> {
+  const job = await queue.getJob(jobId);
+  if (!job) return;
+
+  const state = await job.getState();
+  const maxAttempts = job.opts?.attempts ?? 1;
+  if (state !== 'failed' || job.attemptsMade < maxAttempts) return;
+
+  await queue.remove(jobId, { removeChildren: true });
 }
 
 export function isGitHubReleasePendingReason(reason: number): boolean {


### PR DESCRIPTION
## Summary
- remove exhausted failed deterministic release jobs before enqueueing eligible release builds
- add regression coverage for a pending release blocked by a retained failed rel job

## Validation
- npm run build -- --filter=@openupm/queue
- npm -w @openupm/queue test -- buildPackageGithubReleaseAssetProbe.spec.ts
- npm -w @openupm/queue run lint