### PR TITLE
Add Home link to breadcrumbs

### DIFF
--- a/apps/docs/__tests__/vue/breadcrumb.spec.ts
+++ b/apps/docs/__tests__/vue/breadcrumb.spec.ts
@@ -44,6 +44,8 @@ describe("site breadcrumbs", () => {
   it("renders the current page breadcrumb as non-link text", () => {
     const source = readFileSync(breadcrumbPath, "utf8");
 
+    expect(source).toContain('{ text: "Home", link: "/" }');
+    expect(source).toContain("visibleBreadcrumbItems");
     expect(source).toContain('<span v-else aria-current="page">');
     expect(source).not.toContain('href="#"');
   });

--- a/apps/docs/__tests__/vue/contributorProfile.spec.ts
+++ b/apps/docs/__tests__/vue/contributorProfile.spec.ts
@@ -187,6 +187,7 @@ describe("contributor profile filtering", () => {
 
     expect(source).toContain('<ul class="breadcrumb profile-breadcrumb">');
     expect(source).toContain('class="breadcrumb-item"');
+    expect(source).toContain('<AutoLink :item="homeLink" />');
     expect(source).toContain('<AutoLink :item="contributorsLink" />');
     expect(source).toContain("Owned packages");
     expect(source).toContain("Discovered packages");

--- a/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
+++ b/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
@@ -111,6 +111,7 @@ describe("NuGet package detail UI", () => {
 
     expect(source).toContain('<nav aria-label="Breadcrumb">');
     expect(source).toContain('<ul class="breadcrumb package-breadcrumb">');
+    expect(source).toContain('<AutoLink :item="homeLink" />');
     expect(source).toContain('class="column column-meta col-4');
     expect(source).toContain("<PackageSetup");
     expect(source).toContain(':packument="state.packument"');

--- a/apps/docs/docs/.vuepress/components/SiteBreadcrumb.vue
+++ b/apps/docs/docs/.vuepress/components/SiteBreadcrumb.vue
@@ -57,13 +57,20 @@ const inferItems = (): BreadcrumbItem[] => {
 const breadcrumbItems = computed(() =>
   props.items.length ? props.items : inferItems(),
 );
+
+const visibleBreadcrumbItems = computed(() => {
+  const items = breadcrumbItems.value;
+  if (!items.length) return [];
+  if (items[0]?.link === "/") return items;
+  return [{ text: "Home", link: "/" }, ...items];
+});
 </script>
 
 <template>
-  <nav v-if="breadcrumbItems.length" aria-label="Breadcrumb" class="site-breadcrumb">
+  <nav v-if="visibleBreadcrumbItems.length" aria-label="Breadcrumb" class="site-breadcrumb">
     <ul class="breadcrumb">
       <li
-        v-for="(item, index) in breadcrumbItems"
+        v-for="(item, index) in visibleBreadcrumbItems"
         :key="`${item.text}-${index}`"
         class="breadcrumb-item"
       >

--- a/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/ContributorProfileLayout.vue
@@ -59,6 +59,11 @@ const contributorsLink = {
   link: "/contributors/",
 };
 
+const homeLink = {
+  text: "Home",
+  link: "/",
+};
+
 const isGitHubProfileHost = function (profileHost: string): boolean {
   const hostname = profileHost.toLowerCase();
   return hostname === "github.com" || hostname.endsWith(".github.com");
@@ -134,6 +139,9 @@ onMounted(() => {
         <main class="profile-content">
           <nav aria-label="Breadcrumb">
             <ul class="breadcrumb profile-breadcrumb">
+              <li class="breadcrumb-item">
+                <AutoLink :item="homeLink" />
+              </li>
               <li class="breadcrumb-item">
                 <AutoLink :item="contributorsLink" />
               </li>

--- a/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
@@ -36,6 +36,11 @@ const packagesLink = {
   link: "/packages/",
 };
 
+const homeLink = {
+  text: "Home",
+  link: "/",
+};
+
 type State = {
   adPlacementDataList: AdPlacementData[];
   packument: Partial<Packument>;
@@ -173,6 +178,9 @@ watch(
           <div class="column col-8 col-xl-8 col-lg-8 col-md-12 col-sm-12">
             <nav aria-label="Breadcrumb">
               <ul class="breadcrumb package-breadcrumb">
+                <li class="breadcrumb-item">
+                  <AutoLink :item="homeLink" />
+                </li>
                 <li class="breadcrumb-item">
                   <AutoLink :item="packagesLink" />
                 </li>

--- a/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
+++ b/packages/vuepress-plugin-openupm/__tests__/seo.test.ts
@@ -11,6 +11,7 @@ import {
   buildRelatedPackageSummaries,
   buildRelatedPackageSummaryIndex,
   buildPackageStructuredData,
+  buildUnityNuGetStructuredData,
   getLatestPackageLastModified,
   getPackageLastModified,
   structuredDataHead,
@@ -187,9 +188,53 @@ describe('SEO metadata helpers', () => {
     });
     expect(structuredData[1]).toMatchObject({
       '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          position: 1,
+          name: 'Home',
+          item: 'https://openupm.com/',
+        },
+        {
+          position: 2,
+          name: 'Packages',
+          item: 'https://openupm.com/packages/',
+        },
+        {
+          position: 3,
+          name: 'Example AI',
+        },
+      ],
     });
     expect(structuredDataHead(structuredData)[0][1]).toEqual({
       type: 'application/ld+json',
+    });
+  });
+
+  it('builds Home-first breadcrumb JSON-LD for UnityNuGet package pages', () => {
+    const structuredData = buildUnityNuGetStructuredData({
+      nugetId: 'Newtonsoft.Json',
+      packageName: 'org.nuget.newtonsoft.json',
+      version: '13.0.3',
+    });
+
+    expect(structuredData[1]).toMatchObject({
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          position: 1,
+          name: 'Home',
+          item: 'https://openupm.com/',
+        },
+        {
+          position: 2,
+          name: 'Packages',
+          item: 'https://openupm.com/packages/',
+        },
+        {
+          position: 3,
+          name: 'Newtonsoft.Json',
+        },
+      ],
     });
   });
 

--- a/packages/vuepress-plugin-openupm/src/seo.ts
+++ b/packages/vuepress-plugin-openupm/src/seo.ts
@@ -341,12 +341,18 @@ export const buildPackageStructuredData = (
       {
         '@type': 'ListItem',
         position: 1,
+        name: 'Home',
+        item: `${OPENUPM_ORIGIN}/`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
         name: 'Packages',
         item: `${OPENUPM_ORIGIN}${getPackageListPagePath()}`,
       },
       {
         '@type': 'ListItem',
-        position: 2,
+        position: 3,
         name: displayName || metadataLocal.name,
         item: packageUrl,
       },
@@ -383,14 +389,20 @@ export const buildUnityNuGetStructuredData = (entry: {
       '@type': 'BreadcrumbList',
       itemListElement: [
         {
-        '@type': 'ListItem',
-        position: 1,
-        name: 'Packages',
-        item: `${OPENUPM_ORIGIN}${getPackageListPagePath()}`,
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Home',
+          item: `${OPENUPM_ORIGIN}/`,
         },
         {
           '@type': 'ListItem',
           position: 2,
+          name: 'Packages',
+          item: `${OPENUPM_ORIGIN}${getPackageListPagePath()}`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
           name: entry.nugetId,
           item: packageUrl,
         },


### PR DESCRIPTION
## Summary
- prepend a Home link to shared docs breadcrumbs
- add Home links to contributor and UnityNuGet package breadcrumbs
- include Home as the first item in package breadcrumb JSON-LD

## Validation
- built local internal dependencies before focused tests
- npm run test -- breadcrumb.spec.ts contributorProfile.spec.ts nugetPackageDetail.spec.ts
- npm test -- seo.test.ts
- npm run lint
- npm run docs:build:limit
- served the built docs locally and verified shared SSR breadcrumb output

Note: live browser automation was unavailable in this session, so ClientOnly breadcrumb paths were validated with focused source tests and build coverage.