### PR TITLE
Place README ads at section boundaries

### DIFF
--- a/apps/docs/__tests__/vue/adsense.spec.ts
+++ b/apps/docs/__tests__/vue/adsense.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  estimateReadmeContentHeightPx,
+  selectAdsenseInArticleBoundaryIndexes,
+  shouldAppendAdsenseInArticleFallbackAd,
+} from "../../docs/.vuepress/adsense";
+
+describe("README in-article ad placement", () => {
+  const options = { viewportHeightPx: 1000 };
+
+  it("places ads at section boundaries once roughly a viewport of content has passed", () => {
+    const placements = selectAdsenseInArticleBoundaryIndexes(
+      [
+        {
+          estimatedContentLength: 100,
+          measuredTopPx: 80,
+          isFirstContentHeading: true,
+        },
+        { estimatedContentLength: 700, measuredTopPx: 520 },
+        { estimatedContentLength: 1500, measuredTopPx: 980 },
+        { estimatedContentLength: 2600, measuredTopPx: 1900 },
+      ],
+      options,
+    );
+
+    expect(placements).toEqual([2, 3]);
+  });
+
+  it("uses content length when measured layout is unavailable", () => {
+    const placements = selectAdsenseInArticleBoundaryIndexes(
+      [
+        { estimatedContentLength: 200, isFirstContentHeading: true },
+        { estimatedContentLength: 900 },
+        { estimatedContentLength: 1600 },
+        { estimatedContentLength: 3050 },
+      ],
+      options,
+    );
+
+    expect(placements).toEqual([2, 3]);
+  });
+
+  it("skips the first top-of-article heading instead of inserting an ad above the content", () => {
+    const placements = selectAdsenseInArticleBoundaryIndexes(
+      [
+        {
+          estimatedContentLength: 0,
+          measuredTopPx: 0,
+          isFirstContentHeading: true,
+        },
+        { estimatedContentLength: 1500, measuredTopPx: 980 },
+      ],
+      options,
+    );
+
+    expect(placements).toEqual([1]);
+  });
+
+  it("appends one fallback ad for long README content without eligible section boundaries", () => {
+    expect(shouldAppendAdsenseInArticleFallbackAd(2000, 0, options)).toBe(true);
+    expect(shouldAppendAdsenseInArticleFallbackAd(2000, 1, options)).toBe(
+      false,
+    );
+    expect(shouldAppendAdsenseInArticleFallbackAd(800, 0, options)).toBe(false);
+  });
+
+  it("estimates README height from text length relative to viewport height", () => {
+    expect(estimateReadmeContentHeightPx(1450, options)).toBe(1000);
+  });
+});

--- a/apps/docs/__tests__/vue/packageReadmeView.spec.ts
+++ b/apps/docs/__tests__/vue/packageReadmeView.spec.ts
@@ -4,16 +4,54 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const componentPath = fileURLToPath(
-  new URL("../../docs/.vuepress/components/PackageReadmeView.vue", import.meta.url),
+  new URL(
+    "../../docs/.vuepress/components/PackageReadmeView.vue",
+    import.meta.url,
+  ),
+);
+const readmeHtmlPath = fileURLToPath(
+  new URL("../../docs/.vuepress/components/ReadmeHtml.vue", import.meta.url),
+);
+const adDemoPagePath = fileURLToPath(
+  new URL("../../docs/docs/dev/readme-ad-placement.md", import.meta.url),
+);
+const adDemoComponentPath = fileURLToPath(
+  new URL(
+    "../../docs/.vuepress/components/ReadmeAdPlacementDemo.vue",
+    import.meta.url,
+  ),
 );
 
 describe("PackageReadmeView", () => {
   const source = readFileSync(componentPath, "utf8");
 
   it("renders the README sync footer only when a timestamp formats successfully", () => {
-    expect(source).toContain('readmeUpdatedAt: {');
+    expect(source).toContain("readmeUpdatedAt: {");
     expect(source).toContain('if (!props.readmeUpdatedAt) return "";');
-    expect(source).toContain('<footer v-if="readmeSyncedAgo" class="readme-footer">');
-    expect(source).toContain('t("readme-synced-ago", { time: readmeSyncedAgo })');
+    expect(source).toContain(
+      '<footer v-if="readmeSyncedAgo" class="readme-footer">',
+    );
+    expect(source).toContain(
+      't("readme-synced-ago", { time: readmeSyncedAgo })',
+    );
+  });
+
+  it("refreshes in-article ad placement after README HTML changes", () => {
+    const readmeHtmlSource = readFileSync(readmeHtmlPath, "utf8");
+
+    expect(readmeHtmlSource).toContain("addAdsenseInArticleAds(element);");
+    expect(readmeHtmlSource).toContain(
+      "watch(() => props.content, enhanceReadmeHtml);",
+    );
+  });
+
+  it("has a docs development page for README ad placement behavior", () => {
+    const pageSource = readFileSync(adDemoPagePath, "utf8");
+    const componentSource = readFileSync(adDemoComponentPath, "utf8");
+
+    expect(pageSource).toContain("<ReadmeAdPlacementDemo />");
+    expect(componentSource).toContain("PackageReadmeView");
+    expect(componentSource).toContain("Balanced Sections");
+    expect(componentSource).toContain("No Sections");
   });
 });

--- a/apps/docs/docs/.vuepress/adsense.ts
+++ b/apps/docs/docs/.vuepress/adsense.ts
@@ -1,54 +1,231 @@
-/**
- * Inserts a Google Adsense ad placeholder after every 5-8 paragraphs within the specified container.
- *
- * @param {HTMLElement} containerElement - The container element within which ads should be inserted.
- */
-export function addAdsenseInArticleAds(containerElement: HTMLElement): void {
-  // Select all paragraph elements within the container
-  const paragraphs = containerElement.querySelectorAll("p, h1, h2, h3, h4, h5");
-  // Track of how many paragraphs we've processed
-  let paragraphCount = 0;
-  // Track of how many ads we've inserted
-  let adCount = 0;
-  // Calculate the position of the next ad
-  let nextAdPosition = 7;
+const readmeInArticleAdSelector = "[data-openupm-readme-ad='in-article']";
+const defaultViewportHeightPx = 900;
+const minAdDistanceRatio = 0.85;
+const minFirstAdRatio = 0.65;
+const minFallbackRatio = 1.15;
+const estimatedCharsPerViewport = 1450;
 
-  // Iterate over the paragraphs
-  paragraphs.forEach((paragraph, index) => {
-    // Increment the paragraph count
-    paragraphCount++;
+export type AdsenseInArticleBoundary = {
+  estimatedContentLength: number;
+  isFirstContentHeading?: boolean;
+  measuredTopPx?: number;
+};
 
-    // Check if the current paragraph is at a position where we should insert an ad
-    // - choosing a random number to determine the position.
-    // - also check if inserting at the last paragraph is appropriate.
-    if (
-      paragraphCount === nextAdPosition ||
-      (index === paragraphs.length - 1 && (adCount === 0 || paragraphCount > 9))
-    ) {
-      // Create a new <div> element for the ad
-      const adElement = document.createElement("div");
-      insertAdsenseScript(adElement);
-      // Insert the ad after the current paragraph
-      paragraph.parentNode!.insertBefore(adElement, paragraph.nextSibling);
-      // Increment the ad count
-      adCount += 1;
+export type AdsenseInArticlePlacementOptions = {
+  viewportHeightPx?: number;
+};
 
-      // Reset the paragraph count and calculate the next ad position
-      paragraphCount = 0;
-      nextAdPosition = getRandomInt(10, 15);
-    }
+const getTargetDistancePx = (
+  options: AdsenseInArticlePlacementOptions = {},
+): number => Math.max(options.viewportHeightPx || defaultViewportHeightPx, 600);
+
+export function estimateReadmeContentHeightPx(
+  contentLength: number,
+  options: AdsenseInArticlePlacementOptions = {},
+): number {
+  return (
+    (contentLength / estimatedCharsPerViewport) * getTargetDistancePx(options)
+  );
+}
+
+function getBoundaryPositionPx(
+  boundary: AdsenseInArticleBoundary,
+  options: AdsenseInArticlePlacementOptions,
+): number {
+  return Math.max(
+    boundary.measuredTopPx || 0,
+    estimateReadmeContentHeightPx(boundary.estimatedContentLength, options),
+  );
+}
+
+export function selectAdsenseInArticleBoundaryIndexes(
+  boundaries: AdsenseInArticleBoundary[],
+  options: AdsenseInArticlePlacementOptions = {},
+): number[] {
+  const targetDistancePx = getTargetDistancePx(options);
+  const minDistancePx = targetDistancePx * minAdDistanceRatio;
+  const minFirstAdPositionPx = targetDistancePx * minFirstAdRatio;
+  const placementIndexes: number[] = [];
+  let lastAdPositionPx = 0;
+
+  boundaries.forEach((boundary, index) => {
+    const positionPx = getBoundaryPositionPx(boundary, options);
+    if (boundary.isFirstContentHeading && positionPx < minFirstAdPositionPx)
+      return;
+    if (positionPx < minFirstAdPositionPx) return;
+    if (positionPx - lastAdPositionPx < minDistancePx) return;
+
+    placementIndexes.push(index);
+    lastAdPositionPx = positionPx;
   });
+
+  return placementIndexes;
+}
+
+export function shouldAppendAdsenseInArticleFallbackAd(
+  totalContentLength: number,
+  placementCount: number,
+  options: AdsenseInArticlePlacementOptions = {},
+): boolean {
+  if (placementCount > 0) return false;
+  return (
+    estimateReadmeContentHeightPx(totalContentLength, options) >=
+    getTargetDistancePx(options) * minFallbackRatio
+  );
+}
+
+function removeAdsenseInArticleAds(containerElement: HTMLElement): void {
+  containerElement
+    .querySelectorAll(readmeInArticleAdSelector)
+    .forEach((adElement) => adElement.remove());
+}
+
+function getEstimatedNodeContentLength(node: Node): number {
+  if (node.nodeType === Node.TEXT_NODE)
+    return node.textContent?.trim().length || 0;
+  if (!(node instanceof HTMLElement)) return 0;
+
+  const tagName = node.tagName.toLowerCase();
+  const textLength = node.textContent?.trim().length || 0;
+  if (tagName === "pre") return textLength + 800;
+  if (tagName === "table") return textLength + 650;
+  if (tagName === "img") return textLength + 500;
+  if (tagName === "iframe" || tagName === "video") return textLength + 900;
+  if (tagName === "ul" || tagName === "ol") return textLength + 180;
+  if (tagName === "blockquote") return textLength + 160;
+  if (!node.childNodes.length) return textLength;
+  return Array.from(node.childNodes).reduce(
+    (contentLength, childNode) =>
+      contentLength + getEstimatedNodeContentLength(childNode),
+    0,
+  );
+}
+
+function getEstimatedContentLengthBefore(
+  containerElement: HTMLElement,
+  boundaryElement: HTMLElement,
+): number {
+  let contentLength = 0;
+  for (const childNode of Array.from(containerElement.childNodes)) {
+    const result = getEstimatedContentLengthBeforeBoundary(
+      childNode,
+      boundaryElement,
+    );
+    contentLength += result.contentLength;
+    if (result.foundBoundary) break;
+  }
+
+  return contentLength;
+}
+
+function getEstimatedContainerContentLength(
+  containerElement: HTMLElement,
+): number {
+  return Array.from(containerElement.childNodes).reduce(
+    (contentLength, childNode) =>
+      contentLength + getEstimatedNodeContentLength(childNode),
+    0,
+  );
+}
+
+function getEstimatedContentLengthBeforeBoundary(
+  node: Node,
+  boundaryElement: HTMLElement,
+): { contentLength: number; foundBoundary: boolean } {
+  if (node === boundaryElement || boundaryElement.contains(node))
+    return { contentLength: 0, foundBoundary: true };
+  if (!(node instanceof HTMLElement) || !node.contains(boundaryElement)) {
+    return {
+      contentLength: getEstimatedNodeContentLength(node),
+      foundBoundary: false,
+    };
+  }
+
+  let contentLength = 0;
+  for (const childNode of Array.from(node.childNodes)) {
+    const result = getEstimatedContentLengthBeforeBoundary(
+      childNode,
+      boundaryElement,
+    );
+    contentLength += result.contentLength;
+    if (result.foundBoundary) return { contentLength, foundBoundary: true };
+  }
+
+  return { contentLength, foundBoundary: false };
+}
+
+function getMeasuredTopPx(
+  containerElement: HTMLElement,
+  boundaryElement: HTMLElement,
+): number {
+  const containerRect = containerElement.getBoundingClientRect();
+  const boundaryRect = boundaryElement.getBoundingClientRect();
+  if (!containerRect.height && !boundaryRect.top) return 0;
+  return Math.max(0, boundaryRect.top - containerRect.top);
+}
+
+function getViewportHeightPx(): number {
+  return typeof window === "undefined"
+    ? defaultViewportHeightPx
+    : window.innerHeight;
+}
+
+function createAdsenseInArticleAd(): HTMLElement {
+  const adElement = document.createElement("div");
+  adElement.dataset.openupmReadmeAd = "in-article";
+  adElement.className = "readme-in-article-ad";
+  insertAdsenseScript(adElement);
+  return adElement;
 }
 
 /**
- * Generates a random integer between the specified minimum (inclusive) and maximum (exclusive) values.
+ * Inserts Google Adsense in-article placeholders at README section boundaries.
  *
- * @param {number} min - The minimum value (inclusive).
- * @param {number} max - The maximum value (exclusive).
- * @returns {number} A random integer between the min and max values.
+ * Ads are placed before headings when roughly one viewport of rendered or
+ * estimated content has passed since the previous ad. A single end-of-content
+ * fallback is used for long README files without enough section headings.
+ *
+ * @param {HTMLElement} containerElement - The README container element.
  */
-function getRandomInt(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min) + min);
+export function addAdsenseInArticleAds(containerElement: HTMLElement): void {
+  removeAdsenseInArticleAds(containerElement);
+
+  const boundaryElements = Array.from(
+    containerElement.querySelectorAll<HTMLElement>("h2, h3, h4, h5"),
+  );
+  const totalContentLength =
+    getEstimatedContainerContentLength(containerElement);
+  const options = { viewportHeightPx: getViewportHeightPx() };
+  const boundaries = boundaryElements.map((boundaryElement, index) => ({
+    estimatedContentLength: getEstimatedContentLengthBefore(
+      containerElement,
+      boundaryElement,
+    ),
+    isFirstContentHeading: index === 0,
+    measuredTopPx: getMeasuredTopPx(containerElement, boundaryElement),
+  }));
+  const placementIndexes = selectAdsenseInArticleBoundaryIndexes(
+    boundaries,
+    options,
+  );
+
+  placementIndexes.forEach((boundaryIndex) => {
+    const boundaryElement = boundaryElements[boundaryIndex];
+    boundaryElement.parentNode?.insertBefore(
+      createAdsenseInArticleAd(),
+      boundaryElement,
+    );
+  });
+
+  if (
+    shouldAppendAdsenseInArticleFallbackAd(
+      totalContentLength,
+      placementIndexes.length,
+      options,
+    )
+  ) {
+    containerElement.appendChild(createAdsenseInArticleAd());
+  }
 }
 
 /**

--- a/apps/docs/docs/.vuepress/components/ReadmeAdPlacementDemo.vue
+++ b/apps/docs/docs/.vuepress/components/ReadmeAdPlacementDemo.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+import PackageReadmeView from "@/components/PackageReadmeView.vue";
+
+type DemoFixture = {
+  title: string;
+  summary: string;
+  html: string;
+};
+
+const paragraph = (index: number): string =>
+  `<p>Package README paragraph ${index} describes installation context, examples, compatibility notes, and practical usage details with enough body text to approximate real package documentation density.</p>`;
+
+const section = (
+  title: string,
+  startIndex: number,
+  paragraphCount: number,
+): string => {
+  const paragraphs = Array.from({ length: paragraphCount }, (_, index) =>
+    paragraph(startIndex + index),
+  ).join("");
+  return `<h2>${title}</h2>${paragraphs}`;
+};
+
+const fixtures: DemoFixture[] = [
+  {
+    title: "Balanced Sections",
+    summary: "Frequent headings with moderate body copy between sections.",
+    html: `<div>
+      <h1>Balanced README</h1>
+      ${section("Install", 1, 5)}
+      ${section("Quick Start", 6, 7)}
+      ${section("Configuration", 13, 8)}
+      ${section("Advanced Usage", 21, 9)}
+      ${section("Troubleshooting", 30, 5)}
+    </div>`,
+  },
+  {
+    title: "Long Opening",
+    summary: "A long introduction before the first useful section heading.",
+    html: `<div>
+      <h1>Long Opening README</h1>
+      ${Array.from({ length: 15 }, (_, index) => paragraph(index + 1)).join("")}
+      ${section("Installation", 16, 5)}
+      ${section("Examples", 21, 7)}
+      ${section("Reference", 28, 8)}
+    </div>`,
+  },
+  {
+    title: "Sparse Headings",
+    summary: "Long content with only one late section boundary.",
+    html: `<div>
+      <h1>Sparse README</h1>
+      ${Array.from({ length: 22 }, (_, index) => paragraph(index + 1)).join("")}
+      ${section("Appendix", 23, 4)}
+    </div>`,
+  },
+  {
+    title: "No Sections",
+    summary:
+      "Long content without section headings, showing the fallback placement.",
+    html: `<div>
+      <h1>No Section README</h1>
+      ${Array.from({ length: 26 }, (_, index) => paragraph(index + 1)).join("")}
+    </div>`,
+  },
+];
+
+const selectedTitle = ref(fixtures[0].title);
+
+const selectedFixture = computed(
+  () =>
+    fixtures.find((fixture) => fixture.title === selectedTitle.value) ||
+    fixtures[0],
+);
+</script>
+
+<template>
+  <div class="readme-ad-placement-demo">
+    <nav class="demo-tabs" aria-label="README ad placement fixtures">
+      <button
+        v-for="fixture in fixtures"
+        :key="fixture.title"
+        class="btn btn-link demo-tab"
+        :class="{ active: fixture.title === selectedFixture.title }"
+        type="button"
+        @click="selectedTitle = fixture.title"
+      >
+        {{ fixture.title }}
+      </button>
+    </nav>
+
+    <section class="demo-layout">
+      <aside class="demo-notes">
+        <p class="demo-label">Fixture</p>
+        <h2>{{ selectedFixture.title }}</h2>
+        <p>{{ selectedFixture.summary }}</p>
+        <dl>
+          <div>
+            <dt>Package</dt>
+            <dd>com.openupm.readme-ad-demo</dd>
+          </div>
+          <div>
+            <dt>Renderer</dt>
+            <dd>PackageReadmeView</dd>
+          </div>
+        </dl>
+      </aside>
+
+      <article class="demo-readme">
+        <PackageReadmeView
+          name="com.openupm.readme-ad-demo"
+          :readme-html="selectedFixture.html"
+          :is-loading="false"
+        />
+      </article>
+    </section>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use "@/styles/palette" as *;
+
+.readme-ad-placement-demo {
+  margin-top: 1rem;
+}
+
+.demo-tabs {
+  border-bottom: 1px solid $border-color;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+}
+
+.demo-tab {
+  border-radius: 4px;
+  line-height: 1.2;
+  padding: 0.35rem 0.55rem;
+
+  &.active {
+    background: var(--c-bg-darker);
+    color: var(--c-text-accent);
+    font-weight: 600;
+  }
+}
+
+.demo-layout {
+  align-items: flex-start;
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: minmax(12rem, 18rem) minmax(0, 1fr);
+}
+
+.demo-notes {
+  border-right: 1px solid $border-color;
+  padding-right: 1rem;
+  position: sticky;
+  top: calc(var(--navbar-height) + 1rem);
+
+  h2 {
+    font-size: 1.1rem;
+    margin: 0 0 0.45rem;
+    padding: 0;
+  }
+
+  p {
+    color: $gray-color;
+    font-size: 0.78rem;
+    margin: 0 0 0.8rem;
+  }
+
+  dl {
+    margin: 0;
+  }
+
+  div {
+    margin-bottom: 0.5rem;
+  }
+
+  dt {
+    color: $gray-color;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+  }
+
+  dd {
+    font-size: 0.78rem;
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+}
+
+.demo-label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.demo-readme {
+  min-width: 0;
+}
+
+@media (max-width: 719px) {
+  .demo-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-notes {
+    border-right: 0;
+    border-bottom: 1px solid $border-color;
+    padding: 0 0 0.8rem;
+    position: static;
+  }
+}
+</style>

--- a/apps/docs/docs/.vuepress/components/ReadmeHtml.vue
+++ b/apps/docs/docs/.vuepress/components/ReadmeHtml.vue
@@ -1,19 +1,19 @@
 <script setup lang="ts">
-import { nextTick, onMounted, ref, watch } from 'vue';
-import { addAdsenseInArticleAds } from '@/adsense';
+import { nextTick, onMounted, ref, watch } from "vue";
+import { addAdsenseInArticleAds } from "@/adsense";
 
 const props = defineProps({
   content: {
     type: String,
-    default: ""
-  }
+    default: "",
+  },
 });
 
 // The reference of the readme container element
 const readmeContainerElement = ref<HTMLElement | null>(null);
 
 function getCodeBlockLanguage(codeElement: HTMLElement): string {
-  const languageClass = Array.from(codeElement.classList).find(className => {
+  const languageClass = Array.from(codeElement.classList).find((className) => {
     return className !== "hljs" && /^[a-zA-Z0-9_-]+$/.test(className);
   });
   if (!languageClass) return "text";
@@ -21,10 +21,15 @@ function getCodeBlockLanguage(codeElement: HTMLElement): string {
 }
 
 function normalizeReadmeCodeBlocks(element: HTMLElement): void {
-  element.querySelectorAll<HTMLElement>("pre > code").forEach(codeElement => {
+  element.querySelectorAll<HTMLElement>("pre > code").forEach((codeElement) => {
     const preElement = codeElement.parentElement;
     const parentElement = preElement?.parentElement;
-    if (!preElement || !parentElement || parentElement.className.includes("language-")) return;
+    if (
+      !preElement ||
+      !parentElement ||
+      parentElement.className.includes("language-")
+    )
+      return;
 
     codeElement.classList.add("hljs");
     preElement.classList.add("readme-code-block");
@@ -36,7 +41,7 @@ function normalizeReadmeCodeBlocks(element: HTMLElement): void {
 }
 
 function normalizeReadmeLinks(element: HTMLElement): void {
-  element.querySelectorAll<HTMLAnchorElement>("a").forEach(anchorElement => {
+  element.querySelectorAll<HTMLAnchorElement>("a").forEach((anchorElement) => {
     anchorElement.classList.add("no-external-link-icon");
   });
 }
@@ -47,14 +52,12 @@ function enhanceReadmeHtml(): void {
     if (element) {
       normalizeReadmeCodeBlocks(element);
       normalizeReadmeLinks(element);
+      addAdsenseInArticleAds(element);
     }
   });
 }
 
 onMounted(() => {
-  const element = readmeContainerElement.value;
-  if (element)
-    addAdsenseInArticleAds(element);
   enhanceReadmeHtml();
 });
 
@@ -68,12 +71,16 @@ watch(() => props.content, enhanceReadmeHtml);
 
 <style lang="scss">
 .readme-html {
+  .readme-in-article-ad {
+    margin: 1.2rem 0;
+  }
+
   a.no-external-link-icon::after {
     content: none !important;
     display: none !important;
   }
 
-  div[class*=language-] {
+  div[class*="language-"] {
     pre.readme-code-block {
       background-color: #23241f;
 

--- a/apps/docs/docs/docs/dev/readme-ad-placement.md
+++ b/apps/docs/docs/docs/dev/readme-ad-placement.md
@@ -1,0 +1,12 @@
+---
+title: README Ad Placement Demo
+layout: WideLayout
+sidebar: false
+editLink: false
+---
+
+# README Ad Placement Demo
+
+This page renders representative package README bodies through the package page README component so section-boundary in-article ad placement can be reviewed in the docs app.
+
+<ReadmeAdPlacementDemo />


### PR DESCRIPTION
## Summary
- Move package README in-article ads from paragraph-count insertion to section-boundary insertion before headings.
- Use rendered distance with a content-length fallback to approximate one ad per viewport of README content.
- Add a docs dev demo page for balanced, long-opening, sparse-heading, and no-section README cases.

## Validation
- npm run test -- adsense.spec.ts packageReadmeView.spec.ts
- npm run lint
- OPENUPM_DATA_PATH=<openupm-data> npm run docs:build:limit
- Built docs demo page reviewed locally; sectioned fixtures inserted ads before headings, no-section fixture used one end fallback, and the browser console showed no warnings or errors.