### PR TITLE
Cap trend package metadata dates

### DIFF
--- a/packages/@openupm/server-common/__tests__/trends/aggregation.spec.ts
+++ b/packages/@openupm/server-common/__tests__/trends/aggregation.spec.ts
@@ -148,4 +148,49 @@ describe('trends aggregation', () => {
       { date: '2026-04', value: 17 },
     ]);
   });
+
+  it('caps impossible package metadata dates to the OpenUPM era', () => {
+    const trends = buildPublicTrends({
+      generatedAt: new Date('2026-06-11T00:00:00.000Z'),
+      topics: [{ slug: 'tools', name: 'Tools', keywords: [] }],
+      packages: [
+        {
+          name: 'com.example.legacy',
+          aliases: [],
+          repoUrl: 'https://github.com/example/legacy',
+          displayName: 'Legacy',
+          description: '',
+          licenseSpdxId: null,
+          licenseName: '',
+          topics: ['tools'],
+          hunter: '',
+          createdAt: Date.parse('1975-08-15T00:00:00.000Z') / 1000,
+          trackingMode: 'githubRelease',
+          repo: 'legacy',
+          owner: 'example',
+          ownerUrl: '',
+          parentRepo: null,
+          parentOwner: null,
+          parentOwnerUrl: null,
+          readmeBranch: 'main',
+          hunterUrl: null,
+        },
+      ],
+      releases: [],
+      downloadRanges: [],
+    });
+
+    expect(trends.coverage.catalogGrowth.start).toEqual('2019-01-01');
+    expect(trends.catalogGrowth.totalPackageSubmissionsByDay).toEqual([
+      { date: '2019-01', value: 1 },
+    ]);
+    expect(
+      trends.catalogGrowth.packageSubmissionsByTopicByDay[0].points,
+    ).toEqual([{ date: '2019-01', value: 1 }]);
+    expect(
+      trends.trustAndDistribution.releaseSourceAndSigningByDay
+        .find((series) => series.key === 'githubReleaseAssets')
+        ?.points,
+    ).toEqual([{ date: '2019-01', value: 1 }]);
+  });
 });

--- a/packages/@openupm/server-common/src/trends/aggregation.ts
+++ b/packages/@openupm/server-common/src/trends/aggregation.ts
@@ -10,6 +10,7 @@ import {
 import { ReleaseState } from '@openupm/types';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const MIN_PACKAGE_METADATA_DAY = '2019-01-01';
 
 export interface PackageDownloadRange {
   package: string;
@@ -22,6 +23,11 @@ function toTimestampMs(value: number): number {
 
 function toUtcDay(value: number): string {
   return new Date(toTimestampMs(value)).toISOString().substring(0, 10);
+}
+
+function toPackageMetadataDay(value: number): string {
+  const day = toUtcDay(value);
+  return day < MIN_PACKAGE_METADATA_DAY ? MIN_PACKAGE_METADATA_DAY : day;
 }
 
 function toUtcMonth(day: string): string {
@@ -160,7 +166,7 @@ function buildTopicSeries(
   return topics.map((topic) => {
     const packageDays = packages
       .filter((pkg) => pkg.topics.includes(topic.slug))
-      .map((pkg) => toUtcDay(pkg.createdAt));
+      .map((pkg) => toPackageMetadataDay(pkg.createdAt));
     return {
       key: topic.slug,
       label: topic.name,
@@ -208,10 +214,10 @@ function buildReleaseSourceSeries(
 ): TrendsSeries[] {
   const gitDays = packages
     .filter((pkg) => (pkg.trackingMode || 'git') === 'git')
-    .map((pkg) => toUtcDay(pkg.createdAt));
+    .map((pkg) => toPackageMetadataDay(pkg.createdAt));
   const githubReleaseDays = packages
     .filter((pkg) => pkg.trackingMode === 'githubRelease')
-    .map((pkg) => toUtcDay(pkg.createdAt));
+    .map((pkg) => toPackageMetadataDay(pkg.createdAt));
   return [
     {
       key: 'githubReleaseAssets',
@@ -271,7 +277,9 @@ export function buildPublicTrends(input: {
   downloadRanges: PackageDownloadRange[];
 }): PublicTrends {
   const generatedAt = input.generatedAt || new Date();
-  const packageDays = input.packages.map((pkg) => toUtcDay(pkg.createdAt));
+  const packageDays = input.packages.map((pkg) =>
+    toPackageMetadataDay(pkg.createdAt),
+  );
   const firstPackageDay = minDefinedDate(packageDays);
   const lastPackageDay = maxDefinedDate(packageDays);
   const signedPackageDays = buildSignedPackageDays(input.releases);


### PR DESCRIPTION
## Summary
- clamp package metadata dates before the OpenUPM public era when building trends series
- add regression coverage for catalog, topic, and publishing mode series

## Validation
- npm test -- --filter=@openupm/server-common -- aggregation.spec.ts
- npm run lint