### PR TITLE
Fix forced README backfill refresh

### DIFF
--- a/apps/jobs/__tests__/jobs/fetchPackageExtra.spec.ts
+++ b/apps/jobs/__tests__/jobs/fetchPackageExtra.spec.ts
@@ -142,6 +142,52 @@ describe('fetchPackageExtraJob', () => {
     expect(setReadmeUpdatedAtMock).not.toHaveBeenCalled();
   });
 
+  it('re-renders README content on forced cache hit', async () => {
+    getReadmeCacheKeyMock.mockResolvedValue('v0:main:README.md:1767225600000');
+    const markdown = Buffer.from('# Test Package').toString('base64');
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: markdown,
+        encoding: 'base64',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const { fetchPackageReadme } = await import('../../src/jobs/fetchPackageExtra.js');
+    await fetchPackageReadme(
+      {
+        name: 'com.test.pkg',
+        repo: 'openupm/test-package',
+        repoUrl: 'https://github.com/openupm/test-package',
+        readme: 'main:README.md',
+        readmeBranch: 'main',
+      },
+      'com.test.pkg',
+      1767225600000,
+      true,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/openupm/test-package/contents/README.md?ref=main',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(setReadmeMock).toHaveBeenCalledWith('com.test.pkg', '# Test Package');
+    expect(setReadmeHtmlMock).toHaveBeenCalledWith(
+      'com.test.pkg',
+      expect.stringContaining('<h1 id="test-package">Test Package</h1>'),
+    );
+    expect(setReadmeCacheKeyMock).toHaveBeenCalledWith(
+      'com.test.pkg',
+      'en-US',
+      'v0:main:README.md:1767225600000',
+    );
+    expect(setReadmeUpdatedAtMock).toHaveBeenCalledWith(
+      'com.test.pkg',
+      expect.any(Number),
+    );
+  });
+
   it('stores fallback README content on GitHub content 404', async () => {
     getReadmeCacheKeyMock.mockResolvedValue('v0:main:README.md:old');
     const fetchMock = vi.fn().mockResolvedValueOnce({

--- a/apps/jobs/src/jobs/fetchPackageExtra.ts
+++ b/apps/jobs/src/jobs/fetchPackageExtra.ts
@@ -123,7 +123,7 @@ export async function fetchExtraData(
     await fetchPackageInfo(packageName);
     await fetchPackageScopes(packageName);
     const repoPushedTime = await fetchRepoInfo(pkg, packageName);
-    await fetchPackageReadme(pkg, packageName, repoPushedTime);
+    await fetchPackageReadme(pkg, packageName, repoPushedTime, force);
     await cacheImage(packageName, force);
     await cacheAvatarImage(pkg.owner || undefined, pkg.parentOwner || undefined, pkg.hunter || undefined, force);
     await fetchPackageInstallCount(packageName);
@@ -289,13 +289,14 @@ export async function fetchPackageReadme(
   pkg: PackageReadmeContext,
   packageName: string,
   repoPushedTime: number | null,
+  force = false,
 ): Promise<void> {
   try {
     const readmeInfo = getReadmePathInfo(pkg.readme);
     const cacheRevision = repoPushedTime === null ? 'unavailable' : repoPushedTime;
     const cacheKey = `v0:${readmeInfo.readme}:${cacheRevision}`;
     const existingCacheKey = await getReadmeCacheKey(packageName);
-    if (existingCacheKey === cacheKey) {
+    if (!force && existingCacheKey === cacheKey) {
       logger.info({ pkg: packageName }, 'fetchPackageReadme cache is available');
       return;
     }


### PR DESCRIPTION
## Summary
- make fetch-package-extra --force bypass the README cache key so README HTML is re-rendered
- add a regression test for forced README cache hits

## Validation
- npm run lint --workspace @openupm/jobs
- npm run build -- --filter=@openupm/types --filter=@openupm/test --filter=@openupm/common --filter=@openupm/local-data --filter=@openupm/server-common --filter=@openupm/jobs
- npm test --workspace @openupm/jobs -- fetchPackageExtra.spec.ts