### PR TITLE
fix(docs): default add form readme near package

### DIFF
--- a/apps/docs/__tests__/packageAddForm.spec.ts
+++ b/apps/docs/__tests__/packageAddForm.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { getPackageAddFormDefaultReadme } from "../docs/.vuepress/packageAddForm";
+
+describe("package add form README default", () => {
+  it("prefers README.md adjacent to the selected package.json", () => {
+    expect(
+      getPackageAddFormDefaultReadme(
+        ["README.md", "Packages/com.example.foo/README.md"],
+        "Packages/com.example.foo/package.json",
+      ),
+    ).toBe("Packages/com.example.foo/README.md");
+  });
+
+  it("falls back to the existing root README.md default when no adjacent README.md exists", () => {
+    expect(
+      getPackageAddFormDefaultReadme(
+        ["README.md", "Packages/com.example.foo/CHANGELOG.md"],
+        "Packages/com.example.foo/package.json",
+      ),
+    ).toBe("README.md");
+  });
+
+  it("falls back to the existing first nested README.md default when no root or adjacent README.md exists", () => {
+    expect(
+      getPackageAddFormDefaultReadme(
+        ["Packages/com.example.bar/README.md", "Packages/com.example.foo/CHANGELOG.md"],
+        "Packages/com.example.foo/package.json",
+      ),
+    ).toBe("Packages/com.example.bar/README.md");
+  });
+
+  it("falls back to the existing single markdown file default", () => {
+    expect(
+      getPackageAddFormDefaultReadme(
+        ["Documentation~/Manual.md"],
+        "Packages/com.example.foo/package.json",
+      ),
+    ).toBe("Documentation~/Manual.md");
+  });
+
+  it("keeps no default when no markdown files exist", () => {
+    expect(
+      getPackageAddFormDefaultReadme(
+        [],
+        "Packages/com.example.foo/package.json",
+      ),
+    ).toBeNull();
+  });
+
+  it("uses root README.md when the selected package.json is at the repository root", () => {
+    expect(
+      getPackageAddFormDefaultReadme(
+        ["README.md", "Packages/com.example.foo/README.md"],
+        "package.json",
+      ),
+    ).toBe("README.md");
+  });
+});

--- a/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageAddLayout.vue
@@ -19,6 +19,7 @@ import { isPackageBlockedByScope, isPackageRequiresManualVerification, validPack
 import { topicsWithAll } from '@temp/topics.js';
 import { BLOCKED_SCOPES_FILENAME, SDPXLIST_FILENAME } from "@openupm/types";
 import { decodeGitHubBase64Content } from "@/utils";
+import { getPackageAddFormDefaultReadme } from "@/packageAddForm";
 
 const store = useDefaultStore();
 const { t } = useI18n();
@@ -291,15 +292,8 @@ const fetchGitTrees = async (): Promise<void> => {
     state.form.options.readme = readmePaths.map((x: string) => ({ key: x, text: x }));
     if (readmePaths.length == 0) {
       state.form.errors.readme = t("no-markdown-file-found-fallbacks");
-    } else if (readmePaths.length == 1) {
-      state.form.values.readme = readmePaths[0];
-    } else if (readmePaths.includes("README.md")) {
-      state.form.values.readme = "README.md";
     } else {
-      const filteredPath = readmePaths.filter(x => x.endsWith("README.md"));
-      if (filteredPath.length > 0) {
-        state.form.values.readme = filteredPath[0];
-      }
+      refreshReadmeDefault();
     }
   } catch (error) {
     const errorObj = error as Error;
@@ -483,7 +477,17 @@ const onBranchChange = (): void => {
 const onPackageJsonPathChange = (): void => {
   if (state.form.values.packageJson) {
     fetchPackageJson();
+    refreshReadmeDefault();
   }
+};
+
+const refreshReadmeDefault = (): void => {
+  const readmePaths = state.form.options.readme.map((x) => x.key);
+  const defaultReadme = getPackageAddFormDefaultReadme(
+    readmePaths,
+    state.form.values.packageJson,
+  );
+  if (defaultReadme !== null) state.form.values.readme = defaultReadme;
 };
 
 const onAnalyzeRepo = (): void => {

--- a/apps/docs/docs/.vuepress/packageAddForm.ts
+++ b/apps/docs/docs/.vuepress/packageAddForm.ts
@@ -1,0 +1,27 @@
+const getParentDirectory = function (filePath: string): string {
+  const separatorIndex = filePath.lastIndexOf("/");
+  return separatorIndex === -1 ? "" : filePath.slice(0, separatorIndex);
+};
+
+const joinPath = function (directory: string, filename: string): string {
+  return directory ? `${directory}/${filename}` : filename;
+};
+
+export const getPackageAddFormDefaultReadme = function (
+  readmePaths: string[],
+  packageJsonPath: string | null | undefined,
+): string | null {
+  if (packageJsonPath) {
+    const adjacentReadme = joinPath(getParentDirectory(packageJsonPath), "README.md");
+    if (readmePaths.includes(adjacentReadme)) return adjacentReadme;
+  }
+
+  if (readmePaths.length === 0) return null;
+  if (readmePaths.length === 1) return readmePaths[0];
+  if (readmePaths.includes("README.md")) return "README.md";
+
+  const filteredPath = readmePaths.filter((x) => x.endsWith("README.md"));
+  if (filteredPath.length > 0) return filteredPath[0];
+
+  return null;
+};


### PR DESCRIPTION
## Summary

- default the Package Add Form README field to `README.md` next to the selected `package.json` when that adjacent file exists
- preserve the previous README default fallback when no adjacent package README exists
- add focused tests for adjacent README selection and fallback behavior

Fixes openupm/openupm#6633.

## Validation

- `npm run test -- packageAddForm.spec.ts`
- `npm run test`
- `npm run lint`
- `npm run docs:build:limit`
- Manual local browser check with `BinhouOuO/binhou-tools`: selected package path `Packages/com.binhou.batchrenamer/package.json` defaulted README to `Packages/com.binhou.batchrenamer/README.md`