### PR TITLE
Add trends links to site navigation

### DIFF
--- a/apps/docs/docs/.vuepress/components/Footer.vue
+++ b/apps/docs/docs/.vuepress/components/Footer.vue
@@ -27,6 +27,10 @@ const aboutLinks = computed(() => [
   {
     link: "/queue/",
     text: t("queue-status")
+  },
+  {
+    link: "/trends/",
+    text: t("trends")
   }
 ]);
 

--- a/apps/docs/docs/.vuepress/config-us.ts
+++ b/apps/docs/docs/.vuepress/config-us.ts
@@ -161,13 +161,14 @@ export const themeConfig: any = {
     { text: "Docs", link: "/docs/" },
     { text: "Blog", link: "/blog/" },
     {
-      text: "Support",
-      ariaLabel: "Support Menu",
+      text: "About",
+      ariaLabel: "About Menu",
       children: [
         { text: "Support OpenUPM", link: "/support/" },
         { text: "Contributors", link: "/contributors/" },
         { text: "Uptime Status", link: "https://openupm.github.io/upptime/" },
         { text: "Queue Status", link: "/queue/" },
+        { text: "Trends", link: "/trends/" },
       ],
     },
     {

--- a/apps/docs/docs/.vuepress/locales/en-US.yml
+++ b/apps/docs/docs/.vuepress/locales/en-US.yml
@@ -202,6 +202,7 @@ state: State
 status: Status
 website-status: Uptime Status
 queue-status: Queue Status
+trends: Trends
 submit-pr: Submit Pull Request
 submit-metadata: submit metadata
 supported-unity-version: supported unity version


### PR DESCRIPTION
## Summary
- add Trends after Queue Status in the footer About section
- rename the navbar Support dropdown to About
- add Trends after Queue Status in the About dropdown

## Validation
- npm run lint
- npm run docs:build:limit