### PR TITLE
Mark incomplete current month in trends charts

### DIFF
--- a/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsBarChart.vue
@@ -28,6 +28,7 @@ import { TrendsPoint } from "@openupm/types";
 import {
   formatNumber,
   formatYearTick,
+  isCurrentMonthDate,
   pickDarkSeriesColor,
   pickSeriesColor,
   shouldShowYearTick,
@@ -53,6 +54,10 @@ const dates = computed(() => props.points.map((point) => point.date));
 function seriesColor(index: number): string {
   return isDarkMode.value ? pickDarkSeriesColor(index) : pickSeriesColor(index);
 }
+
+const incompleteBarColor = computed(() =>
+  isDarkMode.value ? "rgba(248, 250, 252, 0.62)" : "rgba(15, 23, 42, 0.42)",
+);
 
 const chartOption = computed(() => ({
   animation: false,
@@ -121,7 +126,26 @@ const chartOption = computed(() => ({
     {
       name: props.seriesLabel || "Value",
       type: "bar",
-      data: props.points.map((point) => point.value),
+      data: props.points.map((point) =>
+        isCurrentMonthDate(point.date)
+          ? {
+              value: point.value,
+              itemStyle: {
+                borderColor: incompleteBarColor.value,
+                borderType: "dashed",
+                borderWidth: 2,
+                decal: {
+                  symbol: "line",
+                  color: incompleteBarColor.value,
+                  dashArrayX: [1, 0],
+                  dashArrayY: [2, 4],
+                  rotation: -Math.PI / 4,
+                  symbolSize: 1,
+                },
+              },
+            }
+          : point.value,
+      ),
       barMaxWidth: 18,
     },
   ],

--- a/apps/docs/docs/.vuepress/components/TrendsLineChart.vue
+++ b/apps/docs/docs/.vuepress/components/TrendsLineChart.vue
@@ -52,6 +52,7 @@ import { TrendsSeries } from "@openupm/types";
 import {
   formatNumber,
   formatYearTick,
+  isCurrentMonthDate,
   pickDarkSeriesColor,
   pickSeriesColor,
   shouldShowYearTick,
@@ -68,6 +69,14 @@ const hoveredSeriesName = ref("");
 const isolatedSeriesKey = ref("");
 const mounted = ref(false);
 const isDarkMode = useDarkMode();
+
+interface AxisTooltipParam {
+  axisValueLabel?: string;
+  marker?: string;
+  name?: string;
+  seriesName?: string;
+  value?: number | string | null;
+}
 
 onMounted(() => {
   mounted.value = true;
@@ -93,6 +102,36 @@ const visibleSeries = computed(() =>
 
 function seriesColor(index: number): string {
   return isDarkMode.value ? pickDarkSeriesColor(index) : pickSeriesColor(index);
+}
+
+function getTooltipNumber(value: AxisTooltipParam["value"]): number | null {
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && value.trim()) return Number(value);
+  return null;
+}
+
+function formatAxisTooltip(
+  params: AxisTooltipParam | AxisTooltipParam[],
+): string {
+  const entries = Array.isArray(params) ? params : [params];
+  const date = entries[0]?.axisValueLabel || entries[0]?.name || "";
+  const uniqueEntries = new Map<string, AxisTooltipParam>();
+
+  for (const entry of entries) {
+    const label = entry.seriesName;
+    const value = getTooltipNumber(entry.value);
+    if (!label || value === null || Number.isNaN(value)) continue;
+    if (!uniqueEntries.has(label)) uniqueEntries.set(label, entry);
+  }
+
+  const rows = Array.from(uniqueEntries.values()).map((entry) => {
+    const value = getTooltipNumber(entry.value);
+    return `${entry.marker || ""}${entry.seriesName}: ${formatNumber(
+      value || 0,
+    )}`;
+  });
+
+  return [date, ...rows].join("<br/>");
 }
 
 const allDates = computed(() =>
@@ -127,7 +166,7 @@ const chartOption = computed(() => ({
     textStyle: {
       color: isDarkMode.value ? "#e5e7eb" : "#1f2937",
     },
-    valueFormatter: (value: number): string => formatNumber(value),
+    formatter: formatAxisTooltip,
   },
   xAxis: {
     type: "category",
@@ -171,20 +210,63 @@ const chartOption = computed(() => ({
       },
     },
   },
-  series: visibleSeries.value.map((entry) => {
+  series: visibleSeries.value.flatMap((entry) => {
     const values = new Map(
       entry.points.map((point) => [point.date, point.value]),
     );
-    return {
-      name: entry.label,
-      type: "line",
-      symbol: "circle",
-      symbolSize: 5,
-      showSymbol: true,
-      data: allDates.value.map((date) => values.get(date) ?? null),
-      connectNulls: false,
-      emphasis: { focus: "series" },
-    };
+    const color = seriesColor(
+      props.series.findIndex((series) => series.key === entry.key),
+    );
+    const firstIncompleteIndex = allDates.value.findIndex(
+      (date) => values.has(date) && isCurrentMonthDate(date),
+    );
+    const baseData = allDates.value.map((date) =>
+      isCurrentMonthDate(date) ? null : values.get(date) ?? null,
+    );
+    const seriesOptions = [
+      {
+        name: entry.label,
+        type: "line",
+        symbol: "circle",
+        symbolSize: 5,
+        showSymbol: true,
+        data: baseData,
+        connectNulls: false,
+        lineStyle: {
+          color,
+        },
+        itemStyle: {
+          color,
+        },
+        emphasis: { focus: "series" },
+      },
+    ];
+
+    if (firstIncompleteIndex >= 0) {
+      const incompleteStartIndex = Math.max(firstIncompleteIndex - 1, 0);
+      seriesOptions.push({
+        name: entry.label,
+        type: "line",
+        symbol: "circle",
+        symbolSize: 5,
+        showSymbol: true,
+        data: allDates.value.map((date, index) =>
+          index >= incompleteStartIndex ? values.get(date) ?? null : null,
+        ),
+        connectNulls: false,
+        lineStyle: {
+          type: "dashed",
+          width: 2,
+          color,
+        },
+        itemStyle: {
+          color,
+        },
+        emphasis: { focus: "series" },
+      });
+    }
+
+    return seriesOptions;
   }),
 }));
 

--- a/apps/docs/docs/.vuepress/trendsView.ts
+++ b/apps/docs/docs/.vuepress/trendsView.ts
@@ -34,6 +34,14 @@ export function formatYearTick(
   return shouldShowYearTick(dates, index) ? value.substring(0, 4) : "";
 }
 
+export function currentMonthKey(): string {
+  return new Date().toISOString().substring(0, 7);
+}
+
+export function isCurrentMonthDate(value: string): boolean {
+  return value.substring(0, 7) === currentMonthKey();
+}
+
 export function valueAtDate(points: TrendsPoint[], date: string): number {
   return points.find((point) => point.date === date)?.value || 0;
 }


### PR DESCRIPTION
## Summary
- render current-month line-chart tails as dashed overlays while keeping completed history solid
- style current-month bars with dashed borders and a decal pattern
- dedupe split line-series tooltip rows so current-month hover keeps a single value per label

## Validation
- npm run lint
- npm run docs:build:limit
- local Playwright check for /trends/ rendered 12 canvases with no unavailable state or console/page errors