### PR TITLE
Fix trends chart year ticks

### DIFF
--- a/apps/docs/__tests__/vue/trendsView.spec.ts
+++ b/apps/docs/__tests__/vue/trendsView.spec.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   filterSeries,
   formatNumber,
+  formatYearTick,
   latestValue,
   previousMonth,
+  shouldShowYearTick,
   sumValues,
   valueAtDate,
 } from "../../docs/.vuepress/trendsView";
@@ -32,5 +34,20 @@ describe("trends view helpers", () => {
     expect(filterSeries(series, "editor")).toEqual([series[1]]);
     expect(filterSeries(series, "ai")).toEqual([series[0]]);
     expect(filterSeries(series, "")).toEqual(series);
+  });
+
+  it("shows one x-axis label per year boundary", () => {
+    const dates = [
+      "2019-01",
+      "2019-02",
+      "2020-01",
+      "2020-02",
+      "2021-01",
+    ];
+
+    expect(dates.map((date, index) => formatYearTick(date, index, dates)))
+      .toEqual(["2019", "", "2020", "", "2021"]);
+    expect(dates.map((_date, index) => shouldShowYearTick(dates, index)))
+      .toEqual([true, false, true, false, true]);
   });
 });

--- a/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
@@ -25,7 +25,13 @@ import { useDarkMode } from "@vuepress/theme-default/client";
 import VChart from "vue-echarts";
 import { TrendsPoint } from "@openupm/types";
 
-import { formatNumber, pickDarkSeriesColor, pickSeriesColor } from "../trendsView";
+import {
+  formatNumber,
+  formatYearTick,
+  pickDarkSeriesColor,
+  pickSeriesColor,
+  shouldShowYearTick,
+} from "../trendsView";
 
 use([CanvasRenderer, BarChart, GridComponent, TooltipComponent]);
 
@@ -74,8 +80,10 @@ const chartOption = computed(() => ({
     data: dates.value,
     axisLabel: {
       color: isDarkMode.value ? "#f8fafc" : "#475569",
-      hideOverlap: true,
-      formatter: formatYearTick,
+      interval: (index: number): boolean =>
+        shouldShowYearTick(dates.value, index),
+      formatter: (value: string, index: number): string =>
+        formatYearTick(value, index, dates.value),
     },
     axisLine: {
       lineStyle: {
@@ -117,12 +125,6 @@ const chartOption = computed(() => ({
     },
   ],
 }));
-
-function formatYearTick(value: string, index: number): string {
-  const year = value.substring(0, 4);
-  const previousDate = dates.value[index - 1];
-  return previousDate?.substring(0, 4) === year ? "" : year;
-}
 
 const selectedSnapshot = computed(() => {
   if (!selectedDate.value) return null;

--- a/apps/docs/docs/.vuepress/components/TrendsLineChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsLineChart.vue
@@ -49,7 +49,13 @@ import { useDarkMode } from "@vuepress/theme-default/client";
 import VChart from "vue-echarts";
 import { TrendsSeries } from "@openupm/types";
 
-import { formatNumber, pickDarkSeriesColor, pickSeriesColor } from "../trendsView";
+import {
+  formatNumber,
+  formatYearTick,
+  pickDarkSeriesColor,
+  pickSeriesColor,
+  shouldShowYearTick,
+} from "../trendsView";
 
 use([CanvasRenderer, LineChart, GridComponent, TooltipComponent]);
 
@@ -129,8 +135,10 @@ const chartOption = computed(() => ({
     data: allDates.value,
     axisLabel: {
       color: isDarkMode.value ? "#f8fafc" : "#475569",
-      hideOverlap: true,
-      formatter: formatYearTick,
+      interval: (index: number): boolean =>
+        shouldShowYearTick(allDates.value, index),
+      formatter: (value: string, index: number): string =>
+        formatYearTick(value, index, allDates.value),
     },
     axisLine: {
       lineStyle: {
@@ -179,12 +187,6 @@ const chartOption = computed(() => ({
     };
   }),
 }));
-
-function formatYearTick(value: string, index: number): string {
-  const year = value.substring(0, 4);
-  const previousDate = allDates.value[index - 1];
-  return previousDate?.substring(0, 4) === year ? "" : year;
-}
 
 const selectedSnapshot = computed(() =>
   selectedDate.value

--- a/apps/docs/docs/.vuepress/trendsView.ts
+++ b/apps/docs/docs/.vuepress/trendsView.ts
@@ -18,6 +18,22 @@ export function previousMonth(value: string): string {
   return date.toISOString().substring(0, 7);
 }
 
+export function shouldShowYearTick(dates: string[], index: number): boolean {
+  const value = dates[index];
+  if (!value) return false;
+  const year = value.substring(0, 4);
+  const previousDate = dates[index - 1];
+  return previousDate?.substring(0, 4) !== year;
+}
+
+export function formatYearTick(
+  value: string,
+  index: number,
+  dates: string[],
+): string {
+  return shouldShowYearTick(dates, index) ? value.substring(0, 4) : "";
+}
+
 export function valueAtDate(points: TrendsPoint[], date: string): number {
   return points.find((point) => point.date === date)?.value || 0;
 }


### PR DESCRIPTION
## Summary
- render x-axis labels only on year-boundary ticks so later years are not suppressed
- share the year tick formatter between line and bar trends charts
- add a focused helper test for year-boundary labels

## Validation
- npm run test -- --filter=@openupm/docs -- trendsView.spec.ts
- npm run lint
- npm --prefix apps/docs run docs:build:limit
- local trends page smoke test with charts rendered