### PR TITLE
docs: cross-link action release workflow

### DIFF
--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -93,9 +93,17 @@ jobs:
           tag: ${{ github.event.release.tag_name }}
 ```
 
-Use the release workflow for packages that publish through GitHub Release asset
-tracking, including signed packages. In that mode, OpenUPM needs the GitHub
-Release and its package asset to exist before it scans the version.
+Use this release workflow for packages that publish through GitHub Release
+asset tracking, including signed packages, when the GitHub Release is published
+before this workflow starts and the package asset is already attached. In that
+mode, OpenUPM needs the GitHub Release and its package asset to exist before it
+scans the version.
+
+If another GitHub Actions workflow creates the GitHub Release and uploads the
+asset, add `openupm/openupm-action` as a later step in that same workflow after
+the upload. A release created by a workflow's `GITHUB_TOKEN` does not normally
+start another workflow from the `release` event, and triggering before the asset
+upload can make OpenUPM scan too early.
 
 ## Inputs
 
@@ -147,4 +155,5 @@ owner profiles. Normal tag or release publishing should not hit it.
 The [`openupm/com.example.openupm-action`](https://github.com/openupm/com.example.openupm-action)
 repository demonstrates a minimal Unity package that publishes through the
 tag-push workflow. Packages that use GitHub Release asset tracking should use
-the [GitHub Release workflow](#github-release-workflow) instead.
+the [GitHub Release workflow](#github-release-workflow) or call the action
+after the release asset upload instead.

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -93,6 +93,10 @@ jobs:
           tag: ${{ github.event.release.tag_name }}
 ```
 
+Use the release workflow for packages that publish through GitHub Release asset
+tracking, including signed packages. In that mode, OpenUPM needs the GitHub
+Release and its package asset to exist before it scans the version.
+
 ## Inputs
 
 | Input                   | Required | Default                   | Description |
@@ -142,4 +146,5 @@ owner profiles. Normal tag or release publishing should not hit it.
 
 The [`openupm/com.example.openupm-action`](https://github.com/openupm/com.example.openupm-action)
 repository demonstrates a minimal Unity package that publishes through the
-[`openupm/openupm-action`](https://github.com/openupm/openupm-action) workflow.
+tag-push workflow. Packages that use GitHub Release asset tracking should use
+the [GitHub Release workflow](#github-release-workflow) instead.

--- a/apps/docs/docs/docs/github-action-publish.md
+++ b/apps/docs/docs/docs/github-action-publish.md
@@ -68,9 +68,19 @@ jobs:
 The `id-token: write` permission lets the action request a GitHub OIDC token.
 The token is scoped to the workflow run and expires quickly.
 
-## GitHub Release Workflow
+## GitHub Release Workflows
 
-You can also trigger OpenUPM after a GitHub Release is published:
+For packages that publish through GitHub Release asset tracking, including
+signed packages, OpenUPM needs the GitHub Release and its package asset to
+exist before it scans the version. Choose the workflow shape based on who
+creates the GitHub Release.
+
+### Case 1: The Release Already Exists
+
+Use a `release: published` workflow when the GitHub Release is created outside
+this workflow, and the package asset is already attached when the release event
+fires. This is a good fit for manually published releases or external release
+tools that publish the release after uploading the asset.
 
 ```yaml
 name: OpenUPM
@@ -93,17 +103,47 @@ jobs:
           tag: ${{ github.event.release.tag_name }}
 ```
 
-Use this release workflow for packages that publish through GitHub Release
-asset tracking, including signed packages, when the GitHub Release is published
-before this workflow starts and the package asset is already attached. In that
-mode, OpenUPM needs the GitHub Release and its package asset to exist before it
-scans the version.
+### Case 2: This Workflow Creates The Release
 
-If another GitHub Actions workflow creates the GitHub Release and uploads the
-asset, add `openupm/openupm-action` as a later step in that same workflow after
-the upload. A release created by a workflow's `GITHUB_TOKEN` does not normally
-start another workflow from the `release` event, and triggering before the asset
-upload can make OpenUPM scan too early.
+If a GitHub Actions workflow builds the package, creates the GitHub Release,
+and uploads the package asset, call `openupm/openupm-action` as a later step in
+that same workflow after the upload:
+
+```yaml
+name: Build signed package and publish to OpenUPM
+
+on:
+  push:
+    tags:
+      - '**'
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Build, sign, and verify the UPM tarball here.
+
+      - name: Upload GitHub Release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: path/to/com.example.package-*.tgz
+
+      - uses: openupm/openupm-action@v1
+        with:
+          package: com.example.package
+          tag: ${{ github.ref_name }}
+```
+
+A release created by a workflow's `GITHUB_TOKEN` does not normally start
+another workflow from the `release` event. Even when a separate release event
+workflow does run, it can start before later asset upload steps finish. Keeping
+the OpenUPM action after the asset upload avoids both cases.
 
 ## Inputs
 
@@ -155,5 +195,4 @@ owner profiles. Normal tag or release publishing should not hit it.
 The [`openupm/com.example.openupm-action`](https://github.com/openupm/com.example.openupm-action)
 repository demonstrates a minimal Unity package that publishes through the
 tag-push workflow. Packages that use GitHub Release asset tracking should use
-the [GitHub Release workflow](#github-release-workflow) or call the action
-after the release asset upload instead.
+one of the [GitHub Release workflows](#github-release-workflows) instead.

--- a/apps/docs/docs/docs/signing-upm-packages.md
+++ b/apps/docs/docs/docs/signing-upm-packages.md
@@ -98,13 +98,15 @@ Actions workflow artifact. Workflow artifacts and logs expire after their
 retention period. Release assets stay attached to the release until the asset or
 release is deleted, so OpenUPM can process older versions later.
 
-After the workflow publishes the GitHub Release and uploads the signed asset,
-call the [OpenUPM GitHub Action](./github-action-publish.md) and wait until
-that version is available from the registry. Signed packages and other GitHub
-Release asset tracking packages should trigger OpenUPM only after the release
-asset is present. If the same GitHub Actions workflow creates the release,
-invoke `openupm/openupm-action` as a later step in that workflow. Use a separate
-[GitHub Release workflow](./github-action-publish.md#github-release-workflow)
+Optionally, for a more integrated release experience, call the
+[OpenUPM GitHub Action](./github-action-publish.md) after the workflow
+publishes the GitHub Release and uploads the signed asset. The action waits
+until that version is available from the registry. Signed packages and other
+GitHub Release asset tracking packages should trigger OpenUPM only after the
+release asset is present. If the same GitHub Actions workflow creates the
+release, invoke `openupm/openupm-action` as a later step in that workflow. Use a
+separate
+[GitHub Release workflow](./github-action-publish.md#github-release-workflows)
 only when the release event is created outside that workflow and the package
 asset is already attached when the event fires.
 
@@ -190,6 +192,6 @@ your own release workflow. This keeps signing credentials and custom build steps
 in your repository while still letting OpenUPM publish the final UPM package.
 Pair this mode with `openupm/openupm-action` after the release asset upload
 when you want CI to notify OpenUPM immediately. The
-[GitHub Release workflow](./github-action-publish.md#github-release-workflow)
+[GitHub Release workflow](./github-action-publish.md#github-release-workflows)
 is a good fit when the release is published before that workflow starts and its
 package asset is already available.

--- a/apps/docs/docs/docs/signing-upm-packages.md
+++ b/apps/docs/docs/docs/signing-upm-packages.md
@@ -99,11 +99,14 @@ retention period. Release assets stay attached to the release until the asset or
 release is deleted, so OpenUPM can process older versions later.
 
 After the workflow publishes the GitHub Release and uploads the signed asset,
-use the [OpenUPM GitHub Action release workflow](./github-action-publish.md#github-release-workflow)
-to trigger OpenUPM and wait until that version is available from the registry.
-Signed packages and other GitHub Release asset tracking packages should use the
-release workflow instead of the tag-push workflow, so OpenUPM is triggered only
-after the release asset is present.
+call the [OpenUPM GitHub Action](./github-action-publish.md) and wait until
+that version is available from the registry. Signed packages and other GitHub
+Release asset tracking packages should trigger OpenUPM only after the release
+asset is present. If the same GitHub Actions workflow creates the release,
+invoke `openupm/openupm-action` as a later step in that workflow. Use a separate
+[GitHub Release workflow](./github-action-publish.md#github-release-workflow)
+only when the release event is created outside that workflow and the package
+asset is already attached when the event fires.
 
 The [Signed UPM Example](https://github.com/openupm/com.example.signed-upm)
 repository is a minimal reference implementation. Its
@@ -185,6 +188,8 @@ from the tagged Git checkout.
 Use `trackingMode: githubRelease` when the published package must be produced by
 your own release workflow. This keeps signing credentials and custom build steps
 in your repository while still letting OpenUPM publish the final UPM package.
-Pair this mode with the [OpenUPM GitHub Action release workflow](./github-action-publish.md#github-release-workflow)
-when you want CI to notify OpenUPM immediately after the GitHub Release is
-published.
+Pair this mode with `openupm/openupm-action` after the release asset upload
+when you want CI to notify OpenUPM immediately. The
+[GitHub Release workflow](./github-action-publish.md#github-release-workflow)
+is a good fit when the release is published before that workflow starts and its
+package asset is already available.

--- a/apps/docs/docs/docs/signing-upm-packages.md
+++ b/apps/docs/docs/docs/signing-upm-packages.md
@@ -98,6 +98,13 @@ Actions workflow artifact. Workflow artifacts and logs expire after their
 retention period. Release assets stay attached to the release until the asset or
 release is deleted, so OpenUPM can process older versions later.
 
+After the workflow publishes the GitHub Release and uploads the signed asset,
+use the [OpenUPM GitHub Action release workflow](./github-action-publish.md#github-release-workflow)
+to trigger OpenUPM and wait until that version is available from the registry.
+Signed packages and other GitHub Release asset tracking packages should use the
+release workflow instead of the tag-push workflow, so OpenUPM is triggered only
+after the release asset is present.
+
 The [Signed UPM Example](https://github.com/openupm/com.example.signed-upm)
 repository is a minimal reference implementation. Its
 [README](https://github.com/openupm/com.example.signed-upm/blob/main/README.md)
@@ -178,3 +185,6 @@ from the tagged Git checkout.
 Use `trackingMode: githubRelease` when the published package must be produced by
 your own release workflow. This keeps signing credentials and custom build steps
 in your repository while still letting OpenUPM publish the final UPM package.
+Pair this mode with the [OpenUPM GitHub Action release workflow](./github-action-publish.md#github-release-workflow)
+when you want CI to notify OpenUPM immediately after the GitHub Release is
+published.


### PR DESCRIPTION
## Summary

- Link the signing guide to the OpenUPM GitHub Action guidance.
- Clarify that the OpenUPM Action step is optional for a more integrated signing release experience.
- Split GitHub Release guidance into two explicit workflow snippets: one for releases that already exist before the workflow starts, and one for workflows that create/upload the release asset before calling OpenUPM.
- Clarify that the example action repository demonstrates the tag-push workflow.

## Validation

- npm run lint from apps/docs
- npm run docs:build:limit from apps/docs