### PR TITLE
Fix downloads monthly tooltip label

### DIFF
--- a/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
@@ -37,6 +37,7 @@ use([CanvasRenderer, BarChart, GridComponent, TooltipComponent]);
 
 const props = defineProps<{
   points: TrendsPoint[];
+  seriesLabel?: string;
 }>();
 
 const selectedDate = ref("");
@@ -118,7 +119,7 @@ const chartOption = computed(() => ({
   },
   series: [
     {
-      name: "Value",
+      name: props.seriesLabel || "Value",
       type: "bar",
       data: props.points.map((point) => point.value),
       barMaxWidth: 18,

--- a/apps/docs/docs/.vuepress/components/TrendsPage.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsPage.vue
@@ -228,7 +228,10 @@
             <h3>Downloads per month</h3>
             <strong>{{ latestDownloadMonth }}</strong>
           </div>
-          <TrendsBarChart :points="trends.downloads.downloadsPerMonth" />
+          <TrendsBarChart
+            :points="trends.downloads.downloadsPerMonth"
+            series-label="Downloads per month"
+          />
         </article>
 
         <article class="trends-chart">

--- a/apps/docs/docs/.vuepress/layouts/Layout.vue
+++ b/apps/docs/docs/.vuepress/layouts/Layout.vue
@@ -3,7 +3,7 @@
 
 <script setup lang="ts">
 import { computed, useAttrs } from 'vue';
-import { usePageFrontmatter } from '@vuepress/client';
+import { ClientOnly, usePageFrontmatter } from '@vuepress/client';
 
 import ParentLayout from '@vuepress/theme-default/layouts/Layout.vue';
 
@@ -39,7 +39,9 @@ const parentLayoutClass = computed(() => [
   <ParentLayout v-bind="parentLayoutAttrs" :class="parentLayoutClass">
     <template #page-content-top>
       <SiteBreadcrumb />
-      <AdsenseDisplayForContentTop v-if="showContentTopAd" />
+      <ClientOnly>
+        <AdsenseDisplayForContentTop v-if="showContentTopAd" />
+      </ClientOnly>
     </template>
 
     <template v-for="(_, name) in $slots" #[name]="slotData">


### PR DESCRIPTION
## Summary
- add an optional label prop for single-series trends bar charts
- label the Downloads per month tooltip as "Downloads per month" instead of the default "Value"
- render the shared content-top AdSense slot inside ClientOnly so ad script DOM mutations are not part of Vue hydration on pages like /queue/ and /trends/

## Validation
- npm run lint
- npm --prefix apps/docs run docs:build:limit
- served the production build locally and verified the Downloads per month hover tooltip uses the requested label
- served the production build locally and verified /queue/ and /trends/ report no hydration mismatch warnings after the content-top ad SSR change