### PR TITLE
fix(docs): add fallback ad for headingless READMEs

### DIFF
--- a/apps/docs/__tests__/vue/adsense.spec.ts
+++ b/apps/docs/__tests__/vue/adsense.spec.ts
@@ -57,12 +57,28 @@ describe("README in-article ad placement", () => {
     expect(placements).toEqual([1]);
   });
 
-  it("appends one fallback ad for long README content without eligible section boundaries", () => {
-    expect(shouldAppendAdsenseInArticleFallbackAd(2000, 0, options)).toBe(true);
-    expect(shouldAppendAdsenseInArticleFallbackAd(2000, 1, options)).toBe(
+  it("appends one fallback ad for headingless README content", () => {
+    expect(shouldAppendAdsenseInArticleFallbackAd(300, 0, 0, options)).toBe(
+      true,
+    );
+    expect(shouldAppendAdsenseInArticleFallbackAd(0, 0, 0, options)).toBe(
       false,
     );
-    expect(shouldAppendAdsenseInArticleFallbackAd(800, 0, options)).toBe(false);
+    expect(shouldAppendAdsenseInArticleFallbackAd(300, 1, 0, options)).toBe(
+      false,
+    );
+  });
+
+  it("appends one fallback ad for long README content without eligible section boundaries", () => {
+    expect(shouldAppendAdsenseInArticleFallbackAd(2000, 0, 1, options)).toBe(
+      true,
+    );
+    expect(shouldAppendAdsenseInArticleFallbackAd(2000, 1, 1, options)).toBe(
+      false,
+    );
+    expect(shouldAppendAdsenseInArticleFallbackAd(800, 0, 1, options)).toBe(
+      false,
+    );
   });
 
   it("estimates README height from text length relative to viewport height", () => {

--- a/apps/docs/docs/.vuepress/adsense.ts
+++ b/apps/docs/docs/.vuepress/adsense.ts
@@ -65,9 +65,11 @@ export function selectAdsenseInArticleBoundaryIndexes(
 export function shouldAppendAdsenseInArticleFallbackAd(
   totalContentLength: number,
   placementCount: number,
+  boundaryCount: number,
   options: AdsenseInArticlePlacementOptions = {},
 ): boolean {
   if (placementCount > 0) return false;
+  if (boundaryCount === 0) return totalContentLength > 0;
   return (
     estimateReadmeContentHeightPx(totalContentLength, options) >=
     getTargetDistancePx(options) * minFallbackRatio
@@ -183,7 +185,8 @@ function createAdsenseInArticleAd(): HTMLElement {
  *
  * Ads are placed before headings when roughly one viewport of rendered or
  * estimated content has passed since the previous ad. A single end-of-content
- * fallback is used for long README files without enough section headings.
+ * fallback is used for headingless README files or long README files without
+ * enough section headings.
  *
  * @param {HTMLElement} containerElement - The README container element.
  */
@@ -221,6 +224,7 @@ export function addAdsenseInArticleAds(containerElement: HTMLElement): void {
     shouldAppendAdsenseInArticleFallbackAd(
       totalContentLength,
       placementIndexes.length,
+      boundaryElements.length,
       options,
     )
   ) {


### PR DESCRIPTION
## Summary
- append one in-article README ad at the end when a README has no section headings
- preserve the existing long-content fallback when headings exist but no section boundary is eligible
- cover headingless fallback behavior in README ad placement tests

## Validation
- npm run test -- adsense.spec.ts packageReadmeView.spec.ts
- npm run lint
- OPENUPM_DATA_PATH=<openupm-data> npm run docs:build:limit
- Local browser review: verified the com.google.external-dependency-manager package page renders a headingless README with one end-of-README in-article ad