### PR TITLE
Render trends dashboard client-only

### DIFF
--- a/apps/docs/docs/.vuepress/components/TrendsPageClient.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsPageClient.vue
@@ -1,0 +1,26 @@
+<template>
+  <TrendsPage v-if="mounted" />
+  <main v-else class="trends-page">
+    <header class="trends-page__header">
+      <div>
+        <div class="trends-page__title-row">
+          <h1>Trends</h1>
+        </div>
+        <p>Loading trends...</p>
+      </div>
+    </header>
+    <div class="trends-page__notice">Loading...</div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+
+import TrendsPage from "./TrendsPage.vue";
+
+const mounted = ref(false);
+
+onMounted(() => {
+  mounted.value = true;
+});
+</script>

--- a/apps/docs/docs/trends/index.md
+++ b/apps/docs/docs/trends/index.md
@@ -5,4 +5,4 @@ description: OpenUPM package, release, signing, and download trends.
 editLink: false
 ---
 
-<TrendsPage />
+<TrendsPageClient />


### PR DESCRIPTION
## Summary
- render the trends dashboard after mount so VuePress does not hydrate the async dashboard/chart subtree from static HTML
- keep the Trends loading shell in SSR and in the first client render, avoiding an empty `/trends/` content area before JavaScript mounts

## Validation
- npm run lint
- npm run test -- seoContentLinks.spec.ts
- npm run docs:build:limit