### PR TITLE
[codex] add Favo Yang blog link

### DIFF
--- a/apps/docs/docs/docs/team.md
+++ b/apps/docs/docs/docs/team.md
@@ -18,6 +18,7 @@ OpenUPM thrives through the hard work and dedication of this team, along with co
     <ul>
       <li><i class="fa fa-code"></i> Creator @OpenUPM</li>
       <li><i class="fa fa-home"></i> <a href="https://littlebigfun.com" rel="noopener noreferrer">littlebigfun.com</a></li>
+      <li><i class="fa fa-blog"></i> <a href="https://favoyang.com" rel="noopener noreferrer">favoyang.com</a></li>
       <li><i class="fab fa-patreon"></i> <a href="https://patreon.com/openupm" rel="noopener noreferrer">patreon.com/openupm</a></li>
       <li><i class="fab fa-github"></i> <a href="https://github.com/favoyang" rel="noopener noreferrer">github.com/favoyang</a></li>
       <li><i class="fab fa-twitter"></i> <a href="https://twitter.com/favo" rel="noopener noreferrer">twitter.com/favo</a></li>


### PR DESCRIPTION
## Summary

- Add `favoyang.com` to Favo Yang's URL list on the team page.
- Use the bundled Font Awesome blog icon to match the existing link style.

## Validation

- `npm run lint`
- `npm run docs:build:limit`
- `git diff --check`