### PR TITLE
[codex] Serve media through download domain

### DIFF
--- a/apps/jobs/__tests__/jobs/updateFeeds.spec.ts
+++ b/apps/jobs/__tests__/jobs/updateFeeds.spec.ts
@@ -59,7 +59,7 @@ describe('updateFeedsJob', () => {
       {
         packageName: 'pkg.one',
         displayName: 'Package One',
-        image: 'https://openupm.sfo2.cdn.digitaloceanspaces.com/media/img.png',
+        image: 'https://download.openupm.com/media/img.png',
         time: 1000,
         version: '1.0.0',
         author: [

--- a/packages/@openupm/common/__tests__/urls.spec.ts
+++ b/packages/@openupm/common/__tests__/urls.spec.ts
@@ -1,7 +1,10 @@
 import {
   getContributorProfilePagePath,
+  getAvatarImageUrl,
+  getMediaBaseUrl,
   getMonthlyDownloadsRangeUrl,
   getMonthlyDownloadsUrl,
+  getPackageImageUrl,
   isPackageDetailPath,
   isPackageListPath,
   parsePackageNameFromPackageDetailPath,
@@ -121,6 +124,24 @@ describe('download count urls', () => {
 
     expect(result).toEqual(
       'https://package.openupm.com/downloads/range/last-month/com.example.package',
+    );
+  });
+});
+
+describe('media urls', () => {
+  it('should use the download domain as the media base url', () => {
+    expect(getMediaBaseUrl()).toEqual('https://download.openupm.com/media/');
+  });
+
+  it('should build package image urls from the media base url', () => {
+    expect(getPackageImageUrl('package-image.png')).toEqual(
+      'https://download.openupm.com/media/package-image.png',
+    );
+  });
+
+  it('should build avatar image urls from the media base url', () => {
+    expect(getAvatarImageUrl('GitHubUser', 48)).toEqual(
+      'https://download.openupm.com/media/githubuser-48x48.png',
     );
   });
 });

--- a/packages/@openupm/common/src/urls.ts
+++ b/packages/@openupm/common/src/urls.ts
@@ -150,7 +150,7 @@ export const getAzureWebBuildUrl = function (buildId: string): string {
  * @returns media base url
  */
 export const getMediaBaseUrl = function (): string {
-  return 'https://openupm.sfo2.cdn.digitaloceanspaces.com/media/';
+  return 'https://download.openupm.com/media/';
 };
 
 /**


### PR DESCRIPTION
## Summary
- switch shared package image and avatar media URLs to the download domain
- update feed URL expectations and add focused media URL helper tests

## Validation
- npm run build -- --filter=@openupm/jobs...
- npm run test -- urls.spec.ts
- npm run test -- updateFeeds.spec.ts
- npm run lint in packages/@openupm/common
- npm run lint in apps/jobs
- git diff --check

## Notes
No live media copy, deployment, or production verification was run in this PR.