### PR TITLE
Add trends dashboard

### DIFF
--- a/apps/docs/__tests__/vue/trendsView.spec.ts
+++ b/apps/docs/__tests__/vue/trendsView.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterSeries,
+  formatNumber,
+  latestValue,
+  previousMonth,
+  sumValues,
+  valueAtDate,
+} from "../../docs/.vuepress/trendsView";
+
+describe("trends view helpers", () => {
+  it("formats values and reads time-series values", () => {
+    expect(formatNumber(123456)).toEqual("123,456");
+    const points = [
+      { date: "2026-05", value: 1 },
+      { date: "2026-06", value: 3 },
+    ];
+    expect(latestValue(points)).toEqual(3);
+    expect(sumValues(points)).toEqual(4);
+    expect(valueAtDate(points, "2026-05")).toEqual(1);
+    expect(valueAtDate(points, "2026-04")).toEqual(0);
+    expect(previousMonth("2026-06-11T00:00:00.000Z")).toEqual("2026-05");
+  });
+
+  it("filters topic series by key or label", () => {
+    const series = [
+      { key: "ai", label: "AI", points: [] },
+      { key: "tools", label: "Editor Tools", points: [] },
+    ];
+
+    expect(filterSeries(series, "editor")).toEqual([series[1]]);
+    expect(filterSeries(series, "ai")).toEqual([series[0]]);
+    expect(filterSeries(series, "")).toEqual(series);
+  });
+});

--- a/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
@@ -1,0 +1,103 @@
+<template>
+  <ClientOnly>
+    <VChart
+      class="trends-echart"
+      :option="chartOption"
+      autoresize
+      @click="handleChartClick"
+    />
+  </ClientOnly>
+  <div v-if="selectedSnapshot" class="trends-chart__snapshot">
+    <strong>{{ selectedSnapshot.date }}</strong>
+    <span :style="{ '--series-color': pickSeriesColor(0) }">
+      {{ formatNumber(selectedSnapshot.value) }}
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { use } from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { BarChart } from "echarts/charts";
+import { GridComponent, TooltipComponent } from "echarts/components";
+import VChart from "vue-echarts";
+import { TrendsPoint } from "@openupm/types";
+
+import { formatNumber, pickSeriesColor } from "../trendsView";
+
+use([CanvasRenderer, BarChart, GridComponent, TooltipComponent]);
+
+const props = defineProps<{
+  points: TrendsPoint[];
+}>();
+
+const selectedDate = ref("");
+
+const dates = computed(() => props.points.map((point) => point.date));
+
+const chartOption = computed(() => ({
+  animation: false,
+  color: [pickSeriesColor(0)],
+  grid: {
+    left: 44,
+    right: 18,
+    top: 14,
+    bottom: 28,
+  },
+  tooltip: {
+    trigger: "axis",
+    axisPointer: { type: "shadow" },
+    valueFormatter: (value: number): string => formatNumber(value),
+  },
+  xAxis: {
+    type: "category",
+    data: dates.value,
+    axisLabel: {
+      color: "inherit",
+      hideOverlap: true,
+      formatter: formatYearTick,
+    },
+    axisTick: { show: false },
+  },
+  yAxis: {
+    type: "value",
+    minInterval: 1,
+    axisLabel: {
+      color: "inherit",
+      formatter: (value: number): string => formatNumber(value),
+    },
+    splitLine: {
+      lineStyle: { color: "rgba(148, 163, 184, 0.18)" },
+    },
+  },
+  series: [
+    {
+      name: "Value",
+      type: "bar",
+      data: props.points.map((point) => point.value),
+      barMaxWidth: 18,
+    },
+  ],
+}));
+
+function formatYearTick(value: string, index: number): string {
+  const year = value.substring(0, 4);
+  const previousDate = dates.value[index - 1];
+  return previousDate?.substring(0, 4) === year ? "" : year;
+}
+
+const selectedSnapshot = computed(() => {
+  if (!selectedDate.value) return null;
+  return {
+    date: selectedDate.value,
+    value:
+      props.points.find((point) => point.date === selectedDate.value)?.value ||
+      0,
+  };
+});
+
+function handleChartClick(params: { name?: string }): void {
+  if (typeof params.name === "string") selectedDate.value = params.name;
+}
+</script>

--- a/apps/docs/docs/.vuepress/components/TrendsLineChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsLineChart.vue
@@ -1,0 +1,149 @@
+<template>
+  <ClientOnly>
+    <VChart
+      class="trends-echart"
+      :option="chartOption"
+      autoresize
+      @click="handleChartClick"
+      @mouseover="handleChartHover"
+      @mouseout="clearChartHover"
+    />
+  </ClientOnly>
+  <div v-if="series.length > 1" class="trends-chart__legend">
+    <span
+      v-for="(entry, index) in series"
+      :key="entry.key"
+      :class="{ 'is-active': entry.label === hoveredSeriesName }"
+      :style="{ '--series-color': pickSeriesColor(index) }"
+    >
+      {{ entry.label }}
+    </span>
+  </div>
+  <div v-if="selectedSnapshot" class="trends-chart__snapshot">
+    <strong>{{ selectedSnapshot.date }}</strong>
+    <span
+      v-for="entry in selectedSnapshot.values"
+      :key="entry.key"
+      :style="{ '--series-color': entry.color }"
+    >
+      {{ entry.label }} {{ formatNumber(entry.value) }}
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { use } from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { LineChart } from "echarts/charts";
+import { GridComponent, TooltipComponent } from "echarts/components";
+import VChart from "vue-echarts";
+import { TrendsSeries } from "@openupm/types";
+
+import { formatNumber, pickSeriesColor } from "../trendsView";
+
+use([CanvasRenderer, LineChart, GridComponent, TooltipComponent]);
+
+const props = defineProps<{
+  series: TrendsSeries[];
+}>();
+
+const selectedDate = ref("");
+const hoveredSeriesName = ref("");
+
+const allDates = computed(() =>
+  Array.from(
+    new Set(
+      props.series.flatMap((entry) => entry.points.map((point) => point.date)),
+    ),
+  ).sort((a, b) => a.localeCompare(b)),
+);
+
+const chartOption = computed(() => ({
+  animation: false,
+  color: props.series.map((_, index) => pickSeriesColor(index)),
+  grid: {
+    left: 44,
+    right: 18,
+    top: 14,
+    bottom: 28,
+  },
+  tooltip: {
+    trigger: "axis",
+    axisPointer: { type: "line" },
+    valueFormatter: (value: number): string => formatNumber(value),
+  },
+  xAxis: {
+    type: "category",
+    boundaryGap: false,
+    data: allDates.value,
+    axisLabel: {
+      color: "inherit",
+      hideOverlap: true,
+      formatter: formatYearTick,
+    },
+    axisTick: { show: false },
+  },
+  yAxis: {
+    type: "value",
+    minInterval: 1,
+    axisLabel: {
+      color: "inherit",
+      formatter: (value: number): string => formatNumber(value),
+    },
+    splitLine: {
+      lineStyle: { color: "rgba(148, 163, 184, 0.18)" },
+    },
+  },
+  series: props.series.map((entry) => {
+    const values = new Map(
+      entry.points.map((point) => [point.date, point.value]),
+    );
+    return {
+      name: entry.label,
+      type: "line",
+      symbol: "circle",
+      symbolSize: 5,
+      showSymbol: true,
+      data: allDates.value.map((date) => values.get(date) ?? null),
+      connectNulls: false,
+      emphasis: { focus: "series" },
+    };
+  }),
+}));
+
+function formatYearTick(value: string, index: number): string {
+  const year = value.substring(0, 4);
+  const previousDate = allDates.value[index - 1];
+  return previousDate?.substring(0, 4) === year ? "" : year;
+}
+
+const selectedSnapshot = computed(() =>
+  selectedDate.value
+    ? {
+        date: selectedDate.value,
+        values: props.series.map((entry, index) => ({
+          key: entry.key,
+          label: entry.label,
+          value:
+            entry.points.find((point) => point.date === selectedDate.value)
+              ?.value || 0,
+          color: pickSeriesColor(index),
+        })),
+      }
+    : null,
+);
+
+function handleChartClick(params: { name?: string }): void {
+  if (typeof params.name === "string") selectedDate.value = params.name;
+}
+
+function handleChartHover(params: { seriesName?: string }): void {
+  hoveredSeriesName.value =
+    typeof params.seriesName === "string" ? params.seriesName : "";
+}
+
+function clearChartHover(): void {
+  hoveredSeriesName.value = "";
+}
+</script>

--- a/apps/docs/docs/.vuepress/components/TrendsPage.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsPage.vue
@@ -1,0 +1,624 @@
+<template>
+  <main class="trends-page">
+    <header class="trends-page__header">
+      <div>
+        <div class="trends-page__title-row">
+          <h1>Trends</h1>
+          <span v-if="trends" class="trends-page__updated">
+            Updated {{ updatedText }}
+          </span>
+        </div>
+        <p v-if="trends">
+          OpenUPM package growth, release activity, signing adoption, and
+          download momentum.
+        </p>
+        <p v-else-if="loading">Loading trends...</p>
+        <p v-else-if="error">{{ error }}</p>
+      </div>
+    </header>
+
+    <div v-if="loading" class="trends-page__notice">Loading...</div>
+    <div v-else-if="error" class="trends-page__notice is-error">
+      {{ error }}
+    </div>
+
+    <template v-if="trends">
+      <section class="trends-page__section">
+        <div class="trends-page__section-title">
+          <h2>Catalog Growth</h2>
+        </div>
+        <div class="trends-page__metrics">
+          <div>
+            <span>Total Packages</span>
+            <strong>{{
+              formatNumber(
+                latestValue(trends.catalogGrowth.totalPackageSubmissionsByDay),
+              )
+            }}</strong>
+          </div>
+          <div>
+            <span>Latest Month</span>
+            <strong>{{ latestPackageMonth }}</strong>
+          </div>
+        </div>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Total packages</h3>
+            <strong>{{
+              formatNumber(
+                latestValue(trends.catalogGrowth.totalPackageSubmissionsByDay),
+              )
+            }}</strong>
+          </div>
+          <TrendsLineChart
+            :series="[
+              {
+                key: 'packages',
+                label: 'Packages',
+                points: trends.catalogGrowth.totalPackageSubmissionsByDay,
+              },
+            ]"
+          />
+        </article>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <div>
+              <h3>Total active packages</h3>
+              <p>Packages with at least one successful published release.</p>
+            </div>
+            <strong>{{
+              formatNumber(
+                latestValue(trends.catalogGrowth.totalActivePackagesByDay),
+              )
+            }}</strong>
+          </div>
+          <TrendsLineChart
+            :series="[
+              {
+                key: 'activePackages',
+                label: 'Active packages',
+                points: trends.catalogGrowth.totalActivePackagesByDay,
+              },
+            ]"
+          />
+        </article>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>New packages per month</h3>
+            <strong>{{ latestPackageMonth }}</strong>
+          </div>
+          <TrendsBarChart
+            :points="trends.catalogGrowth.newPackageSubmissionsByMonth"
+          />
+        </article>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Packages by topic</h3>
+            <input
+              v-model="topicQuery"
+              class="trends-chart__filter"
+              type="search"
+              placeholder="Filter topics"
+            />
+          </div>
+          <TrendsLineChart :series="visibleTopicSeries" />
+        </article>
+      </section>
+
+      <section class="trends-page__section">
+        <div class="trends-page__section-title">
+          <h2>Signing And Publishing Mode</h2>
+        </div>
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Signed packages</h3>
+            <strong>{{
+              formatNumber(
+                latestValue(trends.trustAndDistribution.signedPackagesByDay),
+              )
+            }}</strong>
+          </div>
+          <TrendsLineChart
+            :series="[
+              {
+                key: 'signed',
+                label: 'Signed packages',
+                points: trends.trustAndDistribution.signedPackagesByDay,
+              },
+            ]"
+          />
+        </article>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Publishing modes</h3>
+          </div>
+          <TrendsLineChart
+            :series="trends.trustAndDistribution.releaseSourceAndSigningByDay"
+          />
+        </article>
+      </section>
+
+      <section class="trends-page__section">
+        <div class="trends-page__section-title">
+          <h2>Release Activity</h2>
+        </div>
+        <div class="trends-page__metrics">
+          <div>
+            <span>Total Releases</span>
+            <strong>{{ totalReleasesText }}</strong>
+          </div>
+          <div>
+            <span>Last Month</span>
+            <strong>{{ latestReleaseMonth }}</strong>
+          </div>
+        </div>
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Total releases</h3>
+            <strong>{{ totalReleasesText }}</strong>
+          </div>
+          <TrendsLineChart
+            :series="[
+              {
+                key: 'totalReleases',
+                label: 'Releases',
+                points: trends.releaseActivity.totalReleasesByTime,
+              },
+            ]"
+          />
+        </article>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Releases per month</h3>
+            <strong>{{ latestReleaseMonth }}</strong>
+          </div>
+          <TrendsBarChart :points="trends.releaseActivity.releasesPerMonth" />
+        </article>
+      </section>
+
+      <section class="trends-page__section">
+        <div class="trends-page__section-title">
+          <h2>Downloads</h2>
+        </div>
+        <div class="trends-page__metrics">
+          <div>
+            <span>Total Downloads</span>
+            <strong>{{ totalDownloadsText }}</strong>
+          </div>
+          <div>
+            <span>Latest Month</span>
+            <strong>{{ latestDownloadMonth }}</strong>
+          </div>
+        </div>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Total downloads</h3>
+            <strong>{{ totalDownloadsText }}</strong>
+          </div>
+          <TrendsLineChart
+            :series="[
+              {
+                key: 'totalDownloads',
+                label: 'Total downloads',
+                points: trends.downloads.totalDownloadsByTime,
+              },
+            ]"
+          />
+        </article>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Downloads per month</h3>
+            <strong>{{ latestDownloadMonth }}</strong>
+          </div>
+          <TrendsBarChart :points="trends.downloads.downloadsPerMonth" />
+        </article>
+      </section>
+    </template>
+  </main>
+</template>
+
+<script setup lang="ts">
+import axios from "axios";
+import urlJoin from "url-join";
+import { computed, onMounted, ref } from "vue";
+import { getAPIBaseUrl } from "@openupm/common/build/urls.js";
+import { PublicTrends } from "@openupm/types";
+import {
+  filterSeries,
+  formatNumber,
+  latestValue,
+  previousMonth,
+  valueAtDate,
+} from "../trendsView";
+import TrendsBarChart from "./TrendsBarChart.vue";
+import TrendsLineChart from "./TrendsLineChart.vue";
+
+const loading = ref(true);
+const error = ref("");
+const trends = ref<PublicTrends | null>(null);
+const topicQuery = ref("");
+
+const updatedText = computed(() => {
+  if (!trends.value) return "";
+  return new Date(trends.value.generatedAt).toLocaleString();
+});
+
+const visibleTopicSeries = computed(() =>
+  trends.value
+    ? filterSeries(
+        trends.value.catalogGrowth.packageSubmissionsByTopicByDay,
+        topicQuery.value,
+      )
+    : [],
+);
+
+const latestPackageMonth = computed(() =>
+  trends.value
+    ? formatNumber(
+        latestValue(trends.value.catalogGrowth.newPackageSubmissionsByMonth),
+      )
+    : "0",
+);
+
+const latestReleaseMonth = computed(() =>
+  trends.value
+    ? formatNumber(
+        valueAtDate(
+          trends.value.releaseActivity.releasesPerMonth,
+          previousMonth(trends.value.generatedAt),
+        ),
+      )
+    : "0",
+);
+
+const totalReleasesText = computed(() =>
+  trends.value
+    ? formatNumber(
+        latestValue(trends.value.releaseActivity.totalReleasesByTime),
+      )
+    : "0",
+);
+
+const latestDownloadMonth = computed(() =>
+  trends.value
+    ? formatNumber(latestValue(trends.value.downloads.downloadsPerMonth))
+    : "0",
+);
+
+const totalDownloadsText = computed(() =>
+  trends.value
+    ? formatNumber(latestValue(trends.value.downloads.totalDownloadsByTime))
+    : "0",
+);
+
+async function fetchTrends(): Promise<void> {
+  loading.value = true;
+  error.value = "";
+  try {
+    const response = await axios.get(urlJoin(getAPIBaseUrl(), "/trends"), {
+      headers: { Accept: "application/json" },
+    });
+    trends.value = response.data as PublicTrends;
+  } catch {
+    error.value = "Trends are temporarily unavailable.";
+    trends.value = null;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  void fetchTrends();
+});
+</script>
+
+<style lang="scss">
+.trends-page {
+  max-width: none;
+  margin: 0 auto;
+  padding: 1rem 0.75rem 2rem;
+  color: var(--c-text);
+  font-size: 0.75rem;
+}
+
+.trends-page__header {
+  display: grid;
+  gap: 0.25rem;
+  padding-bottom: 0.2rem;
+
+  h1 {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.2;
+  }
+
+  p {
+    margin: 0;
+    color: var(--c-text-light);
+    font-size: 0.7rem;
+  }
+}
+
+.trends-page__title-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: baseline;
+}
+
+.trends-page__updated {
+  color: var(--c-text-lighter);
+  font-size: 0.65rem;
+}
+
+.trends-page__notice {
+  margin: 0.75rem 0;
+  border: 1px solid var(--c-border);
+  padding: 0.5rem 0.65rem;
+  background: var(--c-bg-light);
+  color: var(--c-text);
+
+  &.is-error {
+    border-color: #f1aeb5;
+    background: #fff5f5;
+    color: #b42318;
+  }
+}
+
+.trends-page__section {
+  margin-top: 1rem;
+}
+
+.trends-page__section-title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: baseline;
+  justify-content: space-between;
+
+  h2 {
+    margin: 0 0 0.4rem;
+    border-bottom-width: 0;
+    font-size: 0.8rem;
+    line-height: 1.2;
+  }
+
+  span {
+    color: var(--c-text-lighter);
+    font-size: 0.65rem;
+  }
+}
+
+.trends-page__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
+  margin-bottom: 0.75rem;
+  border: 1px solid var(--c-border);
+
+  div {
+    display: grid;
+    gap: 0.1rem;
+    border-right: 1px solid var(--c-border);
+    padding: 0.45rem 0.55rem;
+
+    &:last-child {
+      border-right: 0;
+    }
+  }
+
+  span {
+    color: var(--c-text-lighter);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+  }
+
+  strong {
+    font-size: 0.72rem;
+    line-height: 1.1;
+  }
+}
+
+.trends-chart {
+  margin-bottom: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--c-border) 78%, #d7dee8);
+  padding: 0.6rem;
+  background: linear-gradient(180deg, #f8fafc 0%, var(--c-bg-light) 100%);
+}
+
+.trends-chart__title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.45rem;
+
+  h3 {
+    margin: 0;
+    font-size: 0.72rem;
+    line-height: 1.2;
+  }
+
+  p {
+    margin: 0.12rem 0 0;
+    color: var(--c-text-light);
+    font-size: 0.68rem;
+    line-height: 1.25;
+  }
+
+  strong {
+    font-size: 0.7rem;
+  }
+}
+
+.trends-chart__filter {
+  min-width: 10rem;
+  max-width: 16rem;
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+  padding: 0.25rem 0.35rem;
+  background: var(--c-bg);
+  color: var(--c-text);
+  font-size: 0.68rem;
+}
+
+.trends-echart {
+  display: block;
+  width: 100%;
+  height: 13rem;
+  background: linear-gradient(
+      to bottom,
+      rgba(148, 163, 184, 0.12) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to right, rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.72),
+      rgba(241, 245, 249, 0.68)
+    );
+  background-size:
+    100% 25%,
+    12.5% 100%,
+    100% 100%;
+}
+
+.trends-chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.4rem;
+  overflow: visible;
+  margin-top: 0.45rem;
+  color: var(--c-text-light);
+  font-size: 0.65rem;
+
+  span {
+    border: 1px solid transparent;
+    border-radius: 999px;
+    padding: 0.08rem 0.22rem;
+    opacity: 0.72;
+    transition:
+      background-color 0.12s ease,
+      border-color 0.12s ease,
+      color 0.12s ease,
+      opacity 0.12s ease,
+      font-weight 0.12s ease;
+  }
+
+  span.is-active {
+    border-color: color-mix(in srgb, var(--series-color) 46%, transparent);
+    background: color-mix(in srgb, var(--series-color) 16%, transparent);
+    color: var(--c-text);
+    font-weight: 600;
+    opacity: 1;
+  }
+
+  span::before {
+    display: inline-block;
+    width: 0.55rem;
+    height: 0.55rem;
+    margin-right: 0.25rem;
+    background: var(--series-color);
+    content: "";
+    vertical-align: -0.05rem;
+  }
+}
+
+.trends-chart__snapshot {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.8rem;
+  align-items: baseline;
+  margin-top: 0.45rem;
+  border-top: 1px solid color-mix(in srgb, var(--c-border) 70%, transparent);
+  padding-top: 0.45rem;
+  color: var(--c-text-light);
+  font-size: 0.66rem;
+
+  strong {
+    color: var(--c-text);
+    font-size: 0.68rem;
+  }
+
+  span::before {
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    margin-right: 0.25rem;
+    background: var(--series-color);
+    content: "";
+    vertical-align: -0.04rem;
+  }
+}
+
+.trends-table-wrap {
+  overflow-x: auto;
+}
+
+.trends-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.68rem;
+
+  th,
+  td {
+    border-bottom: 1px solid var(--c-border);
+    padding: 0.35rem 0.4rem;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  th {
+    color: var(--c-text-lighter);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+  }
+}
+
+@media (max-width: 800px) {
+  .trends-page__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+
+    div {
+      border-bottom: 1px solid var(--c-border);
+    }
+  }
+}
+
+:is(.dark, [data-theme="dark"]) {
+  .trends-chart {
+    border-color: var(--c-border);
+    background: var(--c-bg-light);
+  }
+
+  .trends-echart {
+    background: linear-gradient(
+        to bottom,
+        rgba(148, 163, 184, 0.12) 1px,
+        transparent 1px
+      ),
+      linear-gradient(to right, rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+      var(--c-bg);
+    background-size:
+      100% 25%,
+      12.5% 100%,
+      100% 100%;
+  }
+
+  .trends-page__notice {
+    &.is-error {
+      border-color: rgba(255, 138, 128, 0.42);
+      background: rgba(180, 35, 24, 0.14);
+      color: #ff8a80;
+    }
+  }
+}
+</style>

--- a/apps/docs/docs/.vuepress/trendsView.ts
+++ b/apps/docs/docs/.vuepress/trendsView.ts
@@ -1,0 +1,50 @@
+import { TrendsPoint, TrendsSeries } from "@openupm/types";
+
+export function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+export function latestValue(points: TrendsPoint[]): number {
+  return points.length ? points[points.length - 1].value : 0;
+}
+
+export function sumValues(points: TrendsPoint[]): number {
+  return points.reduce((sum, point) => sum + point.value, 0);
+}
+
+export function previousMonth(value: string): string {
+  const date = new Date(`${value.substring(0, 7)}-01T00:00:00.000Z`);
+  date.setUTCMonth(date.getUTCMonth() - 1);
+  return date.toISOString().substring(0, 7);
+}
+
+export function valueAtDate(points: TrendsPoint[], date: string): number {
+  return points.find((point) => point.date === date)?.value || 0;
+}
+
+export function pickSeriesColor(index: number): string {
+  const colors = [
+    "#0b7285",
+    "#a16207",
+    "#5f3dc4",
+    "#2b8a3e",
+    "#c92a2a",
+    "#364fc7",
+    "#c2255c",
+    "#087f5b",
+  ];
+  return colors[index % colors.length];
+}
+
+export function filterSeries(
+  series: TrendsSeries[],
+  query: string,
+): TrendsSeries[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return series;
+  return series.filter(
+    (entry) =>
+      entry.key.toLowerCase().includes(normalized) ||
+      entry.label.toLowerCase().includes(normalized),
+  );
+}

--- a/apps/docs/docs/trends/index.md
+++ b/apps/docs/docs/trends/index.md
@@ -1,0 +1,8 @@
+---
+layout: WideLayout
+title: Trends
+description: OpenUPM package, release, signing, and download trends.
+editLink: false
+---
+
+<TrendsPage />

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -79,5 +79,9 @@
   },
   "volta": {
     "node": "22.19.0"
+  },
+  "dependencies": {
+    "echarts": "^6.1.0",
+    "vue-echarts": "^8.0.1"
   }
 }

--- a/apps/jobs/__tests__/jobs/buildTrendsSnapshot.spec.ts
+++ b/apps/jobs/__tests__/jobs/buildTrendsSnapshot.spec.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReleaseState } from '@openupm/types';
+
+const loadPackageNamesMock = vi.fn();
+const loadPackageMetadataLocalMock = vi.fn();
+const loadTopicsMock = vi.fn();
+const fetchAllMock = vi.fn();
+const setPublicTrendsMock = vi.fn();
+const openTrendsSqliteStoreMock = vi.fn();
+const getPackageNamesWithoutDownloadsMock = vi.fn();
+const upsertPackageDownloadsMock = vi.fn();
+const getPackageDownloadRangesMock = vi.fn();
+const closeMock = vi.fn();
+
+vi.mock('@openupm/local-data', () => ({
+  loadPackageNames: loadPackageNamesMock,
+  loadPackageMetadataLocal: loadPackageMetadataLocalMock,
+  loadTopics: loadTopicsMock,
+}));
+
+vi.mock('@openupm/server-common/build/models/release.js', () => ({
+  fetchAll: fetchAllMock,
+}));
+
+vi.mock('@openupm/server-common/build/models/trends.js', () => ({
+  setPublicTrends: setPublicTrendsMock,
+}));
+
+vi.mock('@openupm/server-common/build/trends/sqliteStore.js', () => ({
+  openTrendsSqliteStore: openTrendsSqliteStoreMock,
+}));
+
+describe('buildTrendsSnapshotJob', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-11T00:00:00.000Z'));
+    openTrendsSqliteStoreMock.mockReturnValue({
+      getPackageNamesWithoutDownloads: getPackageNamesWithoutDownloadsMock,
+      upsertPackageDownloads: upsertPackageDownloadsMock,
+      getPackageDownloadRanges: getPackageDownloadRangesMock,
+      close: closeMock,
+    });
+    getPackageNamesWithoutDownloadsMock.mockReturnValue([]);
+    getPackageDownloadRangesMock.mockReturnValue([
+      {
+        package: 'com.example.pkg',
+        downloads: [
+          { day: '2026-01-02', downloads: 7 },
+          { day: '2026-06-10', downloads: 5 },
+        ],
+      },
+    ]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => ({
+        ok: true,
+        json: async () =>
+          url.includes('/downloads/range/')
+            ? {
+                package: 'com.example.pkg',
+                downloads: [{ day: '2026-06-10', downloads: 5 }],
+              }
+            : {
+                name: 'com.example.pkg',
+                versions: {},
+                time: {
+                  created: '2026-01-01T00:00:00.000Z',
+                  modified: '2026-03-05T00:00:00.000Z',
+                  '1.0.0': '2026-01-03T00:00:00.000Z',
+                  '1.1.0': '2026-03-05T00:00:00.000Z',
+                },
+                'dist-tags': {},
+                readme: '',
+              },
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  function mockPackageMetadata(): void {
+    loadPackageNamesMock.mockResolvedValue(['com.example.pkg']);
+    loadTopicsMock.mockResolvedValue([
+      { slug: 'tools', name: 'Tools', keywords: [] },
+    ]);
+    loadPackageMetadataLocalMock.mockResolvedValue({
+      name: 'com.example.pkg',
+      aliases: [],
+      repoUrl: 'https://github.com/example/pkg',
+      displayName: 'Pkg',
+      description: '',
+      licenseSpdxId: null,
+      licenseName: '',
+      topics: ['tools'],
+      hunter: '',
+      createdAt: Date.parse('2026-01-01T00:00:00.000Z'),
+      trackingMode: 'githubRelease',
+      repo: 'pkg',
+      owner: 'example',
+      ownerUrl: '',
+      parentRepo: null,
+      parentOwner: null,
+      parentOwnerUrl: null,
+      readmeBranch: 'main',
+      hunterUrl: null,
+    });
+  }
+
+  function mockReleases(): void {
+    fetchAllMock.mockResolvedValue([
+      {
+        packageName: 'com.example.pkg',
+        version: '1.0.0',
+        commit: '',
+        tag: '',
+        state: ReleaseState.Succeeded,
+        buildId: '',
+        reason: 0,
+        createdAt: Date.parse('2026-01-03T00:00:00.000Z'),
+        updatedAt: Date.parse('2026-01-03T00:00:00.000Z'),
+        source: 'githubRelease',
+        signed: true,
+      },
+    ]);
+  }
+
+  it('refreshes recent download history and saves a public trends snapshot', async () => {
+    mockPackageMetadata();
+    mockReleases();
+
+    const { buildTrendsSnapshotJob } = await import(
+      '../../src/jobs/buildTrendsSnapshot.js'
+    );
+    await buildTrendsSnapshotJob();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://package.openupm.com/com.example.pkg',
+      expect.any(Object),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      'https://package.openupm.com/downloads/range/2026-05-28:2026-06-11/com.example.pkg',
+      expect.any(Object),
+    );
+    expect(upsertPackageDownloadsMock).toHaveBeenCalledWith('com.example.pkg', [
+      { day: '2026-06-10', downloads: 5 },
+    ]);
+    expect(getPackageDownloadRangesMock).toHaveBeenCalledWith([
+      'com.example.pkg',
+    ]);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+    expect(setPublicTrendsMock).toHaveBeenCalledTimes(1);
+    expect(setPublicTrendsMock.mock.calls[0][0]).toMatchObject({
+      catalogGrowth: {
+        totalPackageSubmissionsByDay: [{ date: '2026-01', value: 1 }],
+        totalActivePackagesByDay: [{ date: '2026-01', value: 1 }],
+      },
+      releaseActivity: {
+        activePackagesLast12Months: 1,
+        totalReleasesByTime: [
+          { date: '2026-01', value: 1 },
+          { date: '2026-02', value: 1 },
+          { date: '2026-03', value: 2 },
+        ],
+        releasesPerMonth: [
+          { date: '2026-01', value: 1 },
+          { date: '2026-02', value: 0 },
+          { date: '2026-03', value: 1 },
+        ],
+      },
+      downloads: {
+        totalDownloadsByTime: [
+          { date: '2026-01', value: 7 },
+          { date: '2026-02', value: 7 },
+          { date: '2026-03', value: 7 },
+          { date: '2026-04', value: 7 },
+          { date: '2026-05', value: 7 },
+          { date: '2026-06', value: 12 },
+        ],
+        downloadsPerMonth: [
+          { date: '2026-01', value: 7 },
+          { date: '2026-02', value: 0 },
+          { date: '2026-03', value: 0 },
+          { date: '2026-04', value: 0 },
+          { date: '2026-05', value: 0 },
+          { date: '2026-06', value: 5 },
+        ],
+      },
+    });
+  });
+
+  it('backfills full download history on explicit backfill runs', async () => {
+    mockPackageMetadata();
+    mockReleases();
+
+    const { buildTrendsSnapshotBackfillJob } = await import(
+      '../../src/jobs/buildTrendsSnapshot.js'
+    );
+    await buildTrendsSnapshotBackfillJob();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://package.openupm.com/downloads/range/2026-01-01:2026-06-11/com.example.pkg',
+      expect.any(Object),
+    );
+  });
+
+  it('backfills full download history for packages missing stored downloads', async () => {
+    mockPackageMetadata();
+    mockReleases();
+    getPackageNamesWithoutDownloadsMock.mockReturnValue(['com.example.pkg']);
+
+    const { buildTrendsSnapshotJob } = await import(
+      '../../src/jobs/buildTrendsSnapshot.js'
+    );
+    await buildTrendsSnapshotJob();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://package.openupm.com/downloads/range/2026-01-01:2026-06-11/com.example.pkg',
+      expect.any(Object),
+    );
+  });
+
+  it('keeps packument-published releases when Redis has a retry state', async () => {
+    mockPackageMetadata();
+    fetchAllMock.mockResolvedValue([
+      {
+        packageName: 'com.example.pkg',
+        version: '1.0.0',
+        commit: '',
+        tag: '',
+        state: ReleaseState.Failed,
+        buildId: '',
+        reason: 0,
+        createdAt: Date.parse('2026-06-01T00:00:00.000Z'),
+        updatedAt: Date.parse('2026-06-01T00:00:00.000Z'),
+        source: 'githubRelease',
+        signed: true,
+      },
+    ]);
+
+    const { buildTrendsSnapshotJob } = await import(
+      '../../src/jobs/buildTrendsSnapshot.js'
+    );
+    await buildTrendsSnapshotJob();
+
+    expect(setPublicTrendsMock.mock.calls[0][0]).toMatchObject({
+      catalogGrowth: {
+        totalActivePackagesByDay: [{ date: '2026-01', value: 1 }],
+      },
+      releaseActivity: {
+        totalReleasesByTime: [
+          { date: '2026-01', value: 1 },
+          { date: '2026-02', value: 1 },
+          { date: '2026-03', value: 2 },
+        ],
+      },
+      trustAndDistribution: {
+        signedPackagesByDay: [{ date: '2026-01', value: 1 }],
+      },
+    });
+  });
+});

--- a/apps/jobs/config/default.json5
+++ b/apps/jobs/config/default.json5
@@ -70,6 +70,12 @@
     },
   },
 
+  // Trends
+  trends: {
+    sqlitePath: '/data/openupm-trends.sqlite',
+    recentRefreshLookbackDays: 14,
+  },
+
   // Cron job switches. Keep defaults enabled for production; override in
   // runtime config for maintenance windows or incident mitigation.
   jobs: {
@@ -100,6 +106,10 @@
       healthcheckPingUrl: '',
     },
     updateRecentPackagesJob: {
+      enabled: true,
+      healthcheckPingUrl: '',
+    },
+    buildTrendsSnapshotJob: {
       enabled: true,
       healthcheckPingUrl: '',
     },

--- a/apps/jobs/src/index.ts
+++ b/apps/jobs/src/index.ts
@@ -12,6 +12,10 @@ import { fetchPackageExtraJob } from './jobs/fetchPackageExtra.js';
 import { fetchSiteInfoJob } from './jobs/fetchSiteInfo.js';
 import { updateRecentPackagesJob } from './jobs/updateRecentPackages.js';
 import { updateFeedsJob } from './jobs/updateFeeds.js';
+import {
+  buildTrendsSnapshotBackfillJob,
+  buildTrendsSnapshotJob,
+} from './jobs/buildTrendsSnapshot.js';
 
 const logger = createLogger('@openupm/jobs');
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -115,8 +119,30 @@ function main(): void {
     '1 */2 * * *',
     async () => await fetchPackageExtraJob(null, { all: true, force: false }),
   );
+  scheduleJob(
+    'buildTrendsSnapshotJob',
+    '30 2 * * *',
+    async () => await buildTrendsSnapshotJob(),
+  );
+}
+
+async function run(argv: string[] = process.argv): Promise<void> {
+  const command = argv[2];
+  if (command === 'trends-backfill') {
+    await buildTrendsSnapshotBackfillJob();
+    return;
+  }
+  main();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+  const command = process.argv[2];
+  void run()
+    .then(() => {
+      if (command === 'trends-backfill') process.exit(0);
+    })
+    .catch((err) => {
+      logger.error({ err, command }, 'jobs command failed');
+      process.exit(1);
+    });
 }

--- a/apps/jobs/src/jobs/buildTrendsSnapshot.ts
+++ b/apps/jobs/src/jobs/buildTrendsSnapshot.ts
@@ -1,0 +1,317 @@
+import configRaw from 'config';
+import {
+  DailyDownload,
+  DownloadsRange,
+  Packument,
+  ReleaseModel,
+  ReleaseState,
+} from '@openupm/types';
+import {
+  loadPackageMetadataLocal,
+  loadPackageNames,
+  loadTopics,
+} from '@openupm/local-data';
+import {
+  getDownloadsRangeUrl,
+  getPackumentUrl,
+} from '@openupm/common/build/urls.js';
+import { createLogger } from '@openupm/server-common/build/log.js';
+import { fetchAll } from '@openupm/server-common/build/models/release.js';
+import { setPublicTrends } from '@openupm/server-common/build/models/trends.js';
+import {
+  buildPublicTrends,
+  PackageDownloadRange,
+} from '@openupm/server-common/build/trends/aggregation.js';
+import { openTrendsSqliteStore } from '@openupm/server-common/build/trends/sqliteStore.js';
+
+const logger = createLogger('@openupm/jobs/buildTrendsSnapshot');
+const DOWNLOAD_FETCH_CONCURRENCY = 8;
+const DEFAULT_RECENT_REFRESH_LOOKBACK_DAYS = 14;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config = configRaw as any;
+
+export type TrendsSnapshotMode = 'full' | 'recent';
+
+export interface BuildTrendsSnapshotOptions {
+  mode?: TrendsSnapshotMode;
+  recentRefreshLookbackDays?: number;
+}
+
+function toUtcDay(value: number): string {
+  return new Date(value).toISOString().substring(0, 10);
+}
+
+function parseUtcDay(day: string): number {
+  return Date.parse(`${day}T00:00:00.000Z`);
+}
+
+function addDays(day: string, days: number): string {
+  return toUtcDay(parseUtcDay(day) + days * 24 * 60 * 60 * 1000);
+}
+
+function maxDay(a: string, b: string): string {
+  return a > b ? a : b;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < values.length) {
+      const currentIndex = index;
+      index += 1;
+      results[currentIndex] = await mapper(values[currentIndex]);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    method: 'GET',
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!response.ok) {
+    throw new Error(`request failed ${response.status} for ${url}`);
+  }
+  return (await response.json()) as T;
+}
+
+function normalizeDownloads(downloads: DailyDownload[]): DailyDownload[] {
+  return downloads
+    .filter(
+      (entry) =>
+        typeof entry.day === 'string' &&
+        Number.isFinite(entry.downloads) &&
+        entry.downloads > 0,
+    )
+    .map((entry) => ({
+      day: entry.day,
+      downloads: Math.trunc(entry.downloads),
+    }));
+}
+
+function packumentReleaseEntries(packument: Packument): Array<{
+  version: string;
+  time: number;
+}> {
+  return Object.entries(packument.time || {})
+    .filter(([version]) => version !== 'created' && version !== 'modified')
+    .map(([version, time]) => ({
+      version,
+      time: Date.parse(time),
+    }))
+    .filter((entry) => Number.isFinite(entry.time));
+}
+
+async function fetchPublishedReleases(
+  packageName: string,
+): Promise<ReleaseModel[]> {
+  try {
+    const packument = await fetchJson<Packument>(getPackumentUrl(packageName));
+    return packumentReleaseEntries(packument).map(({ version, time }) => ({
+      packageName,
+      version,
+      commit: '',
+      tag: version,
+      state: ReleaseState.Succeeded,
+      buildId: '',
+      reason: 0,
+      createdAt: time,
+      updatedAt: time,
+    }));
+  } catch (err) {
+    logger.warn({ err, packageName }, 'fetch package packument failed');
+    return [];
+  }
+}
+
+function mergeReleaseRecords(
+  redisReleases: ReleaseModel[],
+  publishedReleases: ReleaseModel[],
+): ReleaseModel[] {
+  const merged = new Map<string, ReleaseModel>();
+  for (const release of publishedReleases) {
+    merged.set(`${release.packageName}@${release.version}`, release);
+  }
+  for (const release of redisReleases) {
+    const key = `${release.packageName}@${release.version}`;
+    const publishedRelease = merged.get(key);
+    merged.set(
+      key,
+      publishedRelease?.state === ReleaseState.Succeeded &&
+        release.state !== ReleaseState.Succeeded
+        ? {
+            ...release,
+            state: ReleaseState.Succeeded,
+            createdAt: publishedRelease.createdAt,
+            updatedAt: publishedRelease.updatedAt,
+          }
+        : release,
+    );
+  }
+  return Array.from(merged.values());
+}
+
+async function fetchPackageDownloadRange(
+  packageName: string,
+  period: string,
+): Promise<PackageDownloadRange> {
+  try {
+    const data = await fetchJson<DownloadsRange>(
+      getDownloadsRangeUrl(packageName, period),
+    );
+    return {
+      package: packageName,
+      downloads: normalizeDownloads(data.downloads || []),
+    };
+  } catch (err) {
+    logger.warn({ err, packageName }, 'fetch package download history failed');
+    return { package: packageName, downloads: [] };
+  }
+}
+
+function getRecentRefreshLookbackDays(
+  options: BuildTrendsSnapshotOptions,
+): number {
+  const value =
+    options.recentRefreshLookbackDays ??
+    config.trends?.recentRefreshLookbackDays ??
+    DEFAULT_RECENT_REFRESH_LOOKBACK_DAYS;
+  return Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : DEFAULT_RECENT_REFRESH_LOOKBACK_DAYS;
+}
+
+function getDownloadStartDay(params: {
+  firstPackageDay: string;
+  mode: TrendsSnapshotMode;
+  options: BuildTrendsSnapshotOptions;
+  today: string;
+}): string {
+  if (params.mode === 'full') return params.firstPackageDay;
+  const lookbackDays = getRecentRefreshLookbackDays(params.options);
+  return maxDay(params.firstPackageDay, addDays(params.today, -lookbackDays));
+}
+
+export async function buildTrendsSnapshotJob(
+  options: BuildTrendsSnapshotOptions = {},
+): Promise<void> {
+  const mode = options.mode || 'recent';
+  const packageNames = await loadPackageNames();
+  const topics = await loadTopics();
+  const packages = (
+    await Promise.all(
+      packageNames.map(async (packageName) => {
+        const pkg = await loadPackageMetadataLocal(packageName);
+        if (!pkg) {
+          logger.warn({ packageName }, 'package metadata local does not exist');
+        }
+        return pkg;
+      }),
+    )
+  ).filter((pkg): pkg is NonNullable<typeof pkg> => pkg !== null);
+
+  const redisReleases = (
+    await Promise.all(
+      packages.map(async (pkg): Promise<ReleaseModel[]> => {
+        try {
+          return await fetchAll(pkg.name);
+        } catch (err) {
+          logger.warn({ err, packageName: pkg.name }, 'fetch releases failed');
+          return [];
+        }
+      }),
+    )
+  ).flat();
+  const publishedReleases = (
+    await mapWithConcurrency(
+      packages.map((pkg) => pkg.name),
+      DOWNLOAD_FETCH_CONCURRENCY,
+      fetchPublishedReleases,
+    )
+  ).flat();
+  const releases = mergeReleaseRecords(redisReleases, publishedReleases);
+
+  const firstPackageDay = packages.length
+    ? packages
+        .map((pkg) => toUtcDay(pkg.createdAt))
+        .sort((a, b) => a.localeCompare(b))[0]
+    : toUtcDay(Date.now());
+  const today = toUtcDay(Date.now());
+  const store = openTrendsSqliteStore(config.trends.sqlitePath);
+  let downloadRanges: PackageDownloadRange[];
+  let fullDownloadBackfillPackages = 0;
+  try {
+    const packageNamesForDownloads = packages.map((pkg) => pkg.name);
+    const packageNamesMissingDownloads =
+      mode === 'recent'
+        ? new Set(
+            store.getPackageNamesWithoutDownloads(packageNamesForDownloads),
+          )
+        : new Set(packageNamesForDownloads);
+    fullDownloadBackfillPackages = packageNamesMissingDownloads.size;
+    const recentDownloadStartDay = getDownloadStartDay({
+      firstPackageDay,
+      mode: 'recent',
+      options,
+      today,
+    });
+    const fetchedDownloadRanges = await mapWithConcurrency(
+      packageNamesForDownloads,
+      DOWNLOAD_FETCH_CONCURRENCY,
+      (packageName) =>
+        fetchPackageDownloadRange(
+          packageName,
+          `${
+            packageNamesMissingDownloads.has(packageName)
+              ? firstPackageDay
+              : recentDownloadStartDay
+          }:${today}`,
+        ),
+    );
+    for (const range of fetchedDownloadRanges) {
+      store.upsertPackageDownloads(range.package, range.downloads);
+    }
+    downloadRanges = store.getPackageDownloadRanges(
+      packages.map((pkg) => pkg.name),
+    );
+  } finally {
+    store.close();
+  }
+
+  const trends = buildPublicTrends({
+    packages,
+    topics,
+    releases,
+    downloadRanges,
+  });
+  await setPublicTrends(trends);
+  logger.info(
+    {
+      packages: packages.length,
+      releases: releases.length,
+      downloadRanges: downloadRanges.length,
+      fullDownloadBackfillPackages,
+      generatedAt: trends.generatedAt,
+      mode,
+    },
+    'trends snapshot updated',
+  );
+}
+
+export async function buildTrendsSnapshotBackfillJob(): Promise<void> {
+  await buildTrendsSnapshotJob({ mode: 'full' });
+}

--- a/apps/web/__tests__/routers/trends.spec.ts
+++ b/apps/web/__tests__/routers/trends.spec.ts
@@ -1,0 +1,100 @@
+import request from 'supertest';
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getPublicTrends: vi.fn(),
+  queueStatusGet: vi.fn(),
+  queueStatusClear: vi.fn(),
+}));
+
+vi.mock('@openupm/server-common/build/models/trends.js', () => ({
+  getPublicTrends: mocks.getPublicTrends,
+}));
+
+vi.mock('../../src/status/queueStatus.js', () => ({
+  buildPublicQueueStatus: vi.fn(),
+  getQueue: vi.fn(),
+  createQueueStatusCache: vi.fn(() => ({
+    get: mocks.queueStatusGet,
+    clear: mocks.queueStatusClear,
+  })),
+}));
+
+const { app } = await import('../../src/apiServer.js');
+
+describe('trends router', () => {
+  beforeEach(async () => {
+    await app.ready();
+  });
+
+  afterEach(() => {
+    mocks.getPublicTrends.mockReset();
+    mocks.queueStatusGet.mockReset();
+    mocks.queueStatusClear.mockReset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns the public trends snapshot', async () => {
+    mocks.getPublicTrends.mockResolvedValue({
+      generatedAt: '2026-06-11T00:00:00.000Z',
+      coverage: {},
+      catalogGrowth: {
+        totalPackageSubmissionsByDay: [],
+        totalActivePackagesByDay: [],
+        newPackageSubmissionsByMonth: [],
+        packageSubmissionsByTopicByDay: [],
+      },
+      trustAndDistribution: {
+        signedPackagesByDay: [],
+        releaseSourceAndSigningByDay: [],
+      },
+      releaseActivity: {
+        activePackagesLast12Months: 0,
+        totalReleasesByTime: [],
+        releasesPerMonth: [],
+      },
+      downloads: {
+        totalDownloadsByTime: [],
+        downloadsPerMonth: [],
+      },
+    });
+
+    const response = await request(app.server)
+      .get('/trends')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect('Content-Type', /json/);
+
+    expect(response.body).toMatchObject({
+      generatedAt: '2026-06-11T00:00:00.000Z',
+      catalogGrowth: { totalPackageSubmissionsByDay: [] },
+      downloads: { totalDownloadsByTime: [] },
+    });
+  });
+
+  it('returns a sanitized 503 response when trends are missing', async () => {
+    mocks.getPublicTrends.mockResolvedValue(null);
+
+    const response = await request(app.server)
+      .get('/trends')
+      .set('Accept', 'application/json')
+      .expect(503)
+      .expect('Content-Type', /json/);
+
+    expect(response.body).toEqual({
+      error: 'TrendsUnavailable',
+      message: 'Trends are not ready yet.',
+    });
+  });
+});

--- a/apps/web/src/apiServer.ts
+++ b/apps/web/src/apiServer.ts
@@ -7,6 +7,7 @@ import feedsRouter from './routers/feeds.js';
 import siteInfoRouter from './routers/siteInfo.js';
 import packagesRouter from './routers/packages.js';
 import queueStatusRouter from './routers/queueStatus.js';
+import trendsRouter from './routers/trends.js';
 
 // Touch the redis.client property to prepare the connection as soon as possible
 redis.client;
@@ -38,3 +39,4 @@ feedsRouter(app);
 siteInfoRouter(app);
 packagesRouter(app);
 queueStatusRouter(app);
+trendsRouter(app);

--- a/apps/web/src/routers/trends.ts
+++ b/apps/web/src/routers/trends.ts
@@ -1,0 +1,25 @@
+import { FastifyInstance } from 'fastify';
+
+import { getPublicTrends } from '@openupm/server-common/build/models/trends.js';
+
+export default function router(server: FastifyInstance): void {
+  server.get('/trends', async function (_request, reply) {
+    try {
+      const trends = await getPublicTrends();
+      if (!trends) {
+        reply.code(503);
+        return {
+          error: 'TrendsUnavailable',
+          message: 'Trends are not ready yet.',
+        };
+      }
+      return trends;
+    } catch {
+      reply.code(503);
+      return {
+        error: 'TrendsUnavailable',
+        message: 'Trends are temporarily unavailable.',
+      };
+    }
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,10 @@
       "name": "@openupm/docs",
       "version": "0.0.0",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "echarts": "^6.1.0",
+        "vue-echarts": "^8.0.1"
+      },
       "devDependencies": {
         "@intlify/unplugin-vue-i18n": "^0.11.0",
         "@openupm/common": "*",
@@ -9642,6 +9646,22 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -19275,6 +19295,16 @@
         }
       }
     },
+    "node_modules/vue-echarts": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-8.0.1.tgz",
+      "integrity": "sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "echarts": "^6.0.0",
+        "vue": "^3.3.0"
+      }
+    },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
@@ -19982,6 +20012,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/packages/@openupm/common/__tests__/urls.spec.ts
+++ b/packages/@openupm/common/__tests__/urls.spec.ts
@@ -2,6 +2,7 @@ import {
   getContributorProfilePagePath,
   getAvatarImageUrl,
   getMediaBaseUrl,
+  getDownloadsRangeUrl,
   getMonthlyDownloadsRangeUrl,
   getMonthlyDownloadsUrl,
   getPackageImageUrl,
@@ -124,6 +125,17 @@ describe('download count urls', () => {
 
     expect(result).toEqual(
       'https://package.openupm.com/downloads/range/last-month/com.example.package',
+    );
+  });
+
+  it('should build a downloads range url for an explicit date period', () => {
+    const result = getDownloadsRangeUrl(
+      'com.example.package',
+      '2026-01-01:2026-01-31',
+    );
+
+    expect(result).toEqual(
+      'https://package.openupm.com/downloads/range/2026-01-01:2026-01-31/com.example.package',
     );
   });
 });

--- a/packages/@openupm/common/src/urls.ts
+++ b/packages/@openupm/common/src/urls.ts
@@ -91,7 +91,9 @@ export const getPackageListPagePath = function (topic?: string): string {
 export const getContributorProfilePagePath = function (
   githubUser: string,
 ): string {
-  return `/contributors/${encodeURIComponent(githubUser.trim().toLowerCase())}/`;
+  return `/contributors/${encodeURIComponent(
+    githubUser.trim().toLowerCase(),
+  )}/`;
 };
 
 // OpenUPM GitHub repo url.
@@ -242,6 +244,18 @@ export const getMonthlyDownloadsRangeUrl = function (name: string): string {
     'last-month',
     name,
   );
+};
+
+/**
+ * Get downloads range url for package name and period.
+ * @param name package name
+ * @param period period, such as last-month or YYYY-MM-DD:YYYY-MM-DD
+ */
+export const getDownloadsRangeUrl = function (
+  name: string,
+  period: string,
+): string {
+  return urlJoin(getRegistryBaseUrl(), 'downloads', 'range', period, name);
 };
 
 /**

--- a/packages/@openupm/common/src/utils.ts
+++ b/packages/@openupm/common/src/utils.ts
@@ -13,9 +13,11 @@ import { getPackageImageUrl } from './urls.js';
  * @param name environment variable name
  * @returns environment variable value
  */
-// TODO: https://github.com/vitejs/vite/issues/1149#issuecomment-857686209
 export const getEnv = function (name: string): string | undefined {
-  return process.env[name];
+  const meta = import.meta as ImportMeta & {
+    env?: Record<string, string | undefined>;
+  };
+  return meta.env?.[name] || process.env[name];
 };
 
 /**

--- a/packages/@openupm/server-common/__tests__/trends/aggregation.spec.ts
+++ b/packages/@openupm/server-common/__tests__/trends/aggregation.spec.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { ReleaseState } from '@openupm/types';
+
+import { buildPublicTrends } from '../../src/trends/aggregation.js';
+
+describe('trends aggregation', () => {
+  it('builds package, topic, signed, release, and download series', () => {
+    const trends = buildPublicTrends({
+      generatedAt: new Date('2026-06-11T00:00:00.000Z'),
+      topics: [
+        { slug: 'tools', name: 'Tools', keywords: [] },
+        { slug: 'ai', name: 'AI', keywords: [] },
+      ],
+      packages: [
+        {
+          name: 'com.example.alpha',
+          aliases: [],
+          repoUrl: 'https://github.com/example/alpha',
+          displayName: 'Alpha',
+          description: '',
+          licenseSpdxId: null,
+          licenseName: '',
+          topics: ['tools'],
+          hunter: '',
+          createdAt: Date.parse('2026-01-01T00:00:00.000Z'),
+          trackingMode: 'git',
+          repo: 'alpha',
+          owner: 'example',
+          ownerUrl: '',
+          parentRepo: null,
+          parentOwner: null,
+          parentOwnerUrl: null,
+          readmeBranch: 'main',
+          hunterUrl: null,
+        },
+        {
+          name: 'com.example.beta',
+          aliases: [],
+          repoUrl: 'https://github.com/example/beta',
+          displayName: 'Beta',
+          description: '',
+          licenseSpdxId: null,
+          licenseName: '',
+          topics: ['tools', 'ai'],
+          hunter: '',
+          createdAt: Date.parse('2026-02-01T00:00:00.000Z'),
+          trackingMode: 'githubRelease',
+          repo: 'beta',
+          owner: 'example',
+          ownerUrl: '',
+          parentRepo: null,
+          parentOwner: null,
+          parentOwnerUrl: null,
+          readmeBranch: 'main',
+          hunterUrl: null,
+        },
+      ],
+      releases: [
+        {
+          packageName: 'com.example.beta',
+          version: '1.0.0',
+          commit: '',
+          tag: '1.0.0',
+          state: ReleaseState.Succeeded,
+          buildId: '',
+          reason: 0,
+          createdAt: Date.parse('2026-02-03T00:00:00.000Z'),
+          updatedAt: Date.parse('2026-02-03T00:00:00.000Z'),
+          source: 'githubRelease',
+          signed: true,
+        },
+        {
+          packageName: 'com.example.alpha',
+          version: '1.1.0',
+          commit: '',
+          tag: '1.1.0',
+          state: ReleaseState.Succeeded,
+          buildId: '',
+          reason: 0,
+          createdAt: Date.parse('2026-04-03T00:00:00.000Z'),
+          updatedAt: Date.parse('2026-04-03T00:00:00.000Z'),
+          source: 'git',
+          signed: false,
+        },
+      ],
+      downloadRanges: [
+        {
+          package: 'com.example.alpha',
+          downloads: [
+            { day: '2026-02-01', downloads: 3 },
+            { day: '2026-02-02', downloads: 5 },
+            { day: '2026-04-01', downloads: 17 },
+          ],
+        },
+        {
+          package: 'com.example.beta',
+          downloads: [
+            { day: '2026-02-01', downloads: 11 },
+            { day: '2026-02-02', downloads: 13 },
+          ],
+        },
+      ],
+    });
+
+    expect(trends.generatedAt).toEqual('2026-06-11T00:00:00.000Z');
+    expect(trends.catalogGrowth.totalPackageSubmissionsByDay.at(-1)).toEqual({
+      date: '2026-02',
+      value: 2,
+    });
+    expect(trends.catalogGrowth.totalActivePackagesByDay).toEqual([
+      { date: '2026-01', value: 0 },
+      { date: '2026-02', value: 1 },
+      { date: '2026-03', value: 1 },
+      { date: '2026-04', value: 2 },
+    ]);
+    expect(
+      trends.catalogGrowth.packageSubmissionsByTopicByDay
+        .find((series) => series.key === 'tools')
+        ?.points.at(-1),
+    ).toEqual({ date: '2026-02', value: 2 });
+    expect(trends.trustAndDistribution.signedPackagesByDay.at(-1)).toEqual({
+      date: '2026-02',
+      value: 1,
+    });
+    expect(
+      trends.trustAndDistribution.releaseSourceAndSigningByDay.map(
+        (series) => series.key,
+      ),
+    ).toEqual(['githubReleaseAssets', 'gitSource']);
+    expect(trends.releaseActivity.totalReleasesByTime).toEqual([
+      { date: '2026-02', value: 1 },
+      { date: '2026-03', value: 1 },
+      { date: '2026-04', value: 2 },
+    ]);
+    expect(trends.releaseActivity.releasesPerMonth).toEqual([
+      { date: '2026-02', value: 1 },
+      { date: '2026-03', value: 0 },
+      { date: '2026-04', value: 1 },
+    ]);
+    expect(trends.downloads.totalDownloadsByTime).toEqual([
+      { date: '2026-02', value: 32 },
+      { date: '2026-03', value: 32 },
+      { date: '2026-04', value: 49 },
+    ]);
+    expect(trends.downloads.downloadsPerMonth).toEqual([
+      { date: '2026-02', value: 32 },
+      { date: '2026-03', value: 0 },
+      { date: '2026-04', value: 17 },
+    ]);
+  });
+});

--- a/packages/@openupm/server-common/__tests__/trends/sqliteStore.spec.ts
+++ b/packages/@openupm/server-common/__tests__/trends/sqliteStore.spec.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openTrendsSqliteStore } from '../../src/trends/sqliteStore.js';
+
+let tmpDir = '';
+
+afterEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = '';
+});
+
+describe('trends sqlite store', () => {
+  it('upserts and reads package daily downloads', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openupm-trends-'));
+    const store = openTrendsSqliteStore(path.join(tmpDir, 'trends.sqlite'));
+    try {
+      expect(
+        store.getPackageNamesWithoutDownloads([
+          'com.example.pkg',
+          'com.example.empty',
+        ]),
+      ).toEqual(['com.example.pkg', 'com.example.empty']);
+      store.upsertPackageDownloads('com.example.pkg', [
+        { day: '2026-01-01', downloads: 3 },
+        { day: '2026-01-02', downloads: 5 },
+      ]);
+      store.upsertPackageDownloads('com.example.pkg', [
+        { day: '2026-01-02', downloads: 9 },
+      ]);
+      expect(
+        store.getPackageNamesWithoutDownloads([
+          'com.example.pkg',
+          'com.example.empty',
+        ]),
+      ).toEqual(['com.example.empty']);
+
+      expect(store.getPackageDownloadRanges(['com.example.pkg'])).toEqual([
+        {
+          package: 'com.example.pkg',
+          downloads: [
+            { day: '2026-01-01', downloads: 3 },
+            { day: '2026-01-02', downloads: 9 },
+          ],
+        },
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/@openupm/server-common/src/models/trends.ts
+++ b/packages/@openupm/server-common/src/models/trends.ts
@@ -1,0 +1,15 @@
+import { PublicTrends } from '@openupm/types';
+
+import redis from '../redis.js';
+
+const REDIS_KEY_PUBLIC_TRENDS = 'trends:latest';
+
+export async function setPublicTrends(trends: PublicTrends): Promise<void> {
+  await redis.client!.set(REDIS_KEY_PUBLIC_TRENDS, JSON.stringify(trends));
+}
+
+export async function getPublicTrends(): Promise<PublicTrends | null> {
+  const jsonText = await redis.client!.get(REDIS_KEY_PUBLIC_TRENDS);
+  if (!jsonText) return null;
+  return JSON.parse(jsonText) as PublicTrends;
+}

--- a/packages/@openupm/server-common/src/trends/aggregation.ts
+++ b/packages/@openupm/server-common/src/trends/aggregation.ts
@@ -1,0 +1,380 @@
+import {
+  DailyDownload,
+  PackageMetadataLocal,
+  PublicTrends,
+  ReleaseModel,
+  TopicBase,
+  TrendsPoint,
+  TrendsSeries,
+} from '@openupm/types';
+import { ReleaseState } from '@openupm/types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface PackageDownloadRange {
+  package: string;
+  downloads: DailyDownload[];
+}
+
+function toUtcDay(value: number): string {
+  return new Date(value).toISOString().substring(0, 10);
+}
+
+function toUtcMonth(day: string): string {
+  return day.substring(0, 7);
+}
+
+function toMonthStart(month: string): Date {
+  return new Date(`${month}-01T00:00:00.000Z`);
+}
+
+function addMonths(month: string, months: number): string {
+  const date = toMonthStart(month);
+  date.setUTCMonth(date.getUTCMonth() + months);
+  return date.toISOString().substring(0, 7);
+}
+
+function parseDay(day: string): number {
+  return Date.parse(`${day}T00:00:00.000Z`);
+}
+
+function addDays(day: string, days: number): string {
+  return toUtcDay(parseDay(day) + days * DAY_MS);
+}
+
+function compareDate(a: string, b: string): number {
+  return a.localeCompare(b);
+}
+
+function minDefinedDate(values: string[]): string | null {
+  const filtered = values.filter(Boolean).sort(compareDate);
+  return filtered.length ? filtered[0] : null;
+}
+
+function maxDefinedDate(values: string[]): string | null {
+  const filtered = values.filter(Boolean).sort(compareDate);
+  return filtered.length ? filtered[filtered.length - 1] : null;
+}
+
+function buildCountByDay(days: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const day of days) counts.set(day, (counts.get(day) || 0) + 1);
+  return counts;
+}
+
+function buildCumulativePoints(
+  countsByDay: Map<string, number>,
+  startDay: string | null,
+  endDay: string | null,
+): TrendsPoint[] {
+  if (!startDay || !endDay) return [];
+  const points: TrendsPoint[] = [];
+  let total = 0;
+  for (let day = startDay; day <= endDay; day = addDays(day, 1)) {
+    total += countsByDay.get(day) || 0;
+    points.push({ date: day, value: total });
+  }
+  return points;
+}
+
+function sampleMonthly(points: TrendsPoint[]): TrendsPoint[] {
+  const byMonth = new Map<string, TrendsPoint>();
+  for (const point of points) byMonth.set(toUtcMonth(point.date), point);
+  const sampled = Array.from(byMonth.entries())
+    .sort(([a], [b]) => compareDate(a, b))
+    .map(([date, point]) => ({ date, value: point.value }));
+  return fillMonthlyPoints(sampled, 'carry');
+}
+
+function buildMonthlyCounts(days: string[]): TrendsPoint[] {
+  const counts = new Map<string, number>();
+  for (const day of days) {
+    const month = toUtcMonth(day);
+    counts.set(month, (counts.get(month) || 0) + 1);
+  }
+  const points = Array.from(counts.entries())
+    .sort(([a], [b]) => compareDate(a, b))
+    .map(([date, value]) => ({ date, value }));
+  return fillMonthlyPoints(points, 'zero');
+}
+
+function fillMonthlyPoints(
+  points: TrendsPoint[],
+  mode: 'zero' | 'carry',
+): TrendsPoint[] {
+  if (points.length === 0) return [];
+  const values = new Map(points.map((point) => [point.date, point.value]));
+  const startMonth = points[0].date;
+  const endMonth = points[points.length - 1].date;
+  const filled: TrendsPoint[] = [];
+  let carriedValue = 0;
+  for (let month = startMonth; month <= endMonth; month = addMonths(month, 1)) {
+    if (values.has(month)) carriedValue = values.get(month) as number;
+    filled.push({
+      date: month,
+      value: mode === 'carry' ? carriedValue : values.get(month) || 0,
+    });
+  }
+  return filled;
+}
+
+function sumDownloadsByDay(
+  ranges: PackageDownloadRange[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const range of ranges) {
+    for (const entry of range.downloads) {
+      counts.set(entry.day, (counts.get(entry.day) || 0) + entry.downloads);
+    }
+  }
+  return counts;
+}
+
+function mapToSortedPoints(counts: Map<string, number>): TrendsPoint[] {
+  return Array.from(counts.entries())
+    .sort(([a], [b]) => compareDate(a, b))
+    .map(([date, value]) => ({ date, value }));
+}
+
+function buildDownloadMonthPoints(
+  downloadsByDay: Map<string, number>,
+): TrendsPoint[] {
+  const counts = new Map<string, number>();
+  for (const [day, downloads] of downloadsByDay) {
+    const month = toUtcMonth(day);
+    counts.set(month, (counts.get(month) || 0) + downloads);
+  }
+  return fillMonthlyPoints(mapToSortedPoints(counts), 'zero');
+}
+
+function buildTopicSeries(
+  topics: TopicBase[],
+  packages: PackageMetadataLocal[],
+  startDay: string | null,
+  endDay: string | null,
+): TrendsSeries[] {
+  return topics.map((topic) => {
+    const packageDays = packages
+      .filter((pkg) => pkg.topics.includes(topic.slug))
+      .map((pkg) => toUtcDay(pkg.createdAt));
+    return {
+      key: topic.slug,
+      label: topic.name,
+      points: sampleMonthly(
+        buildCumulativePoints(buildCountByDay(packageDays), startDay, endDay),
+      ),
+    };
+  });
+}
+
+function getReleaseDay(release: ReleaseModel): string {
+  return toUtcDay(release.createdAt || release.updatedAt);
+}
+
+function buildSignedPackageDays(releases: ReleaseModel[]): string[] {
+  const firstSignedDayByPackage = new Map<string, string>();
+  for (const release of releases) {
+    if (release.signed !== true) continue;
+    const day = getReleaseDay(release);
+    const existing = firstSignedDayByPackage.get(release.packageName);
+    if (!existing || day < existing) {
+      firstSignedDayByPackage.set(release.packageName, day);
+    }
+  }
+  return Array.from(firstSignedDayByPackage.values());
+}
+
+function buildActivePackageDays(releases: ReleaseModel[]): string[] {
+  const firstReleaseDayByPackage = new Map<string, string>();
+  for (const release of releases) {
+    if (release.state !== ReleaseState.Succeeded) continue;
+    const day = getReleaseDay(release);
+    const existing = firstReleaseDayByPackage.get(release.packageName);
+    if (!existing || day < existing) {
+      firstReleaseDayByPackage.set(release.packageName, day);
+    }
+  }
+  return Array.from(firstReleaseDayByPackage.values());
+}
+
+function buildReleaseSourceSeries(
+  packages: PackageMetadataLocal[],
+  startDay: string | null,
+  endDay: string | null,
+): TrendsSeries[] {
+  const gitDays = packages
+    .filter((pkg) => (pkg.trackingMode || 'git') === 'git')
+    .map((pkg) => toUtcDay(pkg.createdAt));
+  const githubReleaseDays = packages
+    .filter((pkg) => pkg.trackingMode === 'githubRelease')
+    .map((pkg) => toUtcDay(pkg.createdAt));
+  return [
+    {
+      key: 'githubReleaseAssets',
+      label: 'GitHub Release asset packages',
+      points: sampleMonthly(
+        buildCumulativePoints(
+          buildCountByDay(githubReleaseDays),
+          startDay,
+          endDay,
+        ),
+      ),
+    },
+    {
+      key: 'gitSource',
+      label: 'Git source packages',
+      points: sampleMonthly(
+        buildCumulativePoints(buildCountByDay(gitDays), startDay, endDay),
+      ),
+    },
+  ];
+}
+
+function buildReleaseMonthPoints(releases: ReleaseModel[]): TrendsPoint[] {
+  return buildMonthlyCounts(
+    releases
+      .filter((release) => release.state === ReleaseState.Succeeded)
+      .map(getReleaseDay),
+  );
+}
+
+function buildSucceededReleaseDays(releases: ReleaseModel[]): string[] {
+  return releases
+    .filter((release) => release.state === ReleaseState.Succeeded)
+    .map(getReleaseDay);
+}
+
+function countActivePackagesLast12Months(
+  releases: ReleaseModel[],
+  generatedAt: Date,
+): number {
+  const cutoff = new Date(generatedAt);
+  cutoff.setUTCFullYear(cutoff.getUTCFullYear() - 1);
+  const packages = new Set<string>();
+  for (const release of releases) {
+    if (release.state !== ReleaseState.Succeeded) continue;
+    const releaseTime = release.createdAt || release.updatedAt;
+    if (releaseTime >= cutoff.getTime()) packages.add(release.packageName);
+  }
+  return packages.size;
+}
+
+export function buildPublicTrends(input: {
+  generatedAt?: Date;
+  packages: PackageMetadataLocal[];
+  topics: TopicBase[];
+  releases: ReleaseModel[];
+  downloadRanges: PackageDownloadRange[];
+}): PublicTrends {
+  const generatedAt = input.generatedAt || new Date();
+  const packageDays = input.packages.map((pkg) => toUtcDay(pkg.createdAt));
+  const firstPackageDay = minDefinedDate(packageDays);
+  const lastPackageDay = maxDefinedDate(packageDays);
+  const signedPackageDays = buildSignedPackageDays(input.releases);
+  const activePackageDays = buildActivePackageDays(input.releases);
+  const signedPackagesByDay = sampleMonthly(
+    buildCumulativePoints(
+      buildCountByDay(signedPackageDays),
+      minDefinedDate([...packageDays, ...signedPackageDays]),
+      maxDefinedDate([...packageDays, ...signedPackageDays]),
+    ),
+  );
+  const downloadsByDay = sumDownloadsByDay(input.downloadRanges);
+  const downloadDays = Array.from(downloadsByDay.keys());
+  const firstDownloadDay = minDefinedDate(downloadDays);
+  const lastDownloadDay = maxDefinedDate(downloadDays);
+  const succeededReleaseDays = buildSucceededReleaseDays(input.releases);
+  const firstReleaseDay = minDefinedDate(succeededReleaseDays);
+  const lastReleaseDay = maxDefinedDate(succeededReleaseDays);
+
+  return {
+    generatedAt: generatedAt.toISOString(),
+    coverage: {
+      catalogGrowth: {
+        state: 'exact',
+        source: 'package metadata',
+        description:
+          'Package submission history is backfilled from package metadata createdAt fields.',
+        start: firstPackageDay || undefined,
+        end: lastPackageDay || undefined,
+      },
+      topicGrowth: {
+        state: 'estimated',
+        source: 'package metadata',
+        description:
+          'Topic history projects each package current topics back to its package submission date.',
+        start: firstPackageDay || undefined,
+        end: lastPackageDay || undefined,
+      },
+      trustAndDistribution: {
+        state: 'partial',
+        source: 'release records and package metadata',
+        description:
+          'Signed package counts use release records with signing metadata; older records may be unknown.',
+      },
+      downloads: {
+        state: 'exact',
+        source: 'daily package download history',
+        description:
+          'Download charts are calculated from per-package daily download history.',
+        start: firstDownloadDay || undefined,
+        end: lastDownloadDay || undefined,
+      },
+    },
+    catalogGrowth: {
+      totalPackageSubmissionsByDay: sampleMonthly(
+        buildCumulativePoints(
+          buildCountByDay(packageDays),
+          firstPackageDay,
+          lastPackageDay,
+        ),
+      ),
+      newPackageSubmissionsByMonth: buildMonthlyCounts(packageDays),
+      totalActivePackagesByDay: sampleMonthly(
+        buildCumulativePoints(
+          buildCountByDay(activePackageDays),
+          minDefinedDate([...packageDays, ...activePackageDays]),
+          maxDefinedDate([...packageDays, ...activePackageDays]),
+        ),
+      ),
+      packageSubmissionsByTopicByDay: buildTopicSeries(
+        input.topics,
+        input.packages,
+        firstPackageDay,
+        lastPackageDay,
+      ),
+    },
+    trustAndDistribution: {
+      signedPackagesByDay,
+      releaseSourceAndSigningByDay: buildReleaseSourceSeries(
+        input.packages,
+        firstPackageDay,
+        lastPackageDay,
+      ),
+    },
+    releaseActivity: {
+      activePackagesLast12Months: countActivePackagesLast12Months(
+        input.releases,
+        generatedAt,
+      ),
+      totalReleasesByTime: sampleMonthly(
+        buildCumulativePoints(
+          buildCountByDay(succeededReleaseDays),
+          firstReleaseDay,
+          lastReleaseDay,
+        ),
+      ),
+      releasesPerMonth: buildReleaseMonthPoints(input.releases),
+    },
+    downloads: {
+      totalDownloadsByTime: sampleMonthly(
+        buildCumulativePoints(
+          downloadsByDay,
+          firstDownloadDay,
+          lastDownloadDay,
+        ),
+      ),
+      downloadsPerMonth: buildDownloadMonthPoints(downloadsByDay),
+    },
+  };
+}

--- a/packages/@openupm/server-common/src/trends/sqliteStore.ts
+++ b/packages/@openupm/server-common/src/trends/sqliteStore.ts
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import { createRequire } from 'module';
+import path from 'path';
+import { DailyDownload } from '@openupm/types';
+
+import { PackageDownloadRange } from './aggregation.js';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
+
+export interface TrendsSqliteStore {
+  close: () => void;
+  getPackageNamesWithoutDownloads: (packageNames: string[]) => string[];
+  upsertPackageDownloads: (
+    packageName: string,
+    downloads: DailyDownload[],
+  ) => void;
+  getPackageDownloadRanges: (packageNames: string[]) => PackageDownloadRange[];
+}
+
+export function openTrendsSqliteStore(dbPath: string): TrendsSqliteStore {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA synchronous = NORMAL;
+    CREATE TABLE IF NOT EXISTS package_downloads (
+      package_name TEXT NOT NULL,
+      day TEXT NOT NULL,
+      downloads INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (package_name, day)
+    );
+    CREATE INDEX IF NOT EXISTS idx_package_downloads_day
+      ON package_downloads(day);
+  `);
+
+  const upsertPackageDownload = db.prepare(`
+    INSERT INTO package_downloads(package_name, day, downloads, updated_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(package_name, day) DO UPDATE SET
+      downloads = excluded.downloads,
+      updated_at = excluded.updated_at
+  `);
+
+  const selectPackageDownloads = db.prepare(`
+    SELECT day, downloads
+    FROM package_downloads
+    WHERE package_name = ?
+    ORDER BY day ASC
+  `);
+  const selectPackageDownloadCount = db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM package_downloads
+    WHERE package_name = ?
+  `);
+
+  return {
+    close: () => db.close(),
+    getPackageNamesWithoutDownloads: (packageNames: string[]): string[] =>
+      packageNames.filter((packageName) => {
+        const row = selectPackageDownloadCount.get(packageName) as {
+          count: number;
+        };
+        return row.count === 0;
+      }),
+    upsertPackageDownloads: (
+      packageName: string,
+      downloads: DailyDownload[],
+    ): void => {
+      const now = Date.now();
+      db.exec('BEGIN');
+      try {
+        for (const entry of downloads) {
+          upsertPackageDownload.run(
+            packageName,
+            entry.day,
+            Math.trunc(entry.downloads),
+            now,
+          );
+        }
+        db.exec('COMMIT');
+      } catch (err) {
+        db.exec('ROLLBACK');
+        throw err;
+      }
+    },
+    getPackageDownloadRanges: (
+      packageNames: string[],
+    ): PackageDownloadRange[] =>
+      packageNames.map((packageName) => ({
+        package: packageName,
+        downloads: selectPackageDownloads.all(packageName).map((entry) => {
+          const row = entry as { day: string; downloads: number };
+          return { day: row.day, downloads: row.downloads };
+        }),
+      })),
+  };
+}

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -171,6 +171,55 @@ export interface DownloadsRange {
   downloads: Array<DailyDownload>;
 }
 
+export type TrendsCoverageState =
+  | 'exact'
+  | 'estimated'
+  | 'partial'
+  | 'collectedFrom';
+
+export interface TrendsCoverage {
+  state: TrendsCoverageState;
+  source: string;
+  description: string;
+  start?: string;
+  end?: string;
+}
+
+export interface TrendsPoint {
+  date: string;
+  value: number;
+}
+
+export interface TrendsSeries {
+  key: string;
+  label: string;
+  points: TrendsPoint[];
+}
+
+export interface PublicTrends {
+  generatedAt: string;
+  coverage: Record<string, TrendsCoverage>;
+  catalogGrowth: {
+    totalPackageSubmissionsByDay: TrendsPoint[];
+    totalActivePackagesByDay: TrendsPoint[];
+    newPackageSubmissionsByMonth: TrendsPoint[];
+    packageSubmissionsByTopicByDay: TrendsSeries[];
+  };
+  trustAndDistribution: {
+    signedPackagesByDay: TrendsPoint[];
+    releaseSourceAndSigningByDay: TrendsSeries[];
+  };
+  releaseActivity: {
+    activePackagesLast12Months: number;
+    totalReleasesByTime: TrendsPoint[];
+    releasesPerMonth: TrendsPoint[];
+  };
+  downloads: {
+    totalDownloadsByTime: TrendsPoint[];
+    downloadsPerMonth: TrendsPoint[];
+  };
+}
+
 export interface TopicBase {
   name: string;
   slug: string;


### PR DESCRIPTION
## Summary
- add a public /trends API backed by a Redis latest snapshot and shared trends aggregation helpers
- add the jobs snapshot builder, manual backfill command, recent daily refresh path, and SQLite download fact persistence
- add a hidden VuePress /trends page with ECharts-based charts, timestamp snapshots, legends, and trend sections for catalog growth, signing/publishing, releases, and downloads

## Validation
- npm run lint
- npm run build
- npm --prefix apps/docs test -- __tests__/vue/trendsView.spec.ts
- npm --prefix packages/@openupm/server-common test -- __tests__/trends/aggregation.spec.ts __tests__/trends/sqliteStore.spec.ts
- npm --prefix apps/jobs test -- __tests__/jobs/buildTrendsSnapshot.spec.ts
- npm --prefix apps/web test -- __tests__/routers/trends.spec.ts
- npm --prefix packages/@openupm/common test -- __tests__/utils.spec.ts __tests__/urls.spec.ts
- npm --prefix apps/docs run docs:build:limit

Staged locally and reviewed.