### PR TITLE
Add GitHub Action publish trigger API

### DIFF
--- a/apps/docs/docs/.vuepress/config-us.ts
+++ b/apps/docs/docs/.vuepress/config-us.ts
@@ -117,6 +117,7 @@ const docSideBar = function (): any {
       collapsible: true,
       children: [
         "/docs/adding-upm-package",
+        "/docs/github-action-publish",
         "/docs/signing-upm-packages",
         "/docs/adding-badge",
         "/docs/troubleshooting-build-errors",

--- a/apps/docs/docs/docs/adding-upm-package.md
+++ b/apps/docs/docs/docs/adding-upm-package.md
@@ -117,6 +117,8 @@ Please adhere to one of the specified pull request title formats: either `Create
 
 After a brief pause, during which the build pipelines complete their tasks (usually ranging from 15 minutes to half an hour, depending on the size of your repository), you can access the package's detailed page at the URL `https://openupm.com/packages/com.your-org.package-name` and review the build results in the **version history** and **build issues** sections. You can also search for your package name on the homepage to locate it. If you encounter any issues, please leave a comment on the pull request, and we'll do our best to assist you. If you prefer a chat, feel free to join our Discord server via this link: [https://discord.gg/FnUgWEP](https://discord.gg/FnUgWEP).
 
+After the package is registered, maintainers can use the [OpenUPM GitHub Action](./github-action-publish.md) to trigger a package scan from a tag workflow and wait until the tagged version is installable from the registry.
+
 ## Troubleshooting
 
 ### Handling a Repository without Git Tag

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -3,9 +3,10 @@
 
 # Publishing with GitHub Actions
 
-OpenUPM can publish a package version automatically after you push a Git tag.
-The official GitHub Action triggers an OpenUPM package scan and waits until the
-matching version is published, fails, or reaches the workflow timeout.
+OpenUPM can publish a package version automatically after you push a Git tag or
+publish a GitHub Release. The official GitHub Action triggers an OpenUPM
+package scan and waits until the matching version is published, fails, or
+reaches the workflow timeout.
 
 Use this when you maintain the package repository and want the tag workflow to
 report whether the OpenUPM registry has accepted the new package version. This
@@ -26,7 +27,7 @@ You do not need an OpenUPM account, an OpenUPM token, a GitHub personal access
 token, or a shared webhook secret. OpenUPM verifies the GitHub OIDC token and
 checks that the workflow repository matches the package `repoUrl`.
 
-## Workflow Example
+## Tag Push Workflow
 
 For a package that uses plain semver tags such as `1.2.3`, add this workflow to
 the package repository:
@@ -56,6 +57,42 @@ jobs:
 
 The `id-token: write` permission lets the action request a GitHub OIDC token.
 The token is scoped to the workflow run and expires quickly.
+
+## GitHub Release Workflow
+
+You can also trigger OpenUPM after a GitHub Release is published. This example
+accepts release tags such as `v1.2.3` and passes `1.2.3` as the OpenUPM package
+version:
+
+```yaml
+name: OpenUPM
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - id: version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "value=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: openupm/openupm-action@v1
+        with:
+          package: com.example.openupm-action
+          version: ${{ steps.version.outputs.value }}
+          tag: ${{ github.event.release.tag_name }}
+```
+
+If your release tags already match `package.json.version`, use the tag value
+directly for both `version` and `tag`.
 
 ## Prefixed Tags
 

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -29,8 +29,12 @@ checks that the workflow repository matches the package `repoUrl`.
 
 ## Tag Push Workflow
 
-For a package that uses plain semver tags such as `1.2.3`, add this workflow to
-the package repository:
+Only send tags that contain a parseable semver package version to the action,
+for example `1.2.3`, `v1.2.3`, `upm/1.2.3`, or
+`com.example.package@v1.2.3`. Other tags are rejected by the action before it
+contacts OpenUPM.
+
+Add this workflow to the package repository:
 
 ```yaml
 name: OpenUPM
@@ -56,9 +60,6 @@ jobs:
 
 The `id-token: write` permission lets the action request a GitHub OIDC token.
 The token is scoped to the workflow run and expires quickly.
-
-OpenUPM derives the package version from common tag shapes such as `1.2.3`,
-`v1.2.3`, `upm/1.2.3`, and `com.example.package@v1.2.3`.
 
 ## GitHub Release Workflow
 
@@ -93,8 +94,6 @@ jobs:
 | `tag`                   | Yes      |                           | Git tag that triggered the workflow. It must contain an OpenUPM-compatible package version. |
 | `timeout-minutes`       | No       | `15`                      | Maximum time to wait before failing the workflow. |
 | `poll-interval-seconds` | No       | `15`                      | Delay between status checks. |
-| `api-url`               | No       | `https://api.openupm.com` | OpenUPM API URL. |
-| `oidc-audience`         | No       | `openupm`                 | OIDC audience requested from GitHub and verified by OpenUPM. |
 
 ## Outputs
 

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -42,7 +42,7 @@ name: OpenUPM
 on:
   push:
     tags:
-      - '*'
+      - '**'
 
 permissions:
   id-token: write

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -1,0 +1,117 @@
+---
+---
+
+# Publishing with GitHub Actions
+
+OpenUPM can publish a package version automatically after you push a Git tag.
+The official GitHub Action triggers an OpenUPM package scan and waits until the
+matching version is published, fails, or reaches the workflow timeout.
+
+Use this when you maintain the package repository and want the tag workflow to
+report whether the OpenUPM registry has accepted the new package version. This
+does not replace the normal OpenUPM package submission process: the package must
+already be registered on OpenUPM, and the registered `repoUrl` must point to the
+same public GitHub repository that runs the workflow.
+
+## What the Action Does
+
+The action performs three steps:
+
+1. Request a short-lived GitHub Actions OIDC token from GitHub.
+2. Send the package name, version, and optional Git tag to OpenUPM.
+3. Poll OpenUPM until the version is installable from the registry, fails, or
+   reaches the configured timeout.
+
+You do not need an OpenUPM account, an OpenUPM token, a GitHub personal access
+token, or a shared webhook secret. OpenUPM verifies the GitHub OIDC token and
+checks that the workflow repository matches the package `repoUrl`.
+
+## Workflow Example
+
+For a package that uses plain semver tags such as `1.2.3`, add this workflow to
+the package repository:
+
+```yaml
+name: OpenUPM
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openupm/openupm-action@v1
+        with:
+          package: com.example.openupm-action
+          version: ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
+```
+
+The `id-token: write` permission lets the action request a GitHub OIDC token.
+The token is scoped to the workflow run and expires quickly.
+
+## Prefixed Tags
+
+If your repository uses prefixed package tags, pass the OpenUPM package version
+separately from the Git tag. For example, a tag named `upm/1.2.3` should use:
+
+```yaml
+- uses: openupm/openupm-action@v1
+  with:
+    package: com.example.package
+    version: 1.2.3
+    tag: upm/1.2.3
+```
+
+The `tag` input must match the GitHub workflow ref. The `version` input must
+match the `version` field in the package's `package.json` at that tag.
+
+## Inputs
+
+| Input                   | Required | Default                   | Description |
+| ----------------------- | -------- | ------------------------- | ----------- |
+| `package`               | Yes      |                           | OpenUPM package name, such as `com.company.tool`. |
+| `version`               | Yes      |                           | Package version to wait for, such as `1.2.3`. |
+| `tag`                   | No       |                           | Git tag that triggered the workflow. Recommended for tag-push workflows. |
+| `timeout-minutes`       | No       | `15`                      | Maximum time to wait before failing the workflow. |
+| `poll-interval-seconds` | No       | `15`                      | Delay between status checks. |
+| `api-url`               | No       | `https://api.openupm.com` | OpenUPM API URL. |
+| `oidc-audience`         | No       | `openupm`                 | OIDC audience requested from GitHub and verified by OpenUPM. |
+
+## Outputs
+
+| Output              | Description |
+| ------------------- | ----------- |
+| `state`             | Final OpenUPM release state, such as `succeeded` or `failed`. |
+| `reason`            | Public failure reason when OpenUPM reports one. |
+| `published-version` | Registry version reported by OpenUPM when available. |
+| `signed`            | Whether OpenUPM reports the package version as signed. |
+| `package-url`       | OpenUPM package page URL. |
+
+## Failure Behavior
+
+The workflow fails when OpenUPM rejects the trigger request, the package version
+fails to build, or the timeout is reached before the version becomes
+installable.
+
+A successful action run means the requested version is available from the
+OpenUPM registry. The package detail page and website search may update through
+their own refresh cycle after the registry publish completes.
+
+If the action reports a build failure, use the package page's build history and
+the [Troubleshooting Build Errors](./troubleshooting-build-errors.md) guide to
+fix the package, then create a new version tag or re-tag a failed version when
+your repository policy allows it.
+
+## Example Repository
+
+The [`openupm/com.example.openupm-action`](https://github.com/openupm/com.example.openupm-action)
+repository demonstrates a minimal Unity package that publishes through the
+[`openupm/openupm-action`](https://github.com/openupm/openupm-action) workflow.

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -51,18 +51,18 @@ jobs:
       - uses: openupm/openupm-action@v1
         with:
           package: com.example.openupm-action
-          version: ${{ github.ref_name }}
           tag: ${{ github.ref_name }}
 ```
 
 The `id-token: write` permission lets the action request a GitHub OIDC token.
 The token is scoped to the workflow run and expires quickly.
 
+OpenUPM derives the package version from common tag shapes such as `1.2.3`,
+`v1.2.3`, `upm/1.2.3`, and `com.example.package@v1.2.3`.
+
 ## GitHub Release Workflow
 
-You can also trigger OpenUPM after a GitHub Release is published. This example
-accepts release tags such as `v1.2.3` and passes `1.2.3` as the OpenUPM package
-version:
+You can also trigger OpenUPM after a GitHub Release is published:
 
 ```yaml
 name: OpenUPM
@@ -79,43 +79,36 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - id: version
-        env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
-        run: echo "value=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
-
       - uses: openupm/openupm-action@v1
         with:
           package: com.example.openupm-action
-          version: ${{ steps.version.outputs.value }}
           tag: ${{ github.event.release.tag_name }}
 ```
 
-If your release tags already match `package.json.version`, use the tag value
-directly for both `version` and `tag`.
-
 ## Prefixed Tags
 
-If your repository uses prefixed package tags, pass the OpenUPM package version
-separately from the Git tag. For example, a tag named `upm/1.2.3` should use:
+For normal prefixed package tags, pass only the original tag. OpenUPM parses
+the package version from the tag and still verifies the full tag against the
+GitHub OIDC token. For example, a tag named `upm/1.2.3` should use:
 
 ```yaml
 - uses: openupm/openupm-action@v1
   with:
     package: com.example.package
-    version: 1.2.3
     tag: upm/1.2.3
 ```
 
-The `tag` input must match the GitHub workflow ref. The `version` input must
-match the `version` field in the package's `package.json` at that tag.
+The `tag` input must match the GitHub workflow ref. If your repository uses a
+tag shape that OpenUPM cannot parse, pass `version` as an explicit override.
+The override must match the `version` field in the package's `package.json` at
+that tag.
 
 ## Inputs
 
 | Input                   | Required | Default                   | Description |
 | ----------------------- | -------- | ------------------------- | ----------- |
 | `package`               | Yes      |                           | OpenUPM package name, such as `com.company.tool`. |
-| `version`               | Yes      |                           | Package version to wait for, such as `1.2.3`. |
+| `version`               | No       |                           | Optional package version override. Only needed when OpenUPM cannot derive the version from `tag`. |
 | `tag`                   | No       |                           | Git tag that triggered the workflow. Recommended for tag-push workflows. |
 | `timeout-minutes`       | No       | `15`                      | Maximum time to wait before failing the workflow. |
 | `poll-interval-seconds` | No       | `15`                      | Delay between status checks. |

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -19,7 +19,7 @@ same public GitHub repository that runs the workflow.
 The action performs three steps:
 
 1. Request a short-lived GitHub Actions OIDC token from GitHub.
-2. Send the package name, version, and optional Git tag to OpenUPM.
+2. Send the package name and Git tag to OpenUPM.
 3. Poll OpenUPM until the version is installable from the registry, fails, or
    reaches the configured timeout.
 
@@ -85,31 +85,12 @@ jobs:
           tag: ${{ github.event.release.tag_name }}
 ```
 
-## Prefixed Tags
-
-For normal prefixed package tags, pass only the original tag. OpenUPM parses
-the package version from the tag and still verifies the full tag against the
-GitHub OIDC token. For example, a tag named `upm/1.2.3` should use:
-
-```yaml
-- uses: openupm/openupm-action@v1
-  with:
-    package: com.example.package
-    tag: upm/1.2.3
-```
-
-The `tag` input must match the GitHub workflow ref. If your repository uses a
-tag shape that OpenUPM cannot parse, pass `version` as an explicit override.
-The override must match the `version` field in the package's `package.json` at
-that tag.
-
 ## Inputs
 
 | Input                   | Required | Default                   | Description |
 | ----------------------- | -------- | ------------------------- | ----------- |
 | `package`               | Yes      |                           | OpenUPM package name, such as `com.company.tool`. |
-| `version`               | No       |                           | Optional package version override. Only needed when OpenUPM cannot derive the version from `tag`. |
-| `tag`                   | No       |                           | Git tag that triggered the workflow. Recommended for tag-push workflows. |
+| `tag`                   | Yes      |                           | Git tag that triggered the workflow. It must contain an OpenUPM-compatible package version. |
 | `timeout-minutes`       | No       | `15`                      | Maximum time to wait before failing the workflow. |
 | `poll-interval-seconds` | No       | `15`                      | Delay between status checks. |
 | `api-url`               | No       | `https://api.openupm.com` | OpenUPM API URL. |

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -131,6 +131,7 @@ match the `version` field in the package's `package.json` at that tag.
 | `published-version` | Registry version reported by OpenUPM when available. |
 | `signed`            | Whether OpenUPM reports the package version as signed. |
 | `package-url`       | OpenUPM package page URL. |
+| `status-url`        | OpenUPM release status API URL. |
 
 ## Failure Behavior
 

--- a/apps/web/__tests__/publishTrigger/githubOidc.spec.ts
+++ b/apps/web/__tests__/publishTrigger/githubOidc.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import {
+  JOSEError,
+  JWKSInvalid,
+  JWKSNoMatchingKey,
+  JWKSTimeout,
+  JWTInvalid,
+} from 'jose/errors';
 
 import {
+  isRetryableJwksError,
   normalizeGitHubRepository,
   PublishTriggerAuthError,
   validateGitHubActionsOidcClaims,
@@ -231,5 +239,32 @@ describe('githubOidc', () => {
         ),
       'RefMismatch',
     );
+  });
+
+  it('classifies transient JWKS fetch failures as retryable', () => {
+    expect(isRetryableJwksError(new JWKSTimeout())).toBe(true);
+    expect(isRetryableJwksError(new JWKSInvalid('JSON Web Key Set malformed'))).toBe(
+      true,
+    );
+    expect(
+      isRetryableJwksError(
+        new JOSEError(
+          'Expected 200 OK from the JSON Web Key Set HTTP response',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableJwksError(
+        new JOSEError(
+          'Failed to parse the JSON Web Key Set HTTP response as JSON',
+        ),
+      ),
+    ).toBe(true);
+    expect(isRetryableJwksError(new TypeError('fetch failed'))).toBe(true);
+  });
+
+  it('does not classify invalid tokens as retryable JWKS failures', () => {
+    expect(isRetryableJwksError(new JWTInvalid('invalid JWT'))).toBe(false);
+    expect(isRetryableJwksError(new JWKSNoMatchingKey())).toBe(false);
   });
 });

--- a/apps/web/__tests__/publishTrigger/githubOidc.spec.ts
+++ b/apps/web/__tests__/publishTrigger/githubOidc.spec.ts
@@ -94,6 +94,40 @@ describe('githubOidc', () => {
     expect(validated.sub).toContain('@200');
   });
 
+  it('accepts ref subjects with additional custom subject claims', () => {
+    const validated = validateGitHubActionsOidcClaims(
+      claims({
+        sub:
+          'repo:openupm/com.example.openupm-action:ref:refs/tags/upm/1.2.3:job_workflow_ref:openupm/reusable/.github/workflows/publish.yml@refs/heads/main',
+      }),
+      {
+        packageRepoUrl:
+          'https://github.com/openupm/com.example.openupm-action',
+        tag: 'upm/1.2.3',
+      },
+    );
+
+    expect(validated.sub).toContain('job_workflow_ref');
+  });
+
+  it('rejects subject refs that only share a tag prefix', () => {
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(
+          claims({
+            sub:
+              'repo:openupm/com.example.openupm-action:ref:refs/tags/upm/1.2.3-extra',
+          }),
+          {
+            packageRepoUrl:
+              'https://github.com/openupm/com.example.openupm-action',
+            tag: 'upm/1.2.3',
+          },
+        ),
+      'SubjectMismatch',
+    );
+  });
+
   it('rejects subject ref mismatches', () => {
     expectAuthError(
       () =>

--- a/apps/web/__tests__/publishTrigger/githubOidc.spec.ts
+++ b/apps/web/__tests__/publishTrigger/githubOidc.spec.ts
@@ -18,6 +18,8 @@ function claims(
     event_name: 'push',
     ref_type: 'tag',
     ref: 'refs/tags/upm/1.2.3',
+    sub:
+      'repo:openupm/com.example.openupm-action:ref:refs/tags/upm/1.2.3',
     ...overrides,
   };
 }
@@ -56,6 +58,58 @@ describe('githubOidc', () => {
     });
 
     expect(validated.repository).toBe('openupm/com.example.openupm-action');
+  });
+
+  it('accepts release event claims for a matching registered tag', () => {
+    const validated = validateGitHubActionsOidcClaims(
+      claims({
+        event_name: 'release',
+        ref: 'refs/tags/v1.2.3',
+        sub:
+          'repo:openupm/com.example.openupm-action:ref:refs/tags/v1.2.3',
+      }),
+      {
+        packageRepoUrl:
+          'https://github.com/openupm/com.example.openupm-action',
+        tag: 'v1.2.3',
+      },
+    );
+
+    expect(validated.event_name).toBe('release');
+  });
+
+  it('accepts immutable repository subject formats for a matching tag', () => {
+    const validated = validateGitHubActionsOidcClaims(
+      claims({
+        sub:
+          'repo:openupm@100/com.example.openupm-action@200:ref:refs/tags/upm/1.2.3',
+      }),
+      {
+        packageRepoUrl:
+          'https://github.com/openupm/com.example.openupm-action',
+        tag: 'upm/1.2.3',
+      },
+    );
+
+    expect(validated.sub).toContain('@200');
+  });
+
+  it('rejects subject ref mismatches', () => {
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(
+          claims({
+            sub:
+              'repo:openupm/com.example.openupm-action:ref:refs/tags/other',
+          }),
+          {
+            packageRepoUrl:
+              'https://github.com/openupm/com.example.openupm-action',
+            tag: 'upm/1.2.3',
+          },
+        ),
+      'SubjectMismatch',
+    );
   });
 
   it('rejects wrong audience', () => {
@@ -129,10 +183,18 @@ describe('githubOidc', () => {
     );
     expectAuthError(
       () =>
-        validateGitHubActionsOidcClaims(claims({ ref: 'refs/tags/v1.2.3' }), {
-          packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
-          tag: 'upm/1.2.3',
-        }),
+        validateGitHubActionsOidcClaims(
+          claims({
+            ref: 'refs/tags/v1.2.3',
+            sub:
+              'repo:openupm/com.example.openupm-action:ref:refs/tags/v1.2.3',
+          }),
+          {
+            packageRepoUrl:
+              'https://github.com/openupm/com.example.openupm-action',
+            tag: 'upm/1.2.3',
+          },
+        ),
       'RefMismatch',
     );
   });

--- a/apps/web/__tests__/publishTrigger/githubOidc.spec.ts
+++ b/apps/web/__tests__/publishTrigger/githubOidc.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeGitHubRepository,
+  PublishTriggerAuthError,
+  validateGitHubActionsOidcClaims,
+  type GitHubActionsOidcClaims,
+} from '../../src/publishTrigger/githubOidc.js';
+
+function claims(
+  overrides: Partial<GitHubActionsOidcClaims> = {},
+): GitHubActionsOidcClaims {
+  return {
+    iss: 'https://token.actions.githubusercontent.com',
+    aud: 'openupm',
+    repository: 'openupm/com.example.openupm-action',
+    repository_visibility: 'public',
+    event_name: 'push',
+    ref_type: 'tag',
+    ref: 'refs/tags/upm/1.2.3',
+    ...overrides,
+  };
+}
+
+function expectAuthError(fn: () => unknown, code: string): void {
+  try {
+    fn();
+    throw new Error('expected auth error');
+  } catch (error) {
+    expect(error).toBeInstanceOf(PublishTriggerAuthError);
+    expect((error as PublishTriggerAuthError).code).toBe(code);
+  }
+}
+
+describe('githubOidc', () => {
+  it('normalizes GitHub repository URLs', () => {
+    expect(
+      normalizeGitHubRepository(
+        'https://github.com/OpenUPM/com.example.openupm-action.git',
+      ),
+    ).toBe('openupm/com.example.openupm-action');
+    expect(
+      normalizeGitHubRepository(
+        'git@github.com:OpenUPM/com.example.openupm-action.git',
+      ),
+    ).toBe('openupm/com.example.openupm-action');
+    expect(normalizeGitHubRepository('https://gitlab.com/openupm/demo')).toBe(
+      null,
+    );
+  });
+
+  it('accepts valid claims for the registered package repository and tag', () => {
+    const validated = validateGitHubActionsOidcClaims(claims(), {
+      packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+      tag: 'upm/1.2.3',
+    });
+
+    expect(validated.repository).toBe('openupm/com.example.openupm-action');
+  });
+
+  it('rejects wrong audience', () => {
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(claims({ aud: 'wrong' }), {
+          packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+          tag: 'upm/1.2.3',
+        }),
+      'InvalidAudience',
+    );
+  });
+
+  it('rejects wrong issuer', () => {
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(claims({ iss: 'https://example.com' }), {
+          packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+          tag: 'upm/1.2.3',
+        }),
+      'InvalidIssuer',
+    );
+  });
+
+  it('rejects repository mismatch', () => {
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(claims({ repository: 'evil/demo' }), {
+          packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+          tag: 'upm/1.2.3',
+        }),
+      'RepositoryMismatch',
+    );
+  });
+
+  it('rejects private repositories for the initial rollout', () => {
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(
+          claims({ repository_visibility: 'private' }),
+          {
+            packageRepoUrl:
+              'https://github.com/openupm/com.example.openupm-action',
+            tag: 'upm/1.2.3',
+          },
+        ),
+      'UnsupportedRepositoryVisibility',
+    );
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(
+          claims({ repository_visibility: undefined }),
+          {
+            packageRepoUrl:
+              'https://github.com/openupm/com.example.openupm-action',
+            tag: 'upm/1.2.3',
+          },
+        ),
+      'UnsupportedRepositoryVisibility',
+    );
+  });
+
+  it('rejects unsupported events and ref mismatches', () => {
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(claims({ event_name: 'pull_request' }), {
+          packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+          tag: 'upm/1.2.3',
+        }),
+      'UnsupportedEvent',
+    );
+    expectAuthError(
+      () =>
+        validateGitHubActionsOidcClaims(claims({ ref: 'refs/tags/v1.2.3' }), {
+          packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+          tag: 'upm/1.2.3',
+        }),
+      'RefMismatch',
+    );
+  });
+});

--- a/apps/web/__tests__/publishTrigger/packageRefresh.spec.ts
+++ b/apps/web/__tests__/publishTrigger/packageRefresh.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const queueMocks = vi.hoisted(() => ({
+  add: vi.fn(),
+  close: vi.fn(),
+  getJob: vi.fn(),
+  queueConstructor: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation((name, settings) => {
+    queueMocks.queueConstructor(name, settings);
+    return {
+      add: queueMocks.add,
+      close: queueMocks.close,
+      getJob: queueMocks.getJob,
+    };
+  }),
+}));
+
+const {
+  closePackageRefreshQueues,
+  enqueuePackageRefresh,
+} = await import('../../src/publishTrigger/packageRefresh.js');
+
+describe('packageRefresh', () => {
+  afterEach(async () => {
+    await closePackageRefreshQueues();
+    for (const mock of Object.values(queueMocks)) mock.mockReset();
+  });
+
+  it('enqueues a deterministic package refresh job', async () => {
+    queueMocks.getJob.mockResolvedValue(null);
+    queueMocks.add.mockResolvedValue({ id: 'build-pkg|com.example.foo' });
+
+    const result = await enqueuePackageRefresh('com.example.foo');
+
+    expect(queueMocks.queueConstructor).toHaveBeenCalledWith(
+      'pkg',
+      expect.objectContaining({
+        connection: expect.any(Object),
+      }),
+    );
+    expect(queueMocks.getJob).toHaveBeenCalledWith('build-pkg|com.example.foo');
+    expect(queueMocks.add).toHaveBeenCalledWith(
+      'build-pkg',
+      { name: 'com.example.foo' },
+      { jobId: 'build-pkg|com.example.foo' },
+    );
+    expect(result).toEqual({
+      queue: 'pkg',
+      jobId: 'build-pkg|com.example.foo',
+      added: true,
+    });
+  });
+
+  it('dedupes an existing package refresh job', async () => {
+    queueMocks.getJob.mockResolvedValue({ id: 'build-pkg|com.example.foo' });
+
+    const result = await enqueuePackageRefresh('com.example.foo');
+
+    expect(queueMocks.add).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      queue: 'pkg',
+      jobId: 'build-pkg|com.example.foo',
+      added: false,
+    });
+  });
+});

--- a/apps/web/__tests__/publishTrigger/packageRefresh.spec.ts
+++ b/apps/web/__tests__/publishTrigger/packageRefresh.spec.ts
@@ -55,7 +55,11 @@ describe('packageRefresh', () => {
   });
 
   it('dedupes an existing package refresh job', async () => {
-    queueMocks.getJob.mockResolvedValue({ id: 'build-pkg|com.example.foo' });
+    queueMocks.getJob.mockResolvedValue({
+      getState: vi.fn().mockResolvedValue('waiting'),
+      id: 'build-pkg|com.example.foo',
+      remove: vi.fn(),
+    });
 
     const result = await enqueuePackageRefresh('com.example.foo');
 
@@ -64,6 +68,30 @@ describe('packageRefresh', () => {
       queue: 'pkg',
       jobId: 'build-pkg|com.example.foo',
       added: false,
+    });
+  });
+
+  it('replaces a failed package refresh job', async () => {
+    const existing = {
+      getState: vi.fn().mockResolvedValue('failed'),
+      id: 'build-pkg|com.example.foo',
+      remove: vi.fn().mockResolvedValue(undefined),
+    };
+    queueMocks.getJob.mockResolvedValue(existing);
+    queueMocks.add.mockResolvedValue({ id: 'build-pkg|com.example.foo' });
+
+    const result = await enqueuePackageRefresh('com.example.foo');
+
+    expect(existing.remove).toHaveBeenCalled();
+    expect(queueMocks.add).toHaveBeenCalledWith(
+      'build-pkg',
+      { name: 'com.example.foo' },
+      { jobId: 'build-pkg|com.example.foo' },
+    );
+    expect(result).toEqual({
+      queue: 'pkg',
+      jobId: 'build-pkg|com.example.foo',
+      added: true,
     });
   });
 });

--- a/apps/web/__tests__/routers/packagePublish.spec.ts
+++ b/apps/web/__tests__/routers/packagePublish.spec.ts
@@ -165,6 +165,34 @@ describe('package publish router', () => {
     expect(response.body.deduped).toBe(true);
   });
 
+  it('accepts GitHub Release event refresh triggers', async () => {
+    mocks.verifyGitHubActionsOidcToken.mockResolvedValueOnce({
+      repository: 'openupm/com.example.openupm-action',
+      event_name: 'release',
+      ref: 'refs/tags/v1.2.3',
+    });
+
+    const response = await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer release-token')
+      .send({ version: VERSION, tag: 'v1.2.3' })
+      .expect(202);
+
+    expect(mocks.verifyGitHubActionsOidcToken).toHaveBeenCalledWith(
+      'release-token',
+      {
+        packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+        tag: 'v1.2.3',
+      },
+    );
+    expect(response.body).toMatchObject({
+      packageName: PACKAGE_NAME,
+      version: VERSION,
+      tag: 'v1.2.3',
+      accepted: true,
+    });
+  });
+
   it('rejects missing version and token before enqueuing', async () => {
     await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)

--- a/apps/web/__tests__/routers/packagePublish.spec.ts
+++ b/apps/web/__tests__/routers/packagePublish.spec.ts
@@ -211,7 +211,7 @@ describe('package publish router', () => {
     });
   });
 
-  it('clears a stale failed release after accepting a refresh', async () => {
+  it('clears a stale failed release before enqueueing a refresh', async () => {
     mocks.fetchOne
       .mockResolvedValueOnce(
         release(ReleaseState.Failed, {
@@ -228,6 +228,11 @@ describe('package publish router', () => {
 
     expect(mocks.enqueuePackageRefresh).toHaveBeenCalledWith(PACKAGE_NAME);
     expect(mocks.removeRelease).toHaveBeenCalledWith(PACKAGE_NAME, VERSION);
+    expect(
+      mocks.removeRelease.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.enqueuePackageRefresh.mock.invocationCallOrder[0],
+    );
     expect(response.body.release).toMatchObject({
       state: 'unknown',
       reason: 'unknown',

--- a/apps/web/__tests__/routers/packagePublish.spec.ts
+++ b/apps/web/__tests__/routers/packagePublish.spec.ts
@@ -1,0 +1,281 @@
+import request from 'supertest';
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import { ReleaseErrorCode, ReleaseModel, ReleaseState } from '@openupm/types';
+
+class MockPublishTriggerAuthError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly statusCode = 401,
+  ) {
+    super(message);
+  }
+}
+
+class MockPublishTriggerRateLimitError extends Error {
+  constructor(public readonly retryAfterSeconds: number) {
+    super('The package refresh trigger rate limit was exceeded.');
+  }
+}
+
+const mocks = vi.hoisted(() => ({
+  loadPackageMetadataLocal: vi.fn(),
+  verifyGitHubActionsOidcToken: vi.fn(),
+  enqueuePackageRefresh: vi.fn(),
+  assertPublishTriggerRateLimit: vi.fn(),
+  fetchOne: vi.fn(),
+}));
+
+vi.mock('@openupm/local-data', () => ({
+  loadPackageMetadataLocal: mocks.loadPackageMetadataLocal,
+}));
+
+vi.mock('@openupm/server-common/build/models/release.js', () => ({
+  fetchOne: mocks.fetchOne,
+}));
+
+vi.mock('../../src/publishTrigger/githubOidc.js', () => ({
+  PublishTriggerAuthError: MockPublishTriggerAuthError,
+  verifyGitHubActionsOidcToken: mocks.verifyGitHubActionsOidcToken,
+}));
+
+vi.mock('../../src/publishTrigger/packageRefresh.js', () => ({
+  enqueuePackageRefresh: mocks.enqueuePackageRefresh,
+}));
+
+vi.mock('../../src/publishTrigger/rateLimit.js', () => ({
+  PublishTriggerRateLimitError: MockPublishTriggerRateLimitError,
+  assertPublishTriggerRateLimit: mocks.assertPublishTriggerRateLimit,
+}));
+
+const { app } = await import('../../src/apiServer.js');
+
+const PACKAGE_NAME = 'com.example.openupm-action';
+const VERSION = '1.2.3';
+
+function metadata() {
+  return {
+    name: PACKAGE_NAME,
+    repoUrl: 'https://github.com/openupm/com.example.openupm-action',
+  };
+}
+
+function release(
+  state: ReleaseState,
+  overrides: Partial<ReleaseModel> = {},
+): ReleaseModel {
+  return {
+    packageName: PACKAGE_NAME,
+    version: VERSION,
+    commit: 'abc123',
+    tag: 'upm/1.2.3',
+    buildId: '123',
+    state,
+    reason: ReleaseErrorCode.None,
+    createdAt: 0,
+    updatedAt: 0,
+    source: 'git',
+    signed: false,
+    ...overrides,
+  };
+}
+
+describe('package publish router', () => {
+  beforeEach(async () => {
+    await app.ready();
+    mocks.loadPackageMetadataLocal.mockResolvedValue(metadata());
+    mocks.verifyGitHubActionsOidcToken.mockResolvedValue({
+      repository: 'openupm/com.example.openupm-action',
+      event_name: 'push',
+      ref: 'refs/tags/upm/1.2.3',
+    });
+    mocks.enqueuePackageRefresh.mockResolvedValue({
+      queue: 'pkg',
+      jobId: `build-pkg|${PACKAGE_NAME}`,
+      added: true,
+    });
+    mocks.fetchOne.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    for (const mock of Object.values(mocks)) mock.mockReset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('accepts a verified package refresh trigger', async () => {
+    const response = await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ version: VERSION, tag: 'upm/1.2.3' })
+      .expect(202)
+      .expect('Content-Type', /json/);
+
+    expect(mocks.verifyGitHubActionsOidcToken).toHaveBeenCalledWith(
+      'test-token',
+      {
+        packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+        tag: 'upm/1.2.3',
+      },
+    );
+    expect(mocks.assertPublishTriggerRateLimit).toHaveBeenCalledWith({
+      packageName: PACKAGE_NAME,
+      repository: 'openupm/com.example.openupm-action',
+      ip: expect.any(String),
+    });
+    expect(mocks.enqueuePackageRefresh).toHaveBeenCalledWith(PACKAGE_NAME);
+    expect(response.body).toMatchObject({
+      packageName: PACKAGE_NAME,
+      version: VERSION,
+      tag: 'upm/1.2.3',
+      accepted: true,
+      deduped: false,
+      release: {
+        state: 'unknown',
+        reason: 'unknown',
+      },
+    });
+    expect(response.body.job).toBeUndefined();
+  });
+
+  it('reports deduped refresh triggers', async () => {
+    mocks.enqueuePackageRefresh.mockResolvedValue({
+      queue: 'pkg',
+      jobId: `build-pkg|${PACKAGE_NAME}`,
+      added: false,
+    });
+
+    const response = await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ version: VERSION })
+      .expect(202);
+
+    expect(response.body.deduped).toBe(true);
+  });
+
+  it('rejects missing version and token before enqueuing', async () => {
+    await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({})
+      .expect(400);
+
+    await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .send({ version: VERSION })
+      .expect(401);
+
+    expect(mocks.enqueuePackageRefresh).not.toHaveBeenCalled();
+  });
+
+  it('maps OIDC and rate-limit rejections to stable API errors', async () => {
+    mocks.verifyGitHubActionsOidcToken.mockRejectedValueOnce(
+      new MockPublishTriggerAuthError(
+        'RepositoryMismatch',
+        'The GitHub Actions OIDC token repository does not match this package.',
+        403,
+      ),
+    );
+
+    await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ version: VERSION })
+      .expect(403)
+      .expect(({ body }) => {
+        expect(body.error).toBe('RepositoryMismatch');
+      });
+
+    mocks.assertPublishTriggerRateLimit.mockImplementationOnce(() => {
+      throw new MockPublishTriggerRateLimitError(60);
+    });
+
+    await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ version: VERSION })
+      .expect(429)
+      .expect('Retry-After', '60');
+  });
+
+  it('returns release status for all public states', async () => {
+    mocks.fetchOne.mockResolvedValueOnce(null);
+    await request(app.server)
+      .get(`/packages/${PACKAGE_NAME}/releases/${VERSION}/status`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.state).toBe('unknown');
+        expect(body.reason).toBe('unknown');
+      });
+
+    mocks.fetchOne.mockResolvedValueOnce(release(ReleaseState.Pending));
+    await request(app.server)
+      .get(`/packages/${PACKAGE_NAME}/releases/${VERSION}/status`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.state).toBe('pending');
+        expect(body.reason).toBe('none');
+      });
+
+    mocks.fetchOne.mockResolvedValueOnce(release(ReleaseState.Building));
+    await request(app.server)
+      .get(`/packages/${PACKAGE_NAME}/releases/${VERSION}/status`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.state).toBe('building');
+      });
+
+    mocks.fetchOne.mockResolvedValueOnce(
+      release(ReleaseState.Succeeded, {
+        signed: true,
+        publishedVersion: '1.2.4',
+      }),
+    );
+    await request(app.server)
+      .get(`/packages/${PACKAGE_NAME}/releases/${VERSION}/status`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          state: 'succeeded',
+          signed: true,
+          publishedVersion: '1.2.4',
+        });
+      });
+
+    mocks.fetchOne.mockResolvedValueOnce(
+      release(ReleaseState.Failed, {
+        reason: ReleaseErrorCode.GitHubReleaseAssetNotFound,
+      }),
+    );
+    await request(app.server)
+      .get(`/packages/${PACKAGE_NAME}/releases/${VERSION}/status`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.state).toBe('failed');
+        expect(body.reason).toBe('GitHubReleaseAssetNotFound');
+      });
+  });
+
+  it('returns 404 status for packages not registered in OpenUPM', async () => {
+    mocks.loadPackageMetadataLocal.mockResolvedValue(null);
+
+    await request(app.server)
+      .get(`/packages/${PACKAGE_NAME}/releases/${VERSION}/status`)
+      .expect(404)
+      .expect(({ body }) => {
+        expect(body.error).toBe('PackageNotFound');
+      });
+  });
+});

--- a/apps/web/__tests__/routers/packagePublish.spec.ts
+++ b/apps/web/__tests__/routers/packagePublish.spec.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   enqueuePackageRefresh: vi.fn(),
   assertPublishTriggerRateLimit: vi.fn(),
   fetchOne: vi.fn(),
+  removeRelease: vi.fn(),
 }));
 
 vi.mock('@openupm/local-data', () => ({
@@ -41,6 +42,7 @@ vi.mock('@openupm/local-data', () => ({
 
 vi.mock('@openupm/server-common/build/models/release.js', () => ({
   fetchOne: mocks.fetchOne,
+  remove: mocks.removeRelease,
 }));
 
 vi.mock('../../src/publishTrigger/githubOidc.js', () => ({
@@ -104,6 +106,7 @@ describe('package publish router', () => {
       added: true,
     });
     mocks.fetchOne.mockResolvedValue(null);
+    mocks.removeRelease.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -205,6 +208,47 @@ describe('package publish router', () => {
       version: VERSION,
       tag: 'upm/v1.2.3',
       accepted: true,
+    });
+  });
+
+  it('clears a stale failed release after accepting a refresh', async () => {
+    mocks.fetchOne
+      .mockResolvedValueOnce(
+        release(ReleaseState.Failed, {
+          reason: ReleaseErrorCode.VersionMismatch,
+        }),
+      )
+      .mockResolvedValueOnce(null);
+
+    const response = await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ tag: 'upm/1.2.3' })
+      .expect(202);
+
+    expect(mocks.enqueuePackageRefresh).toHaveBeenCalledWith(PACKAGE_NAME);
+    expect(mocks.removeRelease).toHaveBeenCalledWith(PACKAGE_NAME, VERSION);
+    expect(response.body.release).toMatchObject({
+      state: 'unknown',
+      reason: 'unknown',
+    });
+  });
+
+  it('keeps non-failed release status while accepting a refresh', async () => {
+    mocks.fetchOne
+      .mockResolvedValueOnce(release(ReleaseState.Succeeded))
+      .mockResolvedValueOnce(release(ReleaseState.Succeeded));
+
+    const response = await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ tag: 'upm/1.2.3' })
+      .expect(202);
+
+    expect(mocks.removeRelease).not.toHaveBeenCalled();
+    expect(response.body.release).toMatchObject({
+      state: 'succeeded',
+      reason: 'none',
     });
   });
 

--- a/apps/web/__tests__/routers/packagePublish.spec.ts
+++ b/apps/web/__tests__/routers/packagePublish.spec.ts
@@ -165,6 +165,27 @@ describe('package publish router', () => {
     expect(response.body.deduped).toBe(true);
   });
 
+  it('normalizes refresh request version and tag fields', async () => {
+    const response = await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ version: ` ${VERSION} `, tag: ' upm/1.2.3 ' })
+      .expect(202);
+
+    expect(mocks.verifyGitHubActionsOidcToken).toHaveBeenCalledWith(
+      'test-token',
+      {
+        packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+        tag: 'upm/1.2.3',
+      },
+    );
+    expect(mocks.fetchOne).toHaveBeenCalledWith(PACKAGE_NAME, VERSION);
+    expect(response.body).toMatchObject({
+      version: VERSION,
+      tag: 'upm/1.2.3',
+    });
+  });
+
   it('accepts GitHub Release event refresh triggers', async () => {
     mocks.verifyGitHubActionsOidcToken.mockResolvedValueOnce({
       repository: 'openupm/com.example.openupm-action',
@@ -198,6 +219,12 @@ describe('package publish router', () => {
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
       .send({})
+      .expect(400);
+
+    await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ version: '   ' })
       .expect(400);
 
     await request(app.server)

--- a/apps/web/__tests__/routers/packagePublish.spec.ts
+++ b/apps/web/__tests__/routers/packagePublish.spec.ts
@@ -118,7 +118,7 @@ describe('package publish router', () => {
     const response = await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
-      .send({ version: VERSION, tag: 'upm/1.2.3' })
+      .send({ tag: 'upm/1.2.3' })
       .expect(202)
       .expect('Content-Type', /json/);
 
@@ -159,17 +159,17 @@ describe('package publish router', () => {
     const response = await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
-      .send({ version: VERSION })
+      .send({ tag: 'upm/1.2.3' })
       .expect(202);
 
     expect(response.body.deduped).toBe(true);
   });
 
-  it('normalizes refresh request version and tag fields', async () => {
+  it('normalizes refresh request tag field', async () => {
     const response = await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
-      .send({ version: ` ${VERSION} `, tag: ' upm/1.2.3 ' })
+      .send({ tag: ' upm/1.2.3 ' })
       .expect(202);
 
     expect(mocks.verifyGitHubActionsOidcToken).toHaveBeenCalledWith(
@@ -218,7 +218,7 @@ describe('package publish router', () => {
     const response = await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer release-token')
-      .send({ version: VERSION, tag: 'v1.2.3' })
+      .send({ tag: 'v1.2.3' })
       .expect(202);
 
     expect(mocks.verifyGitHubActionsOidcToken).toHaveBeenCalledWith(
@@ -236,18 +236,24 @@ describe('package publish router', () => {
     });
   });
 
-  it('rejects missing version and token before enqueuing', async () => {
+  it('rejects missing or unparseable tags before enqueuing', async () => {
     await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
       .send({})
-      .expect(400);
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.error).toBe('InvalidTag');
+      });
 
     await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
       .send({ version: '   ' })
-      .expect(400);
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.error).toBe('InvalidTag');
+      });
 
     await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
@@ -257,7 +263,7 @@ describe('package publish router', () => {
 
     await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
-      .send({ version: VERSION })
+      .send({ tag: 'upm/1.2.3' })
       .expect(401);
 
     expect(mocks.enqueuePackageRefresh).not.toHaveBeenCalled();
@@ -275,7 +281,7 @@ describe('package publish router', () => {
     await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
-      .send({ version: VERSION })
+      .send({ tag: 'upm/1.2.3' })
       .expect(403)
       .expect(({ body }) => {
         expect(body.error).toBe('RepositoryMismatch');
@@ -288,7 +294,7 @@ describe('package publish router', () => {
     await request(app.server)
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
-      .send({ version: VERSION })
+      .send({ tag: 'upm/1.2.3' })
       .expect(429)
       .expect('Retry-After', '60');
   });

--- a/apps/web/__tests__/routers/packagePublish.spec.ts
+++ b/apps/web/__tests__/routers/packagePublish.spec.ts
@@ -186,6 +186,28 @@ describe('package publish router', () => {
     });
   });
 
+  it('derives the package version from the requested tag', async () => {
+    const response = await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ tag: ' upm/v1.2.3 ' })
+      .expect(202);
+
+    expect(mocks.verifyGitHubActionsOidcToken).toHaveBeenCalledWith(
+      'test-token',
+      {
+        packageRepoUrl: 'https://github.com/openupm/com.example.openupm-action',
+        tag: 'upm/v1.2.3',
+      },
+    );
+    expect(mocks.fetchOne).toHaveBeenCalledWith(PACKAGE_NAME, VERSION);
+    expect(response.body).toMatchObject({
+      version: VERSION,
+      tag: 'upm/v1.2.3',
+      accepted: true,
+    });
+  });
+
   it('accepts GitHub Release event refresh triggers', async () => {
     mocks.verifyGitHubActionsOidcToken.mockResolvedValueOnce({
       repository: 'openupm/com.example.openupm-action',
@@ -225,6 +247,12 @@ describe('package publish router', () => {
       .post(`/packages/${PACKAGE_NAME}/refresh`)
       .set('Authorization', 'Bearer test-token')
       .send({ version: '   ' })
+      .expect(400);
+
+    await request(app.server)
+      .post(`/packages/${PACKAGE_NAME}/refresh`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ tag: 'release' })
       .expect(400);
 
     await request(app.server)

--- a/apps/web/config/default.json5
+++ b/apps/web/config/default.json5
@@ -100,6 +100,26 @@
     tokens: [],
   },
 
+  // Public GitHub Actions OIDC package refresh trigger.
+  publishTrigger: {
+    apiBaseUrl: 'https://api.openupm.com',
+    packageBaseUrl: 'https://openupm.com',
+    registryUrl: 'https://package.openupm.com',
+    githubOidc: {
+      issuer: 'https://token.actions.githubusercontent.com',
+      audience: 'openupm',
+      jwksUri: 'https://token.actions.githubusercontent.com/.well-known/jwks',
+      acceptedEvents: ['push', 'release', 'workflow_dispatch'],
+      requirePublicRepository: true,
+      clockToleranceSeconds: 30,
+    },
+    rateLimit: {
+      enabled: true,
+      max: 20,
+      windowMs: 3600000,
+    },
+  },
+
   // Azure devops.
   azureDevops: {
     endpoint: 'https://dev.azure.com/openupm',

--- a/apps/web/config/test.json5
+++ b/apps/web/config/test.json5
@@ -5,4 +5,10 @@
     // enable offline queue mode for testing
     enableOfflineQueue: true,
   },
+
+  publishTrigger: {
+    rateLimit: {
+      enabled: false,
+    },
+  },
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,12 +24,14 @@
   "dependencies": {
     "@fastify/cors": "^8.5.0",
     "@openupm/ads": "*",
+    "@openupm/local-data": "*",
     "@openupm/server-common": "*",
     "bullmq": "^5.58.5",
     "config": "^4.4.1",
     "cron": "^3.1.6",
     "dotenv-flow": "^4.0.1",
     "fastify": "^4.25.2",
+    "jose": "^6.2.3",
     "supertest": "^6.3.4",
     "tslib": "~2.6"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@fastify/cors": "^8.5.0",
     "@openupm/ads": "*",
+    "@openupm/common": "*",
     "@openupm/local-data": "*",
     "@openupm/server-common": "*",
     "bullmq": "^5.58.5",

--- a/apps/web/src/apiServer.ts
+++ b/apps/web/src/apiServer.ts
@@ -6,6 +6,7 @@ import adsRouter from './routers/ads.js';
 import feedsRouter from './routers/feeds.js';
 import siteInfoRouter from './routers/siteInfo.js';
 import packagesRouter from './routers/packages.js';
+import packagePublishRouter from './routers/packagePublish.js';
 import queueStatusRouter from './routers/queueStatus.js';
 import trendsRouter from './routers/trends.js';
 
@@ -37,6 +38,7 @@ app.get('/', () => {
 adsRouter(app);
 feedsRouter(app);
 siteInfoRouter(app);
+packagePublishRouter(app);
 packagesRouter(app);
 queueStatusRouter(app);
 trendsRouter(app);

--- a/apps/web/src/publishTrigger/githubOidc.ts
+++ b/apps/web/src/publishTrigger/githubOidc.ts
@@ -5,6 +5,11 @@ import {
   type JWTPayload,
   type JWTVerifyResult,
 } from 'jose';
+import {
+  JOSEError,
+  JWKSInvalid,
+  JWKSTimeout,
+} from 'jose/errors';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
@@ -66,6 +71,23 @@ function getRemoteJwks(): ReturnType<typeof createRemoteJWKSet> {
 
 export function resetGitHubActionsOidcJwksForTests(): void {
   remoteJwks = null;
+}
+
+export function isRetryableJwksError(error: unknown): boolean {
+  if (error instanceof JWKSTimeout || error instanceof JWKSInvalid) {
+    return true;
+  }
+
+  if (error instanceof TypeError) {
+    return true;
+  }
+
+  return (
+    error instanceof JOSEError &&
+    error.code === 'ERR_JOSE_GENERIC' &&
+    (error.message.includes('JSON Web Key Set HTTP response') ||
+      error.message.includes('JSON Web Key Set malformed'))
+  );
 }
 
 export function normalizeGitHubRepository(value: string): string | null {
@@ -235,7 +257,14 @@ export async function verifyGitHubActionsOidcToken(
       issuer: raw.issuer,
       clockTolerance: raw.clockToleranceSeconds,
     });
-  } catch {
+  } catch (error) {
+    if (isRetryableJwksError(error)) {
+      throw new PublishTriggerAuthError(
+        'OidcUnavailable',
+        'GitHub Actions OIDC verification is temporarily unavailable.',
+        503,
+      );
+    }
     throw new PublishTriggerAuthError(
       'InvalidToken',
       'The GitHub Actions OIDC token could not be verified.',

--- a/apps/web/src/publishTrigger/githubOidc.ts
+++ b/apps/web/src/publishTrigger/githubOidc.ts
@@ -1,0 +1,203 @@
+import configRaw from 'config';
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyResult,
+} from 'jose';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config = configRaw as any;
+
+export interface GitHubActionsOidcClaims extends JWTPayload {
+  event_name?: string;
+  ref?: string;
+  ref_type?: string;
+  repository?: string;
+  repository_visibility?: string;
+}
+
+export interface GitHubActionsOidcValidationOptions {
+  packageRepoUrl: string;
+  tag?: string;
+}
+
+export class PublishTriggerAuthError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly statusCode = 401,
+  ) {
+    super(message);
+  }
+}
+
+let remoteJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function oidcConfig(): {
+  audience: string;
+  issuer: string;
+  jwksUri: string;
+  acceptedEvents: string[];
+  requirePublicRepository: boolean;
+  clockToleranceSeconds: number;
+} {
+  const raw = config.publishTrigger?.githubOidc || {};
+  const issuer = raw.issuer || 'https://token.actions.githubusercontent.com';
+  return {
+    audience: raw.audience || 'openupm',
+    issuer,
+    jwksUri: raw.jwksUri || `${issuer}/.well-known/jwks`,
+    acceptedEvents: raw.acceptedEvents || [
+      'push',
+      'release',
+      'workflow_dispatch',
+    ],
+    requirePublicRepository: raw.requirePublicRepository !== false,
+    clockToleranceSeconds: raw.clockToleranceSeconds ?? 30,
+  };
+}
+
+function getRemoteJwks(): ReturnType<typeof createRemoteJWKSet> {
+  if (remoteJwks) return remoteJwks;
+  remoteJwks = createRemoteJWKSet(new URL(oidcConfig().jwksUri));
+  return remoteJwks;
+}
+
+export function resetGitHubActionsOidcJwksForTests(): void {
+  remoteJwks = null;
+}
+
+export function normalizeGitHubRepository(value: string): string | null {
+  const sshPrefix = 'git@github.com:';
+  if (value.startsWith(sshPrefix)) {
+    const path = value.slice(sshPrefix.length);
+    const [owner, rawRepo] = path.split('/').filter(Boolean);
+    if (!owner || !rawRepo) return null;
+    return `${owner}/${rawRepo.replace(/\.git$/i, '')}`.toLowerCase();
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.hostname.toLowerCase() !== 'github.com') return null;
+    const [owner, rawRepo] = parsed.pathname.split('/').filter(Boolean);
+    if (!owner || !rawRepo) return null;
+    return `${owner}/${rawRepo.replace(/\.git$/i, '')}`.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function asClaims(payload: JWTPayload): GitHubActionsOidcClaims {
+  return payload as GitHubActionsOidcClaims;
+}
+
+export function validateGitHubActionsOidcClaims(
+  claims: GitHubActionsOidcClaims,
+  options: GitHubActionsOidcValidationOptions,
+): GitHubActionsOidcClaims {
+  const {
+    acceptedEvents,
+    issuer,
+    requirePublicRepository,
+    audience,
+  } = oidcConfig();
+
+  if (claims.iss !== issuer) {
+    throw new PublishTriggerAuthError(
+      'InvalidIssuer',
+      'The GitHub Actions OIDC token has an invalid issuer.',
+    );
+  }
+
+  const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
+  if (!audiences.includes(audience)) {
+    throw new PublishTriggerAuthError(
+      'InvalidAudience',
+      'The GitHub Actions OIDC token has an invalid audience.',
+    );
+  }
+
+  if (!claims.repository) {
+    throw new PublishTriggerAuthError(
+      'MissingRepositoryClaim',
+      'The GitHub Actions OIDC token is missing its repository claim.',
+    );
+  }
+
+  const packageRepo = normalizeGitHubRepository(options.packageRepoUrl);
+  if (!packageRepo) {
+    throw new PublishTriggerAuthError(
+      'UnsupportedRepositoryUrl',
+      'The package repository URL is not a supported GitHub repository URL.',
+      403,
+    );
+  }
+
+  if (claims.repository.toLowerCase() !== packageRepo) {
+    throw new PublishTriggerAuthError(
+      'RepositoryMismatch',
+      'The GitHub Actions OIDC token repository does not match this package.',
+      403,
+    );
+  }
+
+  if (requirePublicRepository && claims.repository_visibility !== 'public') {
+    throw new PublishTriggerAuthError(
+      'UnsupportedRepositoryVisibility',
+      'Only public GitHub repositories can trigger OpenUPM publishing.',
+      403,
+    );
+  }
+
+  if (!claims.event_name || !acceptedEvents.includes(claims.event_name)) {
+    throw new PublishTriggerAuthError(
+      'UnsupportedEvent',
+      'This GitHub Actions event cannot trigger OpenUPM publishing.',
+      403,
+    );
+  }
+
+  if (claims.event_name === 'pull_request') {
+    throw new PublishTriggerAuthError(
+      'UnsupportedEvent',
+      'Pull request workflows cannot trigger OpenUPM publishing.',
+      403,
+    );
+  }
+
+  if (options.tag) {
+    const expectedRef = `refs/tags/${options.tag}`;
+    if (claims.ref_type !== 'tag' || claims.ref !== expectedRef) {
+      throw new PublishTriggerAuthError(
+        'RefMismatch',
+        'The GitHub Actions OIDC token ref does not match the requested tag.',
+        403,
+      );
+    }
+  }
+
+  return claims;
+}
+
+export async function verifyGitHubActionsOidcToken(
+  token: string,
+  options: GitHubActionsOidcValidationOptions,
+): Promise<GitHubActionsOidcClaims> {
+  const raw = oidcConfig();
+  let result: JWTVerifyResult;
+  try {
+    result = await jwtVerify(token, getRemoteJwks(), {
+      audience: raw.audience,
+      issuer: raw.issuer,
+      clockTolerance: raw.clockToleranceSeconds,
+    });
+  } catch {
+    throw new PublishTriggerAuthError(
+      'InvalidToken',
+      'The GitHub Actions OIDC token could not be verified.',
+    );
+  }
+
+  return validateGitHubActionsOidcClaims(asClaims(result.payload), options);
+}

--- a/apps/web/src/publishTrigger/githubOidc.ts
+++ b/apps/web/src/publishTrigger/githubOidc.ts
@@ -101,7 +101,7 @@ function immutableRepoSubjectPattern(repository: string, ref: string): RegExp {
   return new RegExp(
     `^repo:${escapeRegExp(owner)}@[0-9]+/${escapeRegExp(
       repo,
-    )}@[0-9]+:ref:${escapeRegExp(ref)}$`,
+    )}@[0-9]+:ref:${escapeRegExp(ref)}(?::|$)`,
     'i',
   );
 }
@@ -113,7 +113,12 @@ function validateSubjectRef(
   if (!claims.sub || !claims.ref || !claims.sub.includes(':ref:')) return;
 
   const expectedLegacySubject = `repo:${packageRepo}:ref:${claims.ref}`;
-  if (claims.sub.toLowerCase() === expectedLegacySubject.toLowerCase()) {
+  const lowerSubject = claims.sub.toLowerCase();
+  const lowerExpectedSubject = expectedLegacySubject.toLowerCase();
+  if (
+    lowerSubject === lowerExpectedSubject ||
+    lowerSubject.startsWith(`${lowerExpectedSubject}:`)
+  ) {
     return;
   }
 

--- a/apps/web/src/publishTrigger/githubOidc.ts
+++ b/apps/web/src/publishTrigger/githubOidc.ts
@@ -92,6 +92,42 @@ function asClaims(payload: JWTPayload): GitHubActionsOidcClaims {
   return payload as GitHubActionsOidcClaims;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function immutableRepoSubjectPattern(repository: string, ref: string): RegExp {
+  const [owner, repo] = repository.split('/');
+  return new RegExp(
+    `^repo:${escapeRegExp(owner)}@[0-9]+/${escapeRegExp(
+      repo,
+    )}@[0-9]+:ref:${escapeRegExp(ref)}$`,
+    'i',
+  );
+}
+
+function validateSubjectRef(
+  claims: GitHubActionsOidcClaims,
+  packageRepo: string,
+): void {
+  if (!claims.sub || !claims.ref || !claims.sub.includes(':ref:')) return;
+
+  const expectedLegacySubject = `repo:${packageRepo}:ref:${claims.ref}`;
+  if (claims.sub.toLowerCase() === expectedLegacySubject.toLowerCase()) {
+    return;
+  }
+
+  if (immutableRepoSubjectPattern(packageRepo, claims.ref).test(claims.sub)) {
+    return;
+  }
+
+  throw new PublishTriggerAuthError(
+    'SubjectMismatch',
+    'The GitHub Actions OIDC token subject does not match this package.',
+    403,
+  );
+}
+
 export function validateGitHubActionsOidcClaims(
   claims: GitHubActionsOidcClaims,
   options: GitHubActionsOidcValidationOptions,
@@ -141,6 +177,8 @@ export function validateGitHubActionsOidcClaims(
       403,
     );
   }
+
+  validateSubjectRef(claims, packageRepo);
 
   if (requirePublicRepository && claims.repository_visibility !== 'public') {
     throw new PublishTriggerAuthError(

--- a/apps/web/src/publishTrigger/packageRefresh.ts
+++ b/apps/web/src/publishTrigger/packageRefresh.ts
@@ -1,0 +1,55 @@
+import configRaw from 'config';
+import { Queue } from 'bullmq';
+
+import { createLogger } from '@openupm/server-common/build/log.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config = configRaw as any;
+const logger = createLogger('@openupm/web/packageRefresh');
+
+const queues: Record<string, Queue> = {};
+
+export interface PackageRefreshResult {
+  queue: string;
+  jobId: string;
+  added: boolean;
+}
+
+function createJobId(...parts: string[]): string {
+  return parts.map((part) => encodeURIComponent(part)).join('|');
+}
+
+function getQueue(name: string): Queue {
+  if (!queues[name]) {
+    queues[name] = new Queue(name, {
+      ...config.queueSettings[name],
+      connection: config.redis,
+    });
+  }
+  return queues[name];
+}
+
+export async function closePackageRefreshQueues(): Promise<void> {
+  await Promise.all(Object.values(queues).map(async (queue) => queue.close()));
+  for (const name of Object.keys(queues)) delete queues[name];
+}
+
+export async function enqueuePackageRefresh(
+  packageName: string,
+): Promise<PackageRefreshResult> {
+  const jobConfig = config.jobs.buildPackage;
+  const queue = getQueue(jobConfig.queue);
+  const jobId = createJobId(jobConfig.name, packageName);
+  const existing = await queue.getJob(jobId);
+  if (existing) {
+    return { queue: jobConfig.queue, jobId, added: false };
+  }
+
+  const job = await queue.add(
+    jobConfig.name,
+    { name: packageName },
+    { jobId },
+  );
+  logger.info({ packageName, jobId: job.id }, 'accepted package refresh');
+  return { queue: jobConfig.queue, jobId, added: true };
+}

--- a/apps/web/src/publishTrigger/packageRefresh.ts
+++ b/apps/web/src/publishTrigger/packageRefresh.ts
@@ -1,5 +1,5 @@
 import configRaw from 'config';
-import { Queue } from 'bullmq';
+import { Queue, type Job } from 'bullmq';
 
 import { createLogger } from '@openupm/server-common/build/log.js';
 
@@ -29,6 +29,13 @@ function getQueue(name: string): Queue {
   return queues[name];
 }
 
+async function canReuseExistingJob(job: Job): Promise<boolean> {
+  const state = await job.getState();
+  if (state !== 'failed') return true;
+  await job.remove();
+  return false;
+}
+
 export async function closePackageRefreshQueues(): Promise<void> {
   await Promise.all(Object.values(queues).map(async (queue) => queue.close()));
   for (const name of Object.keys(queues)) delete queues[name];
@@ -41,7 +48,7 @@ export async function enqueuePackageRefresh(
   const queue = getQueue(jobConfig.queue);
   const jobId = createJobId(jobConfig.name, packageName);
   const existing = await queue.getJob(jobId);
-  if (existing) {
+  if (existing && (await canReuseExistingJob(existing))) {
     return { queue: jobConfig.queue, jobId, added: false };
   }
 

--- a/apps/web/src/publishTrigger/rateLimit.ts
+++ b/apps/web/src/publishTrigger/rateLimit.ts
@@ -1,0 +1,67 @@
+import configRaw from 'config';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config = configRaw as any;
+
+interface RateLimitBucket {
+  count: number;
+  resetAt: number;
+}
+
+const buckets = new Map<string, RateLimitBucket>();
+
+export class PublishTriggerRateLimitError extends Error {
+  constructor(public readonly retryAfterSeconds: number) {
+    super('The package refresh trigger rate limit was exceeded.');
+  }
+}
+
+function rateLimitConfig(): {
+  enabled: boolean;
+  max: number;
+  windowMs: number;
+} {
+  const raw = config.publishTrigger?.rateLimit || {};
+  return {
+    enabled: raw.enabled !== false,
+    max: raw.max ?? 20,
+    windowMs: raw.windowMs ?? 60 * 60 * 1000,
+  };
+}
+
+export function resetPublishTriggerRateLimitForTests(): void {
+  buckets.clear();
+}
+
+export function assertPublishTriggerRateLimit(params: {
+  packageName: string;
+  repository: string;
+  ip: string;
+  now?: number;
+}): void {
+  const rateLimit = rateLimitConfig();
+  if (!rateLimit.enabled || rateLimit.max <= 0 || rateLimit.windowMs <= 0) {
+    return;
+  }
+
+  const now = params.now ?? Date.now();
+  const key = [
+    params.packageName,
+    params.repository.toLowerCase(),
+    params.ip || 'unknown',
+  ].join('|');
+  const existing = buckets.get(key);
+  const bucket =
+    existing && existing.resetAt > now
+      ? existing
+      : { count: 0, resetAt: now + rateLimit.windowMs };
+
+  bucket.count += 1;
+  buckets.set(key, bucket);
+
+  if (bucket.count > rateLimit.max) {
+    throw new PublishTriggerRateLimitError(
+      Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    );
+  }
+}

--- a/apps/web/src/routers/packagePublish.ts
+++ b/apps/web/src/routers/packagePublish.ts
@@ -4,7 +4,10 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { getVersionFromTag } from '@openupm/common/build/semver.js';
 import { loadPackageMetadataLocal } from '@openupm/local-data';
 import { ReleaseErrorCode, ReleaseModel, ReleaseState } from '@openupm/types';
-import { fetchOne } from '@openupm/server-common/build/models/release.js';
+import {
+  fetchOne,
+  remove as removeRelease,
+} from '@openupm/server-common/build/models/release.js';
 import { createLogger } from '@openupm/server-common/build/log.js';
 
 import {
@@ -86,6 +89,16 @@ async function releaseStatus(
   };
 }
 
+async function clearFailedReleaseForRefresh(
+  packageName: string,
+  version: string,
+): Promise<void> {
+  const release = await fetchOne(packageName, version);
+  if (release?.state === ReleaseState.Failed) {
+    await removeRelease(packageName, version);
+  }
+}
+
 function bearerToken(request: FastifyRequest): string | null {
   const header = request.headers.authorization;
   if (!header) return null;
@@ -160,6 +173,7 @@ export default function router(server: FastifyInstance): void {
         });
 
         const job = await enqueuePackageRefresh(packageName);
+        await clearFailedReleaseForRefresh(packageName, version);
         const status = await releaseStatus(packageName, version);
         logger.info(
           {

--- a/apps/web/src/routers/packagePublish.ts
+++ b/apps/web/src/routers/packagePublish.ts
@@ -172,8 +172,8 @@ export default function router(server: FastifyInstance): void {
           ip: request.ip,
         });
 
-        const job = await enqueuePackageRefresh(packageName);
         await clearFailedReleaseForRefresh(packageName, version);
+        const job = await enqueuePackageRefresh(packageName);
         const status = await releaseStatus(packageName, version);
         logger.info(
           {

--- a/apps/web/src/routers/packagePublish.ts
+++ b/apps/web/src/routers/packagePublish.ts
@@ -102,6 +102,12 @@ function sendError(
   return reply.status(statusCode).send({ error: code, message });
 }
 
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
 export default function router(server: FastifyInstance): void {
   server.post(
     '/packages/:name/refresh',
@@ -110,7 +116,8 @@ export default function router(server: FastifyInstance): void {
       reply: FastifyReply,
     ) => {
       const packageName = request.params.name;
-      const { version, tag } = request.body || {};
+      const version = normalizeOptionalString(request.body?.version);
+      const tag = normalizeOptionalString(request.body?.tag);
 
       if (!version) {
         return sendError(

--- a/apps/web/src/routers/packagePublish.ts
+++ b/apps/web/src/routers/packagePublish.ts
@@ -1,0 +1,236 @@
+import configRaw from 'config';
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import { loadPackageMetadataLocal } from '@openupm/local-data';
+import { ReleaseErrorCode, ReleaseModel, ReleaseState } from '@openupm/types';
+import { fetchOne } from '@openupm/server-common/build/models/release.js';
+import { createLogger } from '@openupm/server-common/build/log.js';
+
+import {
+  PublishTriggerAuthError,
+  verifyGitHubActionsOidcToken,
+} from '../publishTrigger/githubOidc.js';
+import { enqueuePackageRefresh } from '../publishTrigger/packageRefresh.js';
+import {
+  assertPublishTriggerRateLimit,
+  PublishTriggerRateLimitError,
+} from '../publishTrigger/rateLimit.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config = configRaw as any;
+const logger = createLogger('@openupm/web/packagePublish');
+
+interface RefreshBody {
+  version?: string;
+  tag?: string;
+}
+
+type ReleasePublishState =
+  | 'unknown'
+  | 'pending'
+  | 'building'
+  | 'succeeded'
+  | 'failed';
+
+interface ReleaseStatusResponse {
+  packageName: string;
+  version: string;
+  state: ReleasePublishState;
+  reason: string;
+  signed: boolean;
+  publishedVersion?: string;
+  registryUrl: string;
+  packageUrl: string;
+}
+
+function apiBaseUrl(): string {
+  return (config.publishTrigger?.apiBaseUrl || 'https://api.openupm.com')
+    .replace(/\/+$/g, '');
+}
+
+function packageUrl(packageName: string): string {
+  const base = (config.publishTrigger?.packageBaseUrl || 'https://openupm.com')
+    .replace(/\/+$/g, '');
+  return `${base}/packages/${encodeURIComponent(packageName)}/`;
+}
+
+function releaseStateName(release: ReleaseModel | null): ReleasePublishState {
+  if (!release) return 'unknown';
+  if (release.state === ReleaseState.Pending) return 'pending';
+  if (release.state === ReleaseState.Building) return 'building';
+  if (release.state === ReleaseState.Succeeded) return 'succeeded';
+  return 'failed';
+}
+
+function releaseReasonName(release: ReleaseModel | null): string {
+  if (!release) return 'unknown';
+  if (release.reason === ReleaseErrorCode.None) return 'none';
+  return ReleaseErrorCode[release.reason] || String(release.reason);
+}
+
+async function releaseStatus(
+  packageName: string,
+  version: string,
+): Promise<ReleaseStatusResponse> {
+  const release = await fetchOne(packageName, version);
+  return {
+    packageName,
+    version,
+    state: releaseStateName(release),
+    reason: releaseReasonName(release),
+    signed: release?.signed ?? false,
+    publishedVersion: release?.publishedVersion,
+    registryUrl:
+      config.publishTrigger?.registryUrl || 'https://package.openupm.com',
+    packageUrl: packageUrl(packageName),
+  };
+}
+
+function bearerToken(request: FastifyRequest): string | null {
+  const header = request.headers.authorization;
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match ? match[1] : null;
+}
+
+function sendError(
+  reply: FastifyReply,
+  statusCode: number,
+  code: string,
+  message: string,
+): FastifyReply {
+  return reply.status(statusCode).send({ error: code, message });
+}
+
+export default function router(server: FastifyInstance): void {
+  server.post(
+    '/packages/:name/refresh',
+    async (
+      request: FastifyRequest<{ Params: { name: string }; Body: RefreshBody }>,
+      reply: FastifyReply,
+    ) => {
+      const packageName = request.params.name;
+      const { version, tag } = request.body || {};
+
+      if (!version) {
+        return sendError(
+          reply,
+          400,
+          'MissingVersion',
+          'A package version is required.',
+        );
+      }
+
+      const token = bearerToken(request);
+      if (!token) {
+        return sendError(
+          reply,
+          401,
+          'MissingToken',
+          'A GitHub Actions OIDC bearer token is required.',
+        );
+      }
+
+      const pkg = await loadPackageMetadataLocal(packageName);
+      if (!pkg) {
+        return sendError(
+          reply,
+          404,
+          'PackageNotFound',
+          'The package is not registered in OpenUPM.',
+        );
+      }
+
+      try {
+        const claims = await verifyGitHubActionsOidcToken(token, {
+          packageRepoUrl: pkg.repoUrl,
+          tag,
+        });
+        assertPublishTriggerRateLimit({
+          packageName,
+          repository: claims.repository || '',
+          ip: request.ip,
+        });
+
+        const job = await enqueuePackageRefresh(packageName);
+        const status = await releaseStatus(packageName, version);
+        logger.info(
+          {
+            packageName,
+            version,
+            tag,
+            repository: claims.repository,
+            event: claims.event_name,
+            ref: claims.ref,
+            jobId: job.jobId,
+            added: job.added,
+          },
+          'accepted package refresh trigger',
+        );
+
+        return reply.status(202).send({
+          packageName,
+          version,
+          tag,
+          accepted: true,
+          deduped: !job.added,
+          statusUrl: `${apiBaseUrl()}/packages/${encodeURIComponent(
+            packageName,
+          )}/releases/${encodeURIComponent(version)}/status`,
+          release: {
+            state: status.state,
+            reason: status.reason,
+          },
+        });
+      } catch (error) {
+        if (error instanceof PublishTriggerAuthError) {
+          logger.warn(
+            { packageName, version, tag, code: error.code },
+            'rejected package refresh trigger',
+          );
+          return sendError(
+            reply,
+            error.statusCode,
+            error.code,
+            error.message,
+          );
+        }
+
+        if (error instanceof PublishTriggerRateLimitError) {
+          reply.header('Retry-After', String(error.retryAfterSeconds));
+          return sendError(
+            reply,
+            429,
+            'RateLimitExceeded',
+            error.message,
+          );
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  server.get(
+    '/packages/:name/releases/:version/status',
+    async (
+      request: FastifyRequest<{
+        Params: { name: string; version: string };
+      }>,
+      reply: FastifyReply,
+    ) => {
+      const { name, version } = request.params;
+      const pkg = await loadPackageMetadataLocal(name);
+      if (!pkg) {
+        return sendError(
+          reply,
+          404,
+          'PackageNotFound',
+          'The package is not registered in OpenUPM.',
+        );
+      }
+
+      return reply.send(await releaseStatus(name, version));
+    },
+  );
+}

--- a/apps/web/src/routers/packagePublish.ts
+++ b/apps/web/src/routers/packagePublish.ts
@@ -22,7 +22,6 @@ const config = configRaw as any;
 const logger = createLogger('@openupm/web/packagePublish');
 
 interface RefreshBody {
-  version?: string;
   tag?: string;
 }
 
@@ -109,14 +108,6 @@ function normalizeOptionalString(value: string | undefined): string | undefined 
   return trimmed || undefined;
 }
 
-function resolveRefreshVersion(
-  version: string | undefined,
-  tag: string | undefined,
-): string | null {
-  if (version) return version;
-  return tag ? getVersionFromTag(tag) : null;
-}
-
 export default function router(server: FastifyInstance): void {
   server.post(
     '/packages/:name/refresh',
@@ -126,17 +117,14 @@ export default function router(server: FastifyInstance): void {
     ) => {
       const packageName = request.params.name;
       const tag = normalizeOptionalString(request.body?.tag);
-      const version = resolveRefreshVersion(
-        normalizeOptionalString(request.body?.version),
-        tag,
-      );
+      const version = tag ? getVersionFromTag(tag) : null;
 
       if (!version) {
         return sendError(
           reply,
           400,
-          'MissingVersion',
-          'A package version is required when it cannot be derived from the tag.',
+          'InvalidTag',
+          'A parseable Git tag is required.',
         );
       }
 

--- a/apps/web/src/routers/packagePublish.ts
+++ b/apps/web/src/routers/packagePublish.ts
@@ -1,6 +1,7 @@
 import configRaw from 'config';
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
+import { getVersionFromTag } from '@openupm/common/build/semver.js';
 import { loadPackageMetadataLocal } from '@openupm/local-data';
 import { ReleaseErrorCode, ReleaseModel, ReleaseState } from '@openupm/types';
 import { fetchOne } from '@openupm/server-common/build/models/release.js';
@@ -108,6 +109,14 @@ function normalizeOptionalString(value: string | undefined): string | undefined 
   return trimmed || undefined;
 }
 
+function resolveRefreshVersion(
+  version: string | undefined,
+  tag: string | undefined,
+): string | null {
+  if (version) return version;
+  return tag ? getVersionFromTag(tag) : null;
+}
+
 export default function router(server: FastifyInstance): void {
   server.post(
     '/packages/:name/refresh',
@@ -116,15 +125,18 @@ export default function router(server: FastifyInstance): void {
       reply: FastifyReply,
     ) => {
       const packageName = request.params.name;
-      const version = normalizeOptionalString(request.body?.version);
       const tag = normalizeOptionalString(request.body?.tag);
+      const version = resolveRefreshVersion(
+        normalizeOptionalString(request.body?.version),
+        tag,
+      );
 
       if (!version) {
         return sendError(
           reply,
           400,
           'MissingVersion',
-          'A package version is required.',
+          'A package version is required when it cannot be derived from the tag.',
         );
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,12 +187,14 @@
       "dependencies": {
         "@fastify/cors": "^8.5.0",
         "@openupm/ads": "*",
+        "@openupm/local-data": "*",
         "@openupm/server-common": "*",
         "bullmq": "^5.58.5",
         "config": "^4.4.1",
         "cron": "^3.1.6",
         "dotenv-flow": "^4.0.1",
         "fastify": "^4.25.2",
+        "jose": "^6.2.3",
         "supertest": "^6.3.4",
         "tslib": "~2.6"
       }
@@ -12672,6 +12674,15 @@
         "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-md4": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,6 +187,7 @@
       "dependencies": {
         "@fastify/cors": "^8.5.0",
         "@openupm/ads": "*",
+        "@openupm/common": "*",
         "@openupm/local-data": "*",
         "@openupm/server-common": "*",
         "bullmq": "^5.58.5",


### PR DESCRIPTION
## Summary

- Add GitHub Actions OIDC verification for package refresh requests.
- Add authenticated package refresh trigger and public release status polling endpoints.
- Enqueue deterministic package scans with request validation, rate limiting, and idempotent behavior.
- Add user-facing docs for the OpenUPM GitHub Action workflow.

## Validation

- npm -w @openupm/web run test -- packagePublish.spec.ts githubOidc.spec.ts packageRefresh.spec.ts
- npm -w @openupm/web run lint
- npm -w @openupm/web run build
- npm -w @openupm/docs run lint
- npm -w @openupm/docs run docs:build:limit
- npm run lint
- npm run build
- npm test

## Notes

- Keep this PR out of automatic merge until the docs/site changes receive human review.
- The endpoint verifies GitHub OIDC JWTs locally through GitHub JWKS and does not require an OpenUPM GitHub API token for token verification.