### PR TITLE
Improve trends charts and hydration

### DIFF
--- a/apps/docs/docs/.vuepress/components/GrowthNavbarMobile.vue
+++ b/apps/docs/docs/.vuepress/components/GrowthNavbarMobile.vue
@@ -1,22 +1,10 @@
 
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useI18n } from 'vue-i18n'
+import { RouteLink } from 'vuepress/client';
 
-import { capitalize } from "lodash-es";
 import { useDefaultStore } from '@/store';
 const store = useDefaultStore();
-const { t } = useI18n();
-
-const packagesLink = computed(() => {
-  return {
-    link: "/packages/",
-    text: capitalize(t("packages")),
-    icon: "fa fa-box-open",
-    iconLeft: true
-  }
-});
 </script>
 
 <template>
@@ -24,7 +12,10 @@ const packagesLink = computed(() => {
     <div class="columns">
       <div class="column col-12">
         <div class="btn-group">
-          <AutoLink :item="packagesLink" class="btn btn-default btn-sm" />
+          <RouteLink to="/packages/" class="auto-link btn btn-default btn-sm">
+            <i class="fa fa-box-open" aria-hidden="true"></i>
+            Packages
+          </RouteLink>
           <a href="https://github.com/openupm/openupm" rel="noopener noreferrer" class="btn btn-default btn-sm">
             <i class="fab fa-github"></i> Stars
             <span class="stars">{{ store.formattedStars }}</span>

--- a/apps/docs/docs/.vuepress/components/Navbar.vue
+++ b/apps/docs/docs/.vuepress/components/Navbar.vue
@@ -1,18 +1,10 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed } from 'vue';
+import { RouteLink } from 'vuepress/client';
 
 import ParentComponent from '@vuepress/theme-default/components/VPNavbar.vue';
 import MySearchBox from '@/components/MySearchBox';
 
-const packageAddLink = computed(() => {
-  return {
-    link: "/packages/add/",
-    text: "",
-    icon: "fas fa-plus-circle",
-    iconLeft: true
-  };
-});
 defineEmits<{ (e: 'toggle-sidebar'): void }>()
 </script>
 
@@ -22,7 +14,9 @@ defineEmits<{ (e: 'toggle-sidebar'): void }>()
       <MySearchBox />
       <div class="navbar-items vp-navbar-items can-hide mr-2">
         <div class="nav-item vp-navbar-item packages-add">
-          <AutoLink :item="packageAddLink" class="nav-link" />
+          <RouteLink to="/packages/add/" class="auto-link nav-link">
+            <i class="fas fa-plus-circle" aria-hidden="true"></i>
+          </RouteLink>
         </div>
       </div>
     </template>

--- a/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
@@ -1,30 +1,31 @@
 <template>
-  <ClientOnly>
-    <VChart
-      class="trends-echart"
-      :option="chartOption"
-      autoresize
-      @click="handleChartClick"
-    />
-  </ClientOnly>
+  <VChart
+    v-if="mounted"
+    class="trends-echart"
+    :option="chartOption"
+    autoresize
+    @click="handleChartClick"
+  />
+  <div v-else class="trends-echart"></div>
   <div v-if="selectedSnapshot" class="trends-chart__snapshot">
     <strong>{{ selectedSnapshot.date }}</strong>
-    <span :style="{ '--series-color': pickSeriesColor(0) }">
+    <span :style="{ '--series-color': seriesColor(0) }">
       {{ formatNumber(selectedSnapshot.value) }}
     </span>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { use } from "echarts/core";
 import { CanvasRenderer } from "echarts/renderers";
 import { BarChart } from "echarts/charts";
 import { GridComponent, TooltipComponent } from "echarts/components";
+import { useDarkMode } from "@vuepress/theme-default/client";
 import VChart from "vue-echarts";
 import { TrendsPoint } from "@openupm/types";
 
-import { formatNumber, pickSeriesColor } from "../trendsView";
+import { formatNumber, pickDarkSeriesColor, pickSeriesColor } from "../trendsView";
 
 use([CanvasRenderer, BarChart, GridComponent, TooltipComponent]);
 
@@ -33,12 +34,25 @@ const props = defineProps<{
 }>();
 
 const selectedDate = ref("");
+const mounted = ref(false);
+const isDarkMode = useDarkMode();
+
+onMounted(() => {
+  mounted.value = true;
+});
 
 const dates = computed(() => props.points.map((point) => point.date));
 
+function seriesColor(index: number): string {
+  return isDarkMode.value ? pickDarkSeriesColor(index) : pickSeriesColor(index);
+}
+
 const chartOption = computed(() => ({
   animation: false,
-  color: [pickSeriesColor(0)],
+  textStyle: {
+    color: isDarkMode.value ? "#cbd5e1" : "#475569",
+  },
+  color: [seriesColor(0)],
   grid: {
     left: 44,
     right: 18,
@@ -48,15 +62,27 @@ const chartOption = computed(() => ({
   tooltip: {
     trigger: "axis",
     axisPointer: { type: "shadow" },
+    backgroundColor: isDarkMode.value ? "#111827" : "#ffffff",
+    borderColor: isDarkMode.value ? "rgba(148, 163, 184, 0.32)" : "#d8dee8",
+    textStyle: {
+      color: isDarkMode.value ? "#e5e7eb" : "#1f2937",
+    },
     valueFormatter: (value: number): string => formatNumber(value),
   },
   xAxis: {
     type: "category",
     data: dates.value,
     axisLabel: {
-      color: "inherit",
+      color: isDarkMode.value ? "#f8fafc" : "#475569",
       hideOverlap: true,
       formatter: formatYearTick,
+    },
+    axisLine: {
+      lineStyle: {
+        color: isDarkMode.value
+          ? "rgba(148, 163, 184, 0.36)"
+          : "rgba(100, 116, 139, 0.32)",
+      },
     },
     axisTick: { show: false },
   },
@@ -64,11 +90,22 @@ const chartOption = computed(() => ({
     type: "value",
     minInterval: 1,
     axisLabel: {
-      color: "inherit",
+      color: isDarkMode.value ? "#f8fafc" : "#475569",
       formatter: (value: number): string => formatNumber(value),
     },
+    axisLine: {
+      lineStyle: {
+        color: isDarkMode.value
+          ? "rgba(148, 163, 184, 0.36)"
+          : "rgba(100, 116, 139, 0.32)",
+      },
+    },
     splitLine: {
-      lineStyle: { color: "rgba(148, 163, 184, 0.18)" },
+      lineStyle: {
+        color: isDarkMode.value
+          ? "rgba(148, 163, 184, 0.2)"
+          : "rgba(148, 163, 184, 0.18)",
+      },
     },
   },
   series: [

--- a/apps/docs/docs/.vuepress/components/TrendsLineChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsLineChart.vue
@@ -1,20 +1,28 @@
 <template>
-  <ClientOnly>
-    <VChart
-      class="trends-echart"
-      :option="chartOption"
-      autoresize
-      @click="handleChartClick"
-      @mouseover="handleChartHover"
-      @mouseout="clearChartHover"
-    />
-  </ClientOnly>
+  <VChart
+    v-if="mounted"
+    class="trends-echart"
+    :option="chartOption"
+    autoresize
+    @click="handleChartClick"
+    @mouseover="handleChartHover"
+    @mouseout="clearChartHover"
+  />
+  <div v-else class="trends-echart"></div>
   <div v-if="series.length > 1" class="trends-chart__legend">
     <span
       v-for="(entry, index) in series"
       :key="entry.key"
-      :class="{ 'is-active': entry.label === hoveredSeriesName }"
-      :style="{ '--series-color': pickSeriesColor(index) }"
+      role="button"
+      tabindex="0"
+      :class="{
+        'is-active': entry.label === hoveredSeriesName,
+        'is-isolated': entry.key === isolatedSeriesKey,
+      }"
+      :style="{ '--series-color': seriesColor(index) }"
+      @click="toggleIsolatedSeries(entry.key)"
+      @keydown.enter.prevent="toggleIsolatedSeries(entry.key)"
+      @keydown.space.prevent="toggleIsolatedSeries(entry.key)"
     >
       {{ entry.label }}
     </span>
@@ -32,15 +40,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { use } from "echarts/core";
 import { CanvasRenderer } from "echarts/renderers";
 import { LineChart } from "echarts/charts";
 import { GridComponent, TooltipComponent } from "echarts/components";
+import { useDarkMode } from "@vuepress/theme-default/client";
 import VChart from "vue-echarts";
 import { TrendsSeries } from "@openupm/types";
 
-import { formatNumber, pickSeriesColor } from "../trendsView";
+import { formatNumber, pickDarkSeriesColor, pickSeriesColor } from "../trendsView";
 
 use([CanvasRenderer, LineChart, GridComponent, TooltipComponent]);
 
@@ -50,18 +59,54 @@ const props = defineProps<{
 
 const selectedDate = ref("");
 const hoveredSeriesName = ref("");
+const isolatedSeriesKey = ref("");
+const mounted = ref(false);
+const isDarkMode = useDarkMode();
+
+onMounted(() => {
+  mounted.value = true;
+});
+
+watch(
+  () => props.series,
+  (series) => {
+    if (
+      isolatedSeriesKey.value &&
+      !series.some((entry) => entry.key === isolatedSeriesKey.value)
+    ) {
+      isolatedSeriesKey.value = "";
+    }
+  },
+);
+
+const visibleSeries = computed(() =>
+  isolatedSeriesKey.value
+    ? props.series.filter((entry) => entry.key === isolatedSeriesKey.value)
+    : props.series,
+);
+
+function seriesColor(index: number): string {
+  return isDarkMode.value ? pickDarkSeriesColor(index) : pickSeriesColor(index);
+}
 
 const allDates = computed(() =>
   Array.from(
     new Set(
-      props.series.flatMap((entry) => entry.points.map((point) => point.date)),
+      visibleSeries.value.flatMap((entry) =>
+        entry.points.map((point) => point.date),
+      ),
     ),
   ).sort((a, b) => a.localeCompare(b)),
 );
 
 const chartOption = computed(() => ({
   animation: false,
-  color: props.series.map((_, index) => pickSeriesColor(index)),
+  textStyle: {
+    color: isDarkMode.value ? "#cbd5e1" : "#475569",
+  },
+  color: visibleSeries.value.map((entry) =>
+    seriesColor(props.series.findIndex((series) => series.key === entry.key)),
+  ),
   grid: {
     left: 44,
     right: 18,
@@ -71,6 +116,11 @@ const chartOption = computed(() => ({
   tooltip: {
     trigger: "axis",
     axisPointer: { type: "line" },
+    backgroundColor: isDarkMode.value ? "#111827" : "#ffffff",
+    borderColor: isDarkMode.value ? "rgba(148, 163, 184, 0.32)" : "#d8dee8",
+    textStyle: {
+      color: isDarkMode.value ? "#e5e7eb" : "#1f2937",
+    },
     valueFormatter: (value: number): string => formatNumber(value),
   },
   xAxis: {
@@ -78,9 +128,16 @@ const chartOption = computed(() => ({
     boundaryGap: false,
     data: allDates.value,
     axisLabel: {
-      color: "inherit",
+      color: isDarkMode.value ? "#f8fafc" : "#475569",
       hideOverlap: true,
       formatter: formatYearTick,
+    },
+    axisLine: {
+      lineStyle: {
+        color: isDarkMode.value
+          ? "rgba(148, 163, 184, 0.36)"
+          : "rgba(100, 116, 139, 0.32)",
+      },
     },
     axisTick: { show: false },
   },
@@ -88,14 +145,25 @@ const chartOption = computed(() => ({
     type: "value",
     minInterval: 1,
     axisLabel: {
-      color: "inherit",
+      color: isDarkMode.value ? "#f8fafc" : "#475569",
       formatter: (value: number): string => formatNumber(value),
     },
+    axisLine: {
+      lineStyle: {
+        color: isDarkMode.value
+          ? "rgba(148, 163, 184, 0.36)"
+          : "rgba(100, 116, 139, 0.32)",
+      },
+    },
     splitLine: {
-      lineStyle: { color: "rgba(148, 163, 184, 0.18)" },
+      lineStyle: {
+        color: isDarkMode.value
+          ? "rgba(148, 163, 184, 0.2)"
+          : "rgba(148, 163, 184, 0.18)",
+      },
     },
   },
-  series: props.series.map((entry) => {
+  series: visibleSeries.value.map((entry) => {
     const values = new Map(
       entry.points.map((point) => [point.date, point.value]),
     );
@@ -122,13 +190,15 @@ const selectedSnapshot = computed(() =>
   selectedDate.value
     ? {
         date: selectedDate.value,
-        values: props.series.map((entry, index) => ({
+        values: visibleSeries.value.map((entry) => ({
           key: entry.key,
           label: entry.label,
           value:
             entry.points.find((point) => point.date === selectedDate.value)
               ?.value || 0,
-          color: pickSeriesColor(index),
+          color: seriesColor(
+            props.series.findIndex((series) => series.key === entry.key),
+          ),
         })),
       }
     : null,
@@ -145,5 +215,9 @@ function handleChartHover(params: { seriesName?: string }): void {
 
 function clearChartHover(): void {
   hoveredSeriesName.value = "";
+}
+
+function toggleIsolatedSeries(key: string): void {
+  isolatedSeriesKey.value = isolatedSeriesKey.value === key ? "" : key;
 }
 </script>

--- a/apps/docs/docs/.vuepress/components/TrendsPage.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsPage.vue
@@ -66,7 +66,10 @@
           <div class="trends-chart__title">
             <div>
               <h3>Total active packages</h3>
-              <p>Packages with at least one successful published release.</p>
+              <p>
+                Packages with at least one successful published release in the
+                last 12 months.
+              </p>
             </div>
             <strong>{{
               formatNumber(
@@ -106,6 +109,13 @@
             />
           </div>
           <TrendsLineChart :series="visibleTopicSeries" />
+        </article>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>New packages per month by topic</h3>
+          </div>
+          <TrendsLineChart :series="visibleMonthlyTopicSeries" />
         </article>
       </section>
 
@@ -220,6 +230,13 @@
           </div>
           <TrendsBarChart :points="trends.downloads.downloadsPerMonth" />
         </article>
+
+        <article class="trends-chart">
+          <div class="trends-chart__title">
+            <h3>Downloads per month by topic</h3>
+          </div>
+          <TrendsLineChart :series="visibleMonthlyDownloadTopicSeries" />
+        </article>
       </section>
     </template>
   </main>
@@ -255,6 +272,24 @@ const visibleTopicSeries = computed(() =>
   trends.value
     ? filterSeries(
         trends.value.catalogGrowth.packageSubmissionsByTopicByDay,
+        topicQuery.value,
+      )
+    : [],
+);
+
+const visibleMonthlyTopicSeries = computed(() =>
+  trends.value
+    ? filterSeries(
+        trends.value.catalogGrowth.packageSubmissionsByTopicByMonth || [],
+        topicQuery.value,
+      )
+    : [],
+);
+
+const visibleMonthlyDownloadTopicSeries = computed(() =>
+  trends.value
+    ? filterSeries(
+        trends.value.downloads.downloadsPerMonthByTopic || [],
         topicQuery.value,
       )
     : [],
@@ -504,6 +539,7 @@ onMounted(() => {
     border: 1px solid transparent;
     border-radius: 999px;
     padding: 0.08rem 0.22rem;
+    cursor: pointer;
     opacity: 0.72;
     transition:
       background-color 0.12s ease,
@@ -511,9 +547,15 @@ onMounted(() => {
       color 0.12s ease,
       opacity 0.12s ease,
       font-weight 0.12s ease;
+
+    &:focus-visible {
+      outline: 2px solid var(--series-color);
+      outline-offset: 2px;
+    }
   }
 
-  span.is-active {
+  span.is-active,
+  span.is-isolated {
     border-color: color-mix(in srgb, var(--series-color) 46%, transparent);
     background: color-mix(in srgb, var(--series-color) 16%, transparent);
     color: var(--c-text);
@@ -595,18 +637,18 @@ onMounted(() => {
 
 :is(.dark, [data-theme="dark"]) {
   .trends-chart {
-    border-color: var(--c-border);
-    background: var(--c-bg-light);
+    border-color: color-mix(in srgb, var(--c-border) 78%, #334155);
+    background: linear-gradient(180deg, #1f2937 0%, var(--c-bg-light) 100%);
   }
 
   .trends-echart {
     background: linear-gradient(
         to bottom,
-        rgba(148, 163, 184, 0.12) 1px,
+        rgba(148, 163, 184, 0.16) 1px,
         transparent 1px
       ),
-      linear-gradient(to right, rgba(148, 163, 184, 0.08) 1px, transparent 1px),
-      var(--c-bg);
+      linear-gradient(to right, rgba(148, 163, 184, 0.1) 1px, transparent 1px),
+      linear-gradient(180deg, rgba(15, 23, 42, 0.84), rgba(17, 24, 39, 0.72));
     background-size:
       100% 25%,
       12.5% 100%,

--- a/apps/docs/docs/.vuepress/components/UnityAiTrialAd.vue
+++ b/apps/docs/docs/.vuepress/components/UnityAiTrialAd.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 const unityAiTrialUrl = "https://unity.com/features/ai?aid=1011lJJH";
 const campaignEnd = new Date("2026-07-01T00:00:00");
@@ -8,19 +8,28 @@ const props = defineProps<{
   variant: "navbar";
 }>();
 
+const mounted = ref(false);
 const isActive = computed(() => new Date() < campaignEnd);
+
+onMounted(() => {
+  window.setTimeout(() => {
+    mounted.value = true;
+  }, 0);
+});
 </script>
 
 <template>
-  <a
-    v-if="isActive"
-    :href="unityAiTrialUrl"
-    :class="['unity-ai-trial-ad', `unity-ai-trial-ad-${props.variant}`]"
-    rel="noopener nofollow"
-    target="_blank"
-  >
-    <span class="unity-ai-trial-ad-copy">Try Unity AI FREE ✨</span>
-  </a>
+  <span class="unity-ai-trial-ad-slot">
+    <a
+      v-if="mounted && isActive"
+      :href="unityAiTrialUrl"
+      :class="['unity-ai-trial-ad', `unity-ai-trial-ad-${props.variant}`]"
+      rel="noopener nofollow"
+      target="_blank"
+    >
+      <span class="unity-ai-trial-ad-copy">Try Unity AI FREE ✨</span>
+    </a>
+  </span>
 </template>
 
 <style lang="scss" scoped>
@@ -38,6 +47,10 @@ const isActive = computed(() => new Date() < campaignEnd);
     color: $primary-color;
     text-decoration: none;
   }
+}
+
+.unity-ai-trial-ad-slot {
+  display: inline-flex;
 }
 
 .unity-ai-trial-ad-navbar {

--- a/apps/docs/docs/.vuepress/layouts/Layout.vue
+++ b/apps/docs/docs/.vuepress/layouts/Layout.vue
@@ -49,9 +49,7 @@ const parentLayoutClass = computed(() => [
   </ParentLayout>
 
   <Footer v-if="showFooter" />
-  <ClientOnly>
-    <CookieConsent />
-  </ClientOnly>
+  <CookieConsent />
 </template>
 
 <style lang="scss">

--- a/apps/docs/docs/.vuepress/theme/NavbarBrand.vue
+++ b/apps/docs/docs/.vuepress/theme/NavbarBrand.vue
@@ -57,9 +57,7 @@ const NavbarBrandLogo: FunctionalComponent = () => {
         {{ navbarBrandTitle }}
       </span>
     </RouteLink>
-    <ClientOnly>
-      <UnityAiTrialAd variant="navbar" />
-    </ClientOnly>
+    <UnityAiTrialAd variant="navbar" />
   </div>
 </template>
 

--- a/apps/docs/docs/.vuepress/trendsView.ts
+++ b/apps/docs/docs/.vuepress/trendsView.ts
@@ -36,6 +36,20 @@ export function pickSeriesColor(index: number): string {
   return colors[index % colors.length];
 }
 
+export function pickDarkSeriesColor(index: number): string {
+  const colors = [
+    "#22d3ee",
+    "#facc15",
+    "#a78bfa",
+    "#4ade80",
+    "#fb7185",
+    "#818cf8",
+    "#f472b6",
+    "#34d399",
+  ];
+  return colors[index % colors.length];
+}
+
 export function filterSeries(
   series: TrendsSeries[],
   query: string,

--- a/apps/jobs/__tests__/jobs/buildTrendsSnapshot.spec.ts
+++ b/apps/jobs/__tests__/jobs/buildTrendsSnapshot.spec.ts
@@ -156,7 +156,14 @@ describe('buildTrendsSnapshotJob', () => {
     expect(setPublicTrendsMock.mock.calls[0][0]).toMatchObject({
       catalogGrowth: {
         totalPackageSubmissionsByDay: [{ date: '2026-01', value: 1 }],
-        totalActivePackagesByDay: [{ date: '2026-01', value: 1 }],
+        totalActivePackagesByDay: [
+          { date: '2026-01', value: 1 },
+          { date: '2026-02', value: 1 },
+          { date: '2026-03', value: 1 },
+          { date: '2026-04', value: 1 },
+          { date: '2026-05', value: 1 },
+          { date: '2026-06', value: 1 },
+        ],
       },
       releaseActivity: {
         activePackagesLast12Months: 1,
@@ -321,7 +328,14 @@ describe('buildTrendsSnapshotJob', () => {
 
     expect(setPublicTrendsMock.mock.calls[0][0]).toMatchObject({
       catalogGrowth: {
-        totalActivePackagesByDay: [{ date: '2026-01', value: 1 }],
+        totalActivePackagesByDay: [
+          { date: '2026-01', value: 1 },
+          { date: '2026-02', value: 1 },
+          { date: '2026-03', value: 1 },
+          { date: '2026-04', value: 1 },
+          { date: '2026-05', value: 1 },
+          { date: '2026-06', value: 1 },
+        ],
       },
       releaseActivity: {
         totalReleasesByTime: [

--- a/apps/web/__tests__/routers/trends.spec.ts
+++ b/apps/web/__tests__/routers/trends.spec.ts
@@ -54,6 +54,7 @@ describe('trends router', () => {
         totalActivePackagesByDay: [],
         newPackageSubmissionsByMonth: [],
         packageSubmissionsByTopicByDay: [],
+        packageSubmissionsByTopicByMonth: [],
       },
       trustAndDistribution: {
         signedPackagesByDay: [],
@@ -67,6 +68,7 @@ describe('trends router', () => {
       downloads: {
         totalDownloadsByTime: [],
         downloadsPerMonth: [],
+        downloadsPerMonthByTopic: [],
       },
     });
 

--- a/packages/@openupm/server-common/__tests__/trends/aggregation.spec.ts
+++ b/packages/@openupm/server-common/__tests__/trends/aggregation.spec.ts
@@ -108,16 +108,33 @@ describe('trends aggregation', () => {
       value: 2,
     });
     expect(trends.catalogGrowth.totalActivePackagesByDay).toEqual([
-      { date: '2026-01', value: 0 },
       { date: '2026-02', value: 1 },
       { date: '2026-03', value: 1 },
       { date: '2026-04', value: 2 },
+      { date: '2026-05', value: 2 },
+      { date: '2026-06', value: 2 },
     ]);
     expect(
       trends.catalogGrowth.packageSubmissionsByTopicByDay
         .find((series) => series.key === 'tools')
         ?.points.at(-1),
     ).toEqual({ date: '2026-02', value: 2 });
+    expect(
+      trends.catalogGrowth.packageSubmissionsByTopicByMonth.find(
+        (series) => series.key === 'tools',
+      )?.points,
+    ).toEqual([
+      { date: '2026-01', value: 1 },
+      { date: '2026-02', value: 1 },
+    ]);
+    expect(
+      trends.catalogGrowth.packageSubmissionsByTopicByMonth.find(
+        (series) => series.key === 'ai',
+      )?.points,
+    ).toEqual([
+      { date: '2026-01', value: 0 },
+      { date: '2026-02', value: 1 },
+    ]);
     expect(trends.trustAndDistribution.signedPackagesByDay.at(-1)).toEqual({
       date: '2026-02',
       value: 1,
@@ -146,6 +163,24 @@ describe('trends aggregation', () => {
       { date: '2026-02', value: 32 },
       { date: '2026-03', value: 0 },
       { date: '2026-04', value: 17 },
+    ]);
+    expect(
+      trends.downloads.downloadsPerMonthByTopic.find(
+        (series) => series.key === 'tools',
+      )?.points,
+    ).toEqual([
+      { date: '2026-02', value: 32 },
+      { date: '2026-03', value: 0 },
+      { date: '2026-04', value: 17 },
+    ]);
+    expect(
+      trends.downloads.downloadsPerMonthByTopic.find(
+        (series) => series.key === 'ai',
+      )?.points,
+    ).toEqual([
+      { date: '2026-02', value: 24 },
+      { date: '2026-03', value: 0 },
+      { date: '2026-04', value: 0 },
     ]);
   });
 
@@ -188,9 +223,67 @@ describe('trends aggregation', () => {
       trends.catalogGrowth.packageSubmissionsByTopicByDay[0].points,
     ).toEqual([{ date: '2019-01', value: 1 }]);
     expect(
+      trends.catalogGrowth.packageSubmissionsByTopicByMonth[0].points,
+    ).toEqual([{ date: '2019-01', value: 1 }]);
+    expect(
       trends.trustAndDistribution.releaseSourceAndSigningByDay
         .find((series) => series.key === 'githubReleaseAssets')
-        ?.points,
+      ?.points,
     ).toEqual([{ date: '2019-01', value: 1 }]);
+  });
+
+  it('counts active packages with a day-accurate 12 month cutoff', () => {
+    const trends = buildPublicTrends({
+      generatedAt: new Date('2026-06-11T00:00:00.000Z'),
+      topics: [],
+      packages: [],
+      releases: [
+        {
+          packageName: 'com.example.expired',
+          version: '1.0.0',
+          commit: '',
+          tag: '1.0.0',
+          state: ReleaseState.Succeeded,
+          buildId: '',
+          reason: 0,
+          createdAt: Date.parse('2025-06-10T00:00:00.000Z'),
+          updatedAt: Date.parse('2025-06-10T00:00:00.000Z'),
+          source: 'git',
+          signed: false,
+        },
+        {
+          packageName: 'com.example.cutoff',
+          version: '1.0.0',
+          commit: '',
+          tag: '1.0.0',
+          state: ReleaseState.Succeeded,
+          buildId: '',
+          reason: 0,
+          createdAt: Date.parse('2025-06-12T00:00:00.000Z'),
+          updatedAt: Date.parse('2025-06-12T00:00:00.000Z'),
+          source: 'git',
+          signed: false,
+        },
+        {
+          packageName: 'com.example.current',
+          version: '1.0.0',
+          commit: '',
+          tag: '1.0.0',
+          state: ReleaseState.Succeeded,
+          buildId: '',
+          reason: 0,
+          createdAt: Date.parse('2026-06-01T00:00:00.000Z'),
+          updatedAt: Date.parse('2026-06-01T00:00:00.000Z'),
+          source: 'git',
+          signed: false,
+        },
+      ],
+      downloadRanges: [],
+    });
+
+    expect(trends.catalogGrowth.totalActivePackagesByDay.at(-1)).toEqual({
+      date: '2026-06',
+      value: 2,
+    });
   });
 });

--- a/packages/@openupm/server-common/src/trends/aggregation.ts
+++ b/packages/@openupm/server-common/src/trends/aggregation.ts
@@ -44,12 +44,33 @@ function addMonths(month: string, months: number): string {
   return date.toISOString().substring(0, 7);
 }
 
+function addMonthsToDay(day: string, months: number): string {
+  const year = Number(day.substring(0, 4));
+  const monthIndex = Number(day.substring(5, 7)) - 1;
+  const dayOfMonth = Number(day.substring(8, 10));
+  const targetMonthStart = new Date(Date.UTC(year, monthIndex + months, 1));
+  const targetYear = targetMonthStart.getUTCFullYear();
+  const targetMonthIndex = targetMonthStart.getUTCMonth();
+  const lastTargetDay = new Date(
+    Date.UTC(targetYear, targetMonthIndex + 1, 0),
+  ).getUTCDate();
+  return new Date(
+    Date.UTC(targetYear, targetMonthIndex, Math.min(dayOfMonth, lastTargetDay)),
+  )
+    .toISOString()
+    .substring(0, 10);
+}
+
 function parseDay(day: string): number {
   return Date.parse(`${day}T00:00:00.000Z`);
 }
 
 function addDays(day: string, days: number): string {
   return toUtcDay(parseDay(day) + days * DAY_MS);
+}
+
+function getMonthEndDay(month: string): string {
+  return addDays(`${addMonths(month, 1)}-01`, -1);
 }
 
 function compareDate(a: string, b: string): number {
@@ -113,9 +134,22 @@ function fillMonthlyPoints(
   mode: 'zero' | 'carry',
 ): TrendsPoint[] {
   if (points.length === 0) return [];
+  return fillMonthlyPointsInRange(
+    points,
+    mode,
+    points[0].date,
+    points[points.length - 1].date,
+  );
+}
+
+function fillMonthlyPointsInRange(
+  points: TrendsPoint[],
+  mode: 'zero' | 'carry',
+  startMonth: string | null,
+  endMonth: string | null,
+): TrendsPoint[] {
+  if (!startMonth || !endMonth) return [];
   const values = new Map(points.map((point) => [point.date, point.value]));
-  const startMonth = points[0].date;
-  const endMonth = points[points.length - 1].date;
   const filled: TrendsPoint[] = [];
   let carriedValue = 0;
   for (let month = startMonth; month <= endMonth; month = addMonths(month, 1)) {
@@ -126,6 +160,19 @@ function fillMonthlyPoints(
     });
   }
   return filled;
+}
+
+function buildMonthlyCountsInRange(
+  days: string[],
+  startMonth: string | null,
+  endMonth: string | null,
+): TrendsPoint[] {
+  return fillMonthlyPointsInRange(
+    buildMonthlyCounts(days),
+    'zero',
+    startMonth,
+    endMonth,
+  );
 }
 
 function sumDownloadsByDay(
@@ -157,6 +204,19 @@ function buildDownloadMonthPoints(
   return fillMonthlyPoints(mapToSortedPoints(counts), 'zero');
 }
 
+function buildDownloadMonthPointsInRange(
+  downloadsByDay: Map<string, number>,
+  startMonth: string | null,
+  endMonth: string | null,
+): TrendsPoint[] {
+  return fillMonthlyPointsInRange(
+    buildDownloadMonthPoints(downloadsByDay),
+    'zero',
+    startMonth,
+    endMonth,
+  );
+}
+
 function buildTopicSeries(
   topics: TopicBase[],
   packages: PackageMetadataLocal[],
@@ -172,6 +232,53 @@ function buildTopicSeries(
       label: topic.name,
       points: sampleMonthly(
         buildCumulativePoints(buildCountByDay(packageDays), startDay, endDay),
+      ),
+    };
+  });
+}
+
+function buildTopicMonthlyPackageSeries(
+  topics: TopicBase[],
+  packages: PackageMetadataLocal[],
+  startMonth: string | null,
+  endMonth: string | null,
+): TrendsSeries[] {
+  return topics.map((topic) => ({
+    key: topic.slug,
+    label: topic.name,
+    points: buildMonthlyCountsInRange(
+      packages
+        .filter((pkg) => pkg.topics.includes(topic.slug))
+        .map((pkg) => toPackageMetadataDay(pkg.createdAt)),
+      startMonth,
+      endMonth,
+    ),
+  }));
+}
+
+function buildTopicMonthlyDownloadSeries(
+  topics: TopicBase[],
+  packages: PackageMetadataLocal[],
+  downloadRanges: PackageDownloadRange[],
+  startMonth: string | null,
+  endMonth: string | null,
+): TrendsSeries[] {
+  const topicsByPackage = new Map(
+    packages.map((pkg) => [pkg.name, new Set(pkg.topics)]),
+  );
+  return topics.map((topic) => {
+    const downloadsByDay = sumDownloadsByDay(
+      downloadRanges.filter((range) =>
+        topicsByPackage.get(range.package)?.has(topic.slug),
+      ),
+    );
+    return {
+      key: topic.slug,
+      label: topic.name,
+      points: buildDownloadMonthPointsInRange(
+        downloadsByDay,
+        startMonth,
+        endMonth,
       ),
     };
   });
@@ -194,17 +301,45 @@ function buildSignedPackageDays(releases: ReleaseModel[]): string[] {
   return Array.from(firstSignedDayByPackage.values());
 }
 
-function buildActivePackageDays(releases: ReleaseModel[]): string[] {
-  const firstReleaseDayByPackage = new Map<string, string>();
+function buildRollingActivePackageMonthPoints(
+  releases: ReleaseModel[],
+  endDay: string,
+): TrendsPoint[] {
+  const releaseDaysByPackage = new Map<string, string[]>();
   for (const release of releases) {
     if (release.state !== ReleaseState.Succeeded) continue;
-    const day = getReleaseDay(release);
-    const existing = firstReleaseDayByPackage.get(release.packageName);
-    if (!existing || day < existing) {
-      firstReleaseDayByPackage.set(release.packageName, day);
-    }
+    const days = releaseDaysByPackage.get(release.packageName) || [];
+    days.push(getReleaseDay(release));
+    releaseDaysByPackage.set(release.packageName, days);
   }
-  return Array.from(firstReleaseDayByPackage.values());
+  for (const days of releaseDaysByPackage.values()) {
+    days.sort(compareDate);
+  }
+  const firstReleaseDay = minDefinedDate(
+    Array.from(releaseDaysByPackage.values()).flat(),
+  );
+  if (!firstReleaseDay) return [];
+
+  const endMonth = toUtcMonth(endDay);
+  const points: TrendsPoint[] = [];
+  for (
+    let month = toUtcMonth(firstReleaseDay);
+    month <= endMonth;
+    month = addMonths(month, 1)
+  ) {
+    const windowEndDay = month === endMonth ? endDay : getMonthEndDay(month);
+    const windowStartDay = addMonthsToDay(windowEndDay, -12);
+    let value = 0;
+    for (const days of releaseDaysByPackage.values()) {
+      if (
+        days.some((day) => day >= windowStartDay && day <= windowEndDay)
+      ) {
+        value += 1;
+      }
+    }
+    points.push({ date: month, value });
+  }
+  return points;
 }
 
 function buildReleaseSourceSeries(
@@ -282,8 +417,11 @@ export function buildPublicTrends(input: {
   );
   const firstPackageDay = minDefinedDate(packageDays);
   const lastPackageDay = maxDefinedDate(packageDays);
+  const firstPackageMonth = firstPackageDay
+    ? toUtcMonth(firstPackageDay)
+    : null;
+  const lastPackageMonth = lastPackageDay ? toUtcMonth(lastPackageDay) : null;
   const signedPackageDays = buildSignedPackageDays(input.releases);
-  const activePackageDays = buildActivePackageDays(input.releases);
   const signedPackagesByDay = sampleMonthly(
     buildCumulativePoints(
       buildCountByDay(signedPackageDays),
@@ -295,6 +433,10 @@ export function buildPublicTrends(input: {
   const downloadDays = Array.from(downloadsByDay.keys());
   const firstDownloadDay = minDefinedDate(downloadDays);
   const lastDownloadDay = maxDefinedDate(downloadDays);
+  const firstDownloadMonth = firstDownloadDay
+    ? toUtcMonth(firstDownloadDay)
+    : null;
+  const lastDownloadMonth = lastDownloadDay ? toUtcMonth(lastDownloadDay) : null;
   const succeededReleaseDays = buildSucceededReleaseDays(input.releases);
   const firstReleaseDay = minDefinedDate(succeededReleaseDays);
   const lastReleaseDay = maxDefinedDate(succeededReleaseDays);
@@ -343,10 +485,9 @@ export function buildPublicTrends(input: {
       ),
       newPackageSubmissionsByMonth: buildMonthlyCounts(packageDays),
       totalActivePackagesByDay: sampleMonthly(
-        buildCumulativePoints(
-          buildCountByDay(activePackageDays),
-          minDefinedDate([...packageDays, ...activePackageDays]),
-          maxDefinedDate([...packageDays, ...activePackageDays]),
+        buildRollingActivePackageMonthPoints(
+          input.releases,
+          toUtcDay(generatedAt.getTime()),
         ),
       ),
       packageSubmissionsByTopicByDay: buildTopicSeries(
@@ -354,6 +495,12 @@ export function buildPublicTrends(input: {
         input.packages,
         firstPackageDay,
         lastPackageDay,
+      ),
+      packageSubmissionsByTopicByMonth: buildTopicMonthlyPackageSeries(
+        input.topics,
+        input.packages,
+        firstPackageMonth,
+        lastPackageMonth,
       ),
     },
     trustAndDistribution: {
@@ -387,6 +534,13 @@ export function buildPublicTrends(input: {
         ),
       ),
       downloadsPerMonth: buildDownloadMonthPoints(downloadsByDay),
+      downloadsPerMonthByTopic: buildTopicMonthlyDownloadSeries(
+        input.topics,
+        input.packages,
+        input.downloadRanges,
+        firstDownloadMonth,
+        lastDownloadMonth,
+      ),
     },
   };
 }

--- a/packages/@openupm/types/src/types.ts
+++ b/packages/@openupm/types/src/types.ts
@@ -204,6 +204,7 @@ export interface PublicTrends {
     totalActivePackagesByDay: TrendsPoint[];
     newPackageSubmissionsByMonth: TrendsPoint[];
     packageSubmissionsByTopicByDay: TrendsSeries[];
+    packageSubmissionsByTopicByMonth: TrendsSeries[];
   };
   trustAndDistribution: {
     signedPackagesByDay: TrendsPoint[];
@@ -217,6 +218,7 @@ export interface PublicTrends {
   downloads: {
     totalDownloadsByTime: TrendsPoint[];
     downloadsPerMonth: TrendsPoint[];
+    downloadsPerMonthByTopic: TrendsSeries[];
   };
 }
 


### PR DESCRIPTION
## Summary
- update active package trends to use packages with a successful release in the last 12 months
- add monthly topic breakdown charts for new packages and downloads
- add legend isolation toggles and stabilize trends page hydration

## Validation
- npm run lint
- npm run test -- --filter=@openupm/server-common -- trends/aggregation.spec.ts
- npm run test -- --filter=@openupm/jobs -- buildTrendsSnapshot.spec.ts
- npm run test -- --filter=@openupm/web -- trends.spec.ts
- npm --prefix apps/docs run docs:build:limit
- staged docs build checked for trends hydration and legend toggle behavior