### PR TITLE
fix(docs): keep mobile menu on no-sidebar pages

### DIFF
--- a/apps/docs/__tests__/vue/mobileNavbar.spec.ts
+++ b/apps/docs/__tests__/vue/mobileNavbar.spec.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const vuepressRoot = resolve(__dirname, "../../docs/.vuepress");
+
+const readVuepressFile = (path: string): string =>
+  readFileSync(resolve(vuepressRoot, path), "utf8");
+
+describe("mobile navbar", () => {
+  it("keeps the default mobile sidebar available on no-sidebar pages", () => {
+    const demoSource = readVuepressFile(
+      "components/ReadmeMarkdownRendererDemo.vue",
+    );
+
+    expect(demoSource).not.toContain(
+      ".vp-theme-container.wide-layout.no-sidebar .vp-sidebar",
+    );
+    expect(demoSource).not.toContain(
+      ".vp-theme-container.wide-layout.no-sidebar .vp-sidebar-mask",
+    );
+  });
+});

--- a/apps/docs/docs/.vuepress/components/ReadmeMarkdownRendererDemo.vue
+++ b/apps/docs/docs/.vuepress/components/ReadmeMarkdownRendererDemo.vue
@@ -117,11 +117,6 @@ const fixtureSlug = (title: string): string => {
 <style lang="scss" scoped>
 @use "@/styles/palette" as *;
 
-:global(.vp-theme-container.wide-layout.no-sidebar .vp-sidebar),
-:global(.vp-theme-container.wide-layout.no-sidebar .vp-sidebar-mask) {
-  display: none;
-}
-
 .readme-markdown-demo {
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- remove the README renderer demo override that hid VuePress sidebar and mask elements on no-sidebar wide pages
- add a docs regression test to keep the mobile menu infrastructure available on no-sidebar pages

## Validation
- npm run test -- mobileNavbar.spec.ts
- npm run lint
- OPENUPM_DATA_PATH=<workspace-data> npm run docs:build:limit
- built docs served locally and checked mobile menu behavior on home, README renderer demo, packages, and docs pages