### PR TITLE
docs: explain unavailable UnityNuGet package data

### DIFF
--- a/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
+++ b/apps/docs/__tests__/vue/nugetPackageDetail.spec.ts
@@ -95,6 +95,11 @@ describe("NuGet package detail UI", () => {
     expect(source).toContain("AdsenseDisplayForPackageDetail");
     expect(source).toContain("state.isUnavailable = true");
     expect(source).toContain("UnityNuGet package data is unavailable");
+    expect(source).toContain("not every merge to the");
+    expect(source).toContain("UnityNuGet main branch");
+    expect(source).toContain("request a release in the");
+    expect(source).toContain("within about 2");
+    expect(source).toContain("open an OpenUPM issue");
   });
 
   it("does not include native OpenUPM-only sections", () => {

--- a/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/NuGetPackageDetailLayout.vue
@@ -194,7 +194,18 @@ watch(
               <p class="custom-container-title">UnityNuGet package data is unavailable</p>
               <p>
                 This page is generated from the UnityNuGet package list, but live package data is loaded from the
-                OpenUPM registry uplink and cache. Try again after the registry cache refreshes.
+                OpenUPM registry uplink and cache.
+              </p>
+              <p>
+                OpenUPM's UnityNuGet service follows released UnityNuGet Docker images, not every merge to the
+                UnityNuGet main branch. If the package was merged but UnityNuGet has not published a new release yet,
+                please request a release in the
+                <a href="https://github.com/bdovaz/UnityNuGet/issues">UnityNuGet repository</a>.
+              </p>
+              <p>
+                If a new UnityNuGet Docker image was already released, OpenUPM usually catches up within about 2
+                hours. After that, please
+                <a href="https://github.com/openupm/openupm/issues">open an OpenUPM issue</a> for help.
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
- expand the UnityNuGet unavailable package warning with the two likely causes
- point users to UnityNuGet when a merged package is waiting for a release
- point users to OpenUPM after a released UnityNuGet image has had time to catch up

## Validation
- npm run build -- --filter=@openupm/types --filter=@openupm/test --filter=@openupm/common --filter=@openupm/local-data --filter=vuepress-plugin-openupm
- npm --prefix apps/docs run test -- nugetPackageDetail.spec.ts
- npm --prefix apps/docs run lint
- npm --prefix apps/docs run docs:build:limit