### PR TITLE
Clean stale failed release jobs for deleted tags

### DIFF
--- a/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
@@ -188,6 +188,7 @@ describe('buildPackage GitHub Release pending probes', () => {
     );
 
     expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalled();
+    expect(removeReleaseMock).not.toHaveBeenCalled();
     expect(queueRemoveMock).not.toHaveBeenCalled();
     expect(addJobMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -195,6 +196,68 @@ describe('buildPackage GitHub Release pending probes', () => {
         data: { name: 'com.example.asset', version: '1.0.0' },
       }),
     );
+  });
+
+  it('removes a retained failed release job when its Git tag was deleted', async () => {
+    const deletedRelease = createRelease({
+      reason: ReleaseErrorCode.GitHubReleaseNotFound,
+    });
+    gitListRemoteTagsMock.mockResolvedValue([
+      { tag: 'upm/1.0.1', commit: 'def456' },
+    ]);
+    fetchAllMock.mockResolvedValue([deletedRelease]);
+    fetchOneMock.mockResolvedValue(null);
+    saveReleaseMock.mockImplementation(async (value) => ({
+      packageName: 'com.example.asset',
+      version: '1.0.1',
+      commit: 'def456',
+      tag: 'upm/1.0.1',
+      state: ReleaseState.Pending,
+      buildId: '',
+      reason: ReleaseErrorCode.None,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      source: 'githubRelease',
+      signed: false,
+      ...value,
+    }));
+
+    const { buildPackage } = await import('../../src/workers/buildPackage.js');
+    await buildPackage('com.example.asset');
+
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.example.asset|1.0.0',
+      { removeChildren: true },
+    );
+    expect(removeReleaseMock).toHaveBeenCalledWith(
+      'com.example.asset',
+      '1.0.0',
+    );
+    expect(resolveGitHubReleaseAssetMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ releaseTag: 'upm/1.0.0' }),
+    );
+  });
+
+  it('removes a retained failed release job when its only valid Git tag was deleted', async () => {
+    const deletedRelease = createRelease({
+      reason: ReleaseErrorCode.GitHubReleaseNotFound,
+    });
+    gitListRemoteTagsMock.mockResolvedValue([]);
+    fetchAllMock.mockResolvedValue([deletedRelease]);
+
+    const { buildPackage } = await import('../../src/workers/buildPackage.js');
+    await buildPackage('com.example.asset');
+
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.example.asset|1.0.0',
+      { removeChildren: true },
+    );
+    expect(removeReleaseMock).toHaveBeenCalledWith(
+      'com.example.asset',
+      '1.0.0',
+    );
+    expect(fetchOneMock).not.toHaveBeenCalled();
+    expect(addJobMock).not.toHaveBeenCalled();
   });
 
   it('keeps retryable failed releases retained until explicit reset', async () => {

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -114,16 +114,16 @@ export async function buildPackage(name: string): Promise<void> {
   });
   await setInvalidTags(name, invalidTags);
 
-  if (!validTags.length) {
-    logger.info({ pkg: name }, 'no valid tags found');
-    return;
-  }
-
   const releases = await updateReleaseRecords(
     pkg.name,
     validTags,
     pkg.trackingMode || 'git',
   );
+  if (!validTags.length) {
+    logger.info({ pkg: name }, 'no valid tags found');
+    return;
+  }
+
   await probePendingGitHubReleaseAssets(pkg, releases);
   await addReleaseJobs(releases);
 }
@@ -235,7 +235,7 @@ async function updateReleaseRecords(
           },
           'remove failed release that not listed in remoteTags',
         );
-        await remove(packageName, rel.version);
+        await removeStaleFailedRelease(packageName, rel);
       }
     }
   }
@@ -257,6 +257,17 @@ async function updateReleaseRecords(
     releases.push(release);
   }
   return releases;
+}
+
+async function removeStaleFailedRelease(
+  packageName: string,
+  release: ReleaseModel,
+): Promise<void> {
+  const jobConfig = config.jobs.buildRelease;
+  const queue = getQueue(jobConfig.queue);
+  const jobId = createJobId(jobConfig.name, packageName, release.version);
+  await queue.remove(jobId, { removeChildren: true });
+  await remove(packageName, release.version);
 }
 
 async function addReleaseJobs(releases: ReleaseModel[]): Promise<void> {


### PR DESCRIPTION
## Summary
- remove the deterministic release queue job when a failed release record is cleaned up because its Git tag and commit are no longer present upstream
- keep retained GitHub Release retry behavior unchanged while the tag is still present
- add focused queue worker coverage for deleted-tag cleanup

## Validation
- npm run lint -- --filter=@openupm/queue
- npm test -- --filter=@openupm/queue -- buildPackageGithubReleaseAssetProbe.spec.ts
- npm test -- --filter=@openupm/queue