### PR TITLE
Cap trends download backfill start date

### DIFF
--- a/apps/jobs/__tests__/jobs/buildTrendsSnapshot.spec.ts
+++ b/apps/jobs/__tests__/jobs/buildTrendsSnapshot.spec.ts
@@ -207,6 +207,42 @@ describe('buildTrendsSnapshotJob', () => {
     );
   });
 
+  it('caps full download backfill history to the OpenUPM era', async () => {
+    mockPackageMetadata();
+    loadPackageMetadataLocalMock.mockResolvedValueOnce({
+      name: 'com.example.pkg',
+      aliases: [],
+      repoUrl: 'https://github.com/example/pkg',
+      displayName: 'Pkg',
+      description: '',
+      licenseSpdxId: null,
+      licenseName: '',
+      topics: ['tools'],
+      hunter: '',
+      createdAt: Date.parse('1975-08-15T00:00:00.000Z') / 1000,
+      trackingMode: 'githubRelease',
+      repo: 'pkg',
+      owner: 'example',
+      ownerUrl: '',
+      parentRepo: null,
+      parentOwner: null,
+      parentOwnerUrl: null,
+      readmeBranch: 'main',
+      hunterUrl: null,
+    });
+    mockReleases();
+
+    const { buildTrendsSnapshotBackfillJob } = await import(
+      '../../src/jobs/buildTrendsSnapshot.js'
+    );
+    await buildTrendsSnapshotBackfillJob();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://package.openupm.com/downloads/range/2019-01-01:2026-06-11/com.example.pkg',
+      expect.any(Object),
+    );
+  });
+
   it('backfills full download history for packages missing stored downloads', async () => {
     mockPackageMetadata();
     mockReleases();
@@ -219,6 +255,43 @@ describe('buildTrendsSnapshotJob', () => {
 
     expect(fetch).toHaveBeenCalledWith(
       'https://package.openupm.com/downloads/range/2026-01-01:2026-06-11/com.example.pkg',
+      expect.any(Object),
+    );
+  });
+
+  it('caps missing package download backfills during recent refresh', async () => {
+    mockPackageMetadata();
+    loadPackageMetadataLocalMock.mockResolvedValueOnce({
+      name: 'com.example.pkg',
+      aliases: [],
+      repoUrl: 'https://github.com/example/pkg',
+      displayName: 'Pkg',
+      description: '',
+      licenseSpdxId: null,
+      licenseName: '',
+      topics: ['tools'],
+      hunter: '',
+      createdAt: Date.parse('1975-08-15T00:00:00.000Z') / 1000,
+      trackingMode: 'githubRelease',
+      repo: 'pkg',
+      owner: 'example',
+      ownerUrl: '',
+      parentRepo: null,
+      parentOwner: null,
+      parentOwnerUrl: null,
+      readmeBranch: 'main',
+      hunterUrl: null,
+    });
+    mockReleases();
+    getPackageNamesWithoutDownloadsMock.mockReturnValue(['com.example.pkg']);
+
+    const { buildTrendsSnapshotJob } = await import(
+      '../../src/jobs/buildTrendsSnapshot.js'
+    );
+    await buildTrendsSnapshotJob();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://package.openupm.com/downloads/range/2019-01-01:2026-06-11/com.example.pkg',
       expect.any(Object),
     );
   });

--- a/apps/jobs/src/jobs/buildTrendsSnapshot.ts
+++ b/apps/jobs/src/jobs/buildTrendsSnapshot.ts
@@ -27,6 +27,7 @@ import { openTrendsSqliteStore } from '@openupm/server-common/build/trends/sqlit
 const logger = createLogger('@openupm/jobs/buildTrendsSnapshot');
 const DOWNLOAD_FETCH_CONCURRENCY = 8;
 const DEFAULT_RECENT_REFRESH_LOOKBACK_DAYS = 14;
+const MIN_DOWNLOAD_HISTORY_DAY = '2019-01-01';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
 
@@ -205,9 +206,13 @@ function getDownloadStartDay(params: {
   options: BuildTrendsSnapshotOptions;
   today: string;
 }): string {
-  if (params.mode === 'full') return params.firstPackageDay;
+  const earliestDownloadDay = maxDay(
+    params.firstPackageDay,
+    MIN_DOWNLOAD_HISTORY_DAY,
+  );
+  if (params.mode === 'full') return earliestDownloadDay;
   const lookbackDays = getRecentRefreshLookbackDays(params.options);
-  return maxDay(params.firstPackageDay, addDays(params.today, -lookbackDays));
+  return maxDay(earliestDownloadDay, addDays(params.today, -lookbackDays));
 }
 
 export async function buildTrendsSnapshotJob(
@@ -267,6 +272,12 @@ export async function buildTrendsSnapshotJob(
           )
         : new Set(packageNamesForDownloads);
     fullDownloadBackfillPackages = packageNamesMissingDownloads.size;
+    const fullDownloadStartDay = getDownloadStartDay({
+      firstPackageDay,
+      mode: 'full',
+      options,
+      today,
+    });
     const recentDownloadStartDay = getDownloadStartDay({
       firstPackageDay,
       mode: 'recent',
@@ -281,7 +292,7 @@ export async function buildTrendsSnapshotJob(
           packageName,
           `${
             packageNamesMissingDownloads.has(packageName)
-              ? firstPackageDay
+              ? fullDownloadStartDay
               : recentDownloadStartDay
           }:${today}`,
         ),


### PR DESCRIPTION
## Summary
- cap trends download fetch ranges to the OpenUPM era so bad package metadata cannot request implausibly old history
- apply the same cap to full backfills and missing-package backfills during recent refresh
- cover the 1975 metadata case in focused job tests

## Validation
- npm run build
- npm --prefix apps/jobs test -- __tests__/jobs/buildTrendsSnapshot.spec.ts
- npm run lint