### PR TITLE
Add trends sidebar config

### DIFF
--- a/apps/docs/__tests__/seoContentLinks.spec.ts
+++ b/apps/docs/__tests__/seoContentLinks.spec.ts
@@ -17,6 +17,12 @@ describe("docs SEO content links", () => {
     expect(config).toContain("/docs/scoped-registry-troubleshooting");
   });
 
+  it("marks the trends page as a no-sidebar route", () => {
+    const config = readDocsFile(".vuepress/config-us.ts");
+
+    expect(config).toContain('"/trends/": false');
+  });
+
   it("links high-intent docs pages to scoped registry troubleshooting", () => {
     const linkedDocs = [
       "docs/index.md",

--- a/apps/docs/docs/.vuepress/config-us.ts
+++ b/apps/docs/docs/.vuepress/config-us.ts
@@ -226,6 +226,7 @@ export const themeConfig: any = {
     "/nuget/": docSideBar(),
     "/support/": docSideBar(),
     "/contributors/": docSideBar(),
+    "/trends/": false,
   },
 };
 


### PR DESCRIPTION
## Summary
- mark /trends/ as an explicit no-sidebar route in VuePress theme config
- add a regression test for the trends sidebar config

## Validation
- npm --prefix apps/docs test -- seoContentLinks.spec.ts
- npm run lint
- npm run docs:build:limit