### PR TITLE
docs: convert blog HTML to markdown

### DIFF
--- a/apps/docs/docs/blog/digitalocean-sponsorship-2022-c6108c451828/index.md
+++ b/apps/docs/docs/blog/digitalocean-sponsorship-2022-c6108c451828/index.md
@@ -12,6 +12,16 @@ editLink: false
 
 <BlogPostMeta />
 
-<p>I am delighted to announce a continuing ‘Service Sponsorship’ between OpenUPM and DigitalOcean for 2022.</p><p>DigitalOcean has agreed to sponsor OpenUPM again for 2022, by providing a very generous amount of credit that helps us host the website and other infrastructure. If you haven’t tried their “simpler cloud, happier devs, better results” service, feel free to register with the <a href="https://m.do.co/c/50e7f9860fa9">referral link</a> to get a $100 onboarding reward (available for 60 days) to warm up.</p><figure><img alt="" src="./images/digitalocean-sponsorship-2022-c6108c451828-01-blog-image.png" /><figcaption>The brand of DigitalOcean</figcaption></figure><p>To learn more about the OpenUPM infrastructure, please read <a href="/blog/digitalocean-sponsorship-our-server-infrastructure-d1019b84d71c/">the article</a>. Our infrastructure remains the same.</p><p>Thanks to DigitalOcean for their generous sponsorship of this site and for supporting open source!</p>
+I am delighted to announce a continuing ‘Service Sponsorship’ between OpenUPM and DigitalOcean for 2022.
+
+DigitalOcean has agreed to sponsor OpenUPM again for 2022, by providing a very generous amount of credit that helps us host the website and other infrastructure. If you haven’t tried their “simpler cloud, happier devs, better results” service, feel free to register with the [referral link](https://m.do.co/c/50e7f9860fa9) to get a $100 onboarding reward (available for 60 days) to warm up.
+
+![](./images/digitalocean-sponsorship-2022-c6108c451828-01-blog-image.png)
+
+*The brand of DigitalOcean*
+
+To learn more about the OpenUPM infrastructure, please read [the article](/blog/digitalocean-sponsorship-our-server-infrastructure-d1019b84d71c/). Our infrastructure remains the same.
+
+Thanks to DigitalOcean for their generous sponsorship of this site and for supporting open source!
 
 <BlogPostNav />

--- a/apps/docs/docs/blog/digitalocean-sponsorship-2024-b015451e530b/index.md
+++ b/apps/docs/docs/blog/digitalocean-sponsorship-2024-b015451e530b/index.md
@@ -12,16 +12,16 @@ editLink: false
 
 <BlogPostMeta />
 
-<p>DigitalOcean renewed its OpenUPM sponsorship for 2024. Their credits continue to cover the public website and the supporting services that keep the registry available.</p>
+DigitalOcean renewed its OpenUPM sponsorship for 2024. Their credits continue to cover the public website and the supporting services that keep the registry available.
 
-<h2>About DigitalOcean</h2>
+## About DigitalOcean
 
-<p>DigitalOcean describes its platform as "simpler cloud, happier devs, better results." If you want to try it, our <a href="https://m.do.co/c/50e7f9860fa9">referral link</a> includes a $200 onboarding credit valid for 60 days.</p>
+DigitalOcean describes its platform as "simpler cloud, happier devs, better results." If you want to try it, our [referral link](https://m.do.co/c/50e7f9860fa9) includes a $200 onboarding credit valid for 60 days.
 
-<h2>What the sponsorship supports</h2>
+## What the sponsorship supports
 
-<p>OpenUPM still uses DigitalOcean for its public infrastructure. The credits help with the website and backend services that package authors and Unity projects rely on. For more background, see the earlier <a href="/blog/digitalocean-sponsorship-our-server-infrastructure-d1019b84d71c/">infrastructure overview article</a>.</p>
+OpenUPM still uses DigitalOcean for its public infrastructure. The credits help with the website and backend services that package authors and Unity projects rely on. For more background, see the earlier [infrastructure overview article](/blog/digitalocean-sponsorship-our-server-infrastructure-d1019b84d71c/).
 
-<p>Thanks to DigitalOcean for continuing the sponsorship, and thanks to everyone who uses and supports OpenUPM.</p>
+Thanks to DigitalOcean for continuing the sponsorship, and thanks to everyone who uses and supports OpenUPM.
 
 <BlogPostNav />

--- a/apps/docs/docs/blog/host-your-first-private-upm-registry-in-just-15-minutes-c92d67f27de4/index.md
+++ b/apps/docs/docs/blog/host-your-first-private-upm-registry-in-just-15-minutes-c92d67f27de4/index.md
@@ -12,6 +12,6 @@ editLink: false
 
 <BlogPostMeta />
 
-<p>Looking to streamline your development workflow? Discover how to set up your own private Unity Package Manager (UPM) registry in just 15 minutes. Our guide walks you through using Verdaccio with DigitalOcean to achieve efficient, secure package management. Ideal for both individual developers and teams, this setup ensures your codes are accessible and protected. Dive into the detailed process, from prerequisites to Unity integration, by visiting the OpenUPM guide <a href="/docs/host-private-upm-registry-15-minutes">Host Your Private UPM Registry in 15 Minutes</a>.</p>
+Looking to streamline your development workflow? Discover how to set up your own private Unity Package Manager (UPM) registry in just 15 minutes. Our guide walks you through using Verdaccio with DigitalOcean to achieve efficient, secure package management. Ideal for both individual developers and teams, this setup ensures your codes are accessible and protected. Dive into the detailed process, from prerequisites to Unity integration, by visiting the OpenUPM guide [Host Your Private UPM Registry in 15 Minutes](/docs/host-private-upm-registry-15-minutes).
 
 <BlogPostNav />

--- a/apps/docs/docs/blog/openupm-2025-recap-6283fcd0217e/index.md
+++ b/apps/docs/docs/blog/openupm-2025-recap-6283fcd0217e/index.md
@@ -11,70 +11,122 @@ editLink: false
 
 <BlogPostMeta />
 
-<p>OpenUPM had a quieter year for new submissions in 2025, but package owners kept shipping. Downloads were slightly lower than in 2024, and release activity picked up hard in the fall.</p>
+OpenUPM had a quieter year for new submissions in 2025, but package owners kept shipping. Downloads were slightly lower than in 2024, and release activity picked up hard in the fall.
 
-<h2>Community in 2025</h2>
+## Community in 2025
 
-<ul><li>489 packages submitted, down from 618 in 2024.</li><li>218 unique package hunters and 232 unique owners.</li><li>336 packages, or 68.7%, were submitted by their own owners. That is a new high for creator-led submissions.</li></ul>
+- 489 packages submitted, down from 618 in 2024.
+- 218 unique package hunters and 232 unique owners.
+- 336 packages, or 68.7%, were submitted by their own owners. That is a new high for creator-led submissions.
 
-<h2>Downloads</h2>
+## Downloads
 
-<ul><li>Total downloads: 4,497,493, down 11.1% from 2024.</li><li>Monthly volume averaged about 374,791 downloads. October had 427,029 downloads, September had 421,651, and December fell to 287,514.</li></ul>
+- Total downloads: 4,497,493, down 11.1% from 2024.
+- Monthly volume averaged about 374,791 downloads. October had 427,029 downloads, September had 421,651, and December fell to 287,514.
 
-<figure><img alt="Monthly downloads in 2025" src="./images/openupm-2025-recap-6283fcd0217e-01-monthly-downloads-in-2025.png" /></figure>
+![Monthly downloads in 2025](./images/openupm-2025-recap-6283fcd0217e-01-monthly-downloads-in-2025.png)
 
-<p>Top 10 downloaded packages:</p>
+Top 10 downloaded packages:
 
-<ol><li>External Dependency Manager for Unity (<a href="/packages/com.google.external-dependency-manager/">com.google.external-dependency-manager</a>): 589,537</li><li>UI Particle (<a href="/packages/com.coffee.ui-particle/">com.coffee.ui-particle</a>): 342,587</li><li>VContainer (<a href="/packages/jp.hadashikick.vcontainer/">jp.hadashikick.vcontainer</a>): 310,184</li><li>UniTask (<a href="/packages/com.cysharp.unitask/">com.cysharp.unitask</a>): 289,844</li><li>NuGetForUnity (<a href="/packages/com.github-glitchenzo.nugetforunity/">com.github-glitchenzo.nugetforunity</a>): 267,166</li><li>Compilation Visualizer (<a href="/packages/com.needle.compilation-visualizer/">com.needle.compilation-visualizer</a>): 136,023</li><li>Google Play Common (<a href="/packages/com.google.play.common/">com.google.play.common</a>): 110,713</li><li>Google Play Core (<a href="/packages/com.google.play.core/">com.google.play.core</a>): 95,834</li><li>Google Play In-app Review (<a href="/packages/com.google.play.review/">com.google.play.review</a>): 89,527</li><li>Backtrace (<a href="/packages/io.backtrace.unity/">io.backtrace.unity</a>): 67,358</li></ol>
+1. External Dependency Manager for Unity ([com.google.external-dependency-manager](/packages/com.google.external-dependency-manager/)): 589,537
+2. UI Particle ([com.coffee.ui-particle](/packages/com.coffee.ui-particle/)): 342,587
+3. VContainer ([jp.hadashikick.vcontainer](/packages/jp.hadashikick.vcontainer/)): 310,184
+4. UniTask ([com.cysharp.unitask](/packages/com.cysharp.unitask/)): 289,844
+5. NuGetForUnity ([com.github-glitchenzo.nugetforunity](/packages/com.github-glitchenzo.nugetforunity/)): 267,166
+6. Compilation Visualizer ([com.needle.compilation-visualizer](/packages/com.needle.compilation-visualizer/)): 136,023
+7. Google Play Common ([com.google.play.common](/packages/com.google.play.common/)): 110,713
+8. Google Play Core ([com.google.play.core](/packages/com.google.play.core/)): 95,834
+9. Google Play In-app Review ([com.google.play.review](/packages/com.google.play.review/)): 89,527
+10. Backtrace ([io.backtrace.unity](/packages/io.backtrace.unity/)): 67,358
 
-<h2>Fastest-growing packages</h2>
+## Fastest-growing packages
 
-<p>Top 10 fastest-growing packages in 2025, by percentage, with at least 100 downloads in 2024. Format: growth rate, current downloads vs 2024 downloads.</p>
+Top 10 fastest-growing packages in 2025, by percentage, with at least 100 downloads in 2024. Format: growth rate, current downloads vs 2024 downloads.
 
-<ol><li>Google Play Integrity (<a href="/packages/com.google.play.integrity/">com.google.play.integrity</a>): 11,341.0% (24,026 vs 210)</li><li>Google Play Common (<a href="/packages/com.google.play.common/">com.google.play.common</a>): 4,169.7% (110,713 vs 2,593)</li><li>Google Play In-app Updates (<a href="/packages/com.google.play.appupdate/">com.google.play.appupdate</a>): 3,737.8% (15,428 vs 402)</li><li>Google Play In-app Review (<a href="/packages/com.google.play.review/">com.google.play.review</a>): 3,714.5% (89,527 vs 2,347)</li><li>Google Play Core (<a href="/packages/com.google.play.core/">com.google.play.core</a>): 3,652.3% (95,834 vs 2,554)</li><li>Nice Vibrations (<a href="/packages/com.github.lofelt.nicevibrations/">com.github.lofelt.nicevibrations</a>): 2,659.9% (4,471 vs 162)</li><li>AppMetrica (<a href="/packages/io.appmetrica.analytics/">io.appmetrica.analytics</a>): 2,017.6% (7,348 vs 347)</li><li>UnitySkiaSharp (<a href="/packages/com.u2sb.skiasharp/">com.u2sb.skiasharp</a>): 1,834.0% (2,727 vs 141)</li><li>MvpToolkit (<a href="/packages/com.behc.mvptoolkit/">com.behc.mvptoolkit</a>): 1,759.9% (3,199 vs 172)</li><li>Adjust (<a href="/packages/com.adjust.sdk/">com.adjust.sdk</a>): 1,566.6% (6,083 vs 365)</li></ol>
+1. Google Play Integrity ([com.google.play.integrity](/packages/com.google.play.integrity/)): 11,341.0% (24,026 vs 210)
+2. Google Play Common ([com.google.play.common](/packages/com.google.play.common/)): 4,169.7% (110,713 vs 2,593)
+3. Google Play In-app Updates ([com.google.play.appupdate](/packages/com.google.play.appupdate/)): 3,737.8% (15,428 vs 402)
+4. Google Play In-app Review ([com.google.play.review](/packages/com.google.play.review/)): 3,714.5% (89,527 vs 2,347)
+5. Google Play Core ([com.google.play.core](/packages/com.google.play.core/)): 3,652.3% (95,834 vs 2,554)
+6. Nice Vibrations ([com.github.lofelt.nicevibrations](/packages/com.github.lofelt.nicevibrations/)): 2,659.9% (4,471 vs 162)
+7. AppMetrica ([io.appmetrica.analytics](/packages/io.appmetrica.analytics/)): 2,017.6% (7,348 vs 347)
+8. UnitySkiaSharp ([com.u2sb.skiasharp](/packages/com.u2sb.skiasharp/)): 1,834.0% (2,727 vs 141)
+9. MvpToolkit ([com.behc.mvptoolkit](/packages/com.behc.mvptoolkit/)): 1,759.9% (3,199 vs 172)
+10. Adjust ([com.adjust.sdk](/packages/com.adjust.sdk/)): 1,566.6% (6,083 vs 365)
 
-<h2>Trending packages</h2>
+## Trending packages
 
-<p>Top 10 packages by download increase in 2025 vs 2024:</p>
+Top 10 packages by download increase in 2025 vs 2024:
 
-<ol><li>External Dependency Manager for Unity (<a href="/packages/com.google.external-dependency-manager/">com.google.external-dependency-manager</a>): +333,557 (130.3% from 255,980)</li><li>NuGetForUnity (<a href="/packages/com.github-glitchenzo.nugetforunity/">com.github-glitchenzo.nugetforunity</a>): +215,026 (412.4% from 52,140)</li><li>Google Play Common (<a href="/packages/com.google.play.common/">com.google.play.common</a>): +108,120 (4,169.7% from 2,593)</li><li>Google Play Core (<a href="/packages/com.google.play.core/">com.google.play.core</a>): +93,280 (3,652.3% from 2,554)</li><li>Google Play In-app Review (<a href="/packages/com.google.play.review/">com.google.play.review</a>): +87,180 (3,714.5% from 2,347)</li><li>VContainer (<a href="/packages/jp.hadashikick.vcontainer/">jp.hadashikick.vcontainer</a>): +70,071 (29.2% from 240,113)</li><li>UI Particle (<a href="/packages/com.coffee.ui-particle/">com.coffee.ui-particle</a>): +69,379 (25.4% from 273,208)</li><li>PlayableGraphMonitor! (<a href="/packages/com.greenbamboogames.playablegraphmonitor/">com.greenbamboogames.playablegraphmonitor</a>): +34,412 (864.2% from 3,982)</li><li>Google Mobile Ads for Unity (<a href="/packages/com.google.ads.mobile/">com.google.ads.mobile</a>): +24,970 (67.8% from 36,808)</li><li>AltTester Unity SDK (<a href="/packages/com.alttester.sdk/">com.alttester.sdk</a>): +24,761 (412.7% from 6,000)</li></ol>
+1. External Dependency Manager for Unity ([com.google.external-dependency-manager](/packages/com.google.external-dependency-manager/)): +333,557 (130.3% from 255,980)
+2. NuGetForUnity ([com.github-glitchenzo.nugetforunity](/packages/com.github-glitchenzo.nugetforunity/)): +215,026 (412.4% from 52,140)
+3. Google Play Common ([com.google.play.common](/packages/com.google.play.common/)): +108,120 (4,169.7% from 2,593)
+4. Google Play Core ([com.google.play.core](/packages/com.google.play.core/)): +93,280 (3,652.3% from 2,554)
+5. Google Play In-app Review ([com.google.play.review](/packages/com.google.play.review/)): +87,180 (3,714.5% from 2,347)
+6. VContainer ([jp.hadashikick.vcontainer](/packages/jp.hadashikick.vcontainer/)): +70,071 (29.2% from 240,113)
+7. UI Particle ([com.coffee.ui-particle](/packages/com.coffee.ui-particle/)): +69,379 (25.4% from 273,208)
+8. PlayableGraphMonitor! ([com.greenbamboogames.playablegraphmonitor](/packages/com.greenbamboogames.playablegraphmonitor/)): +34,412 (864.2% from 3,982)
+9. Google Mobile Ads for Unity ([com.google.ads.mobile](/packages/com.google.ads.mobile/)): +24,970 (67.8% from 36,808)
+10. AltTester Unity SDK ([com.alttester.sdk](/packages/com.alttester.sdk/)): +24,761 (412.7% from 6,000)
 
-<h2>New packages</h2>
+## New packages
 
-<p>Top 10 new packages by downloads:</p>
+Top 10 new packages by downloads:
 
-<ol><li>ZLinq (<a href="/packages/com.cysharp.zlinq/">com.cysharp.zlinq</a>): 5,218</li><li>AI Game Developer - MCP (<a href="/packages/com.ivanmurzak.unity.mcp/">com.ivanmurzak.unity.mcp</a>): 4,940</li><li>HierarchyFinder (<a href="/packages/io.github.hatayama.hierarchyfinder/">io.github.hatayama.hierarchyfinder</a>): 3,334</li><li>InspectorAutoAssigner (<a href="/packages/io.github.hatayama.inspectorautoassigner/">io.github.hatayama.inspectorautoassigner</a>): 2,973</li><li>CleanFormerlySerializedAs (<a href="/packages/io.github.hatayama.cleanformerlyserializedas/">io.github.hatayama.cleanformerlyserializedas</a>): 2,783</li><li>MCP for Unity (<a href="/packages/com.coplaydev.unity-mcp/">com.coplaydev.unity-mcp</a>): 2,367</li><li>Mirage Steamworks.net Socket (<a href="/packages/com.miragenet.steamworkssocket/">com.miragenet.steamworkssocket</a>): 1,557</li><li>Cursor Editor (<a href="/packages/com.boxqkrtm.ide.cursor/">com.boxqkrtm.ide.cursor</a>): 1,215</li><li>AddressablesLoader (<a href="/packages/com.realitygames.addressablesloader/">com.realitygames.addressablesloader</a>): 1,198</li><li>Instant Replay (<a href="/packages/jp.co.cyberagent.instant-replay/">jp.co.cyberagent.instant-replay</a>): 1,105</li></ol>
+1. ZLinq ([com.cysharp.zlinq](/packages/com.cysharp.zlinq/)): 5,218
+2. AI Game Developer - MCP ([com.ivanmurzak.unity.mcp](/packages/com.ivanmurzak.unity.mcp/)): 4,940
+3. HierarchyFinder ([io.github.hatayama.hierarchyfinder](/packages/io.github.hatayama.hierarchyfinder/)): 3,334
+4. InspectorAutoAssigner ([io.github.hatayama.inspectorautoassigner](/packages/io.github.hatayama.inspectorautoassigner/)): 2,973
+5. CleanFormerlySerializedAs ([io.github.hatayama.cleanformerlyserializedas](/packages/io.github.hatayama.cleanformerlyserializedas/)): 2,783
+6. MCP for Unity ([com.coplaydev.unity-mcp](/packages/com.coplaydev.unity-mcp/)): 2,367
+7. Mirage Steamworks.net Socket ([com.miragenet.steamworkssocket](/packages/com.miragenet.steamworkssocket/)): 1,557
+8. Cursor Editor ([com.boxqkrtm.ide.cursor](/packages/com.boxqkrtm.ide.cursor/)): 1,215
+9. AddressablesLoader ([com.realitygames.addressablesloader](/packages/com.realitygames.addressablesloader/)): 1,198
+10. Instant Replay ([jp.co.cyberagent.instant-replay](/packages/jp.co.cyberagent.instant-replay/)): 1,105
 
-<h2>Topics</h2>
+## Topics
 
-<p>By downloads, the top categories were:</p>
+By downloads, the top categories were:
 
-<ul><li>Utilities</li><li>Editor Enhancement</li><li>Package Management</li><li>Integration</li><li>GUI</li></ul>
+- Utilities
+- Editor Enhancement
+- Package Management
+- Integration
+- GUI
 
-<h2>AI packages</h2>
+## AI packages
 
-<p>Top 5 AI packages by downloads:</p>
+Top 5 AI packages by downloads:
 
-<ol><li>OpenAI (<a href="/packages/com.openai.unity/">com.openai.unity</a>): 7,058</li><li>AI Game Developer - MCP (<a href="/packages/com.ivanmurzak.unity.mcp/">com.ivanmurzak.unity.mcp</a>): 4,940</li><li>ElevenLabs (<a href="/packages/com.rest.elevenlabs/">com.rest.elevenlabs</a>): 4,551</li><li>MCP for Unity (<a href="/packages/com.coplaydev.unity-mcp/">com.coplaydev.unity-mcp</a>): 2,367</li><li>Theymes SDK (<a href="/packages/com.theymes.sdk/">com.theymes.sdk</a>): 614</li></ol>
+1. OpenAI ([com.openai.unity](/packages/com.openai.unity/)): 7,058
+2. AI Game Developer - MCP ([com.ivanmurzak.unity.mcp](/packages/com.ivanmurzak.unity.mcp/)): 4,940
+3. ElevenLabs ([com.rest.elevenlabs](/packages/com.rest.elevenlabs/)): 4,551
+4. MCP for Unity ([com.coplaydev.unity-mcp](/packages/com.coplaydev.unity-mcp/)): 2,367
+5. Theymes SDK ([com.theymes.sdk](/packages/com.theymes.sdk/)): 614
 
-<p>AI tooling is still a small slice of OpenUPM traffic, but it is no longer theoretical. Some of these packages now have real usage.</p>
+AI tooling is still a small slice of OpenUPM traffic, but it is no longer theoretical. Some of these packages now have real usage.
 
-<h2>Releases</h2>
+## Releases
 
-<p>Release activity averaged about 742 releases per month, with the largest spike late in the year:</p>
+Release activity averaged about 742 releases per month, with the largest spike late in the year:
 
-<figure><img alt="Monthly Releases in 2025" src="./images/openupm-2025-recap-6283fcd0217e-02-monthly-releases-in-2025.png" /></figure>
+![Monthly Releases in 2025](./images/openupm-2025-recap-6283fcd0217e-02-monthly-releases-in-2025.png)
 
-<ul><li>September: 1,762 releases, the year's peak.</li><li>December: 882 releases.</li></ul>
+- September: 1,762 releases, the year's peak.
+- December: 882 releases.
 
-<p>Top 5 packages by release count:</p>
+Top 5 packages by release count:
 
-<ol><li>Rive (<a href="/packages/app.rive.rive-unity/">app.rive.rive-unity</a>): 1,234</li><li>PurrNet (<a href="/packages/dev.purrnet.purrnet/">dev.purrnet.purrnet</a>): 326</li><li>SaintsField (<a href="/packages/today.comes.saintsfield/">today.comes.saintsfield</a>): 212</li><li>Purrdiction (<a href="/packages/dev.purrnet.purrdiction/">dev.purrnet.purrdiction</a>): 162</li><li>VRCFury (<a href="/packages/com.vrcfury.vrcfury/">com.vrcfury.vrcfury</a>): 151</li></ol>
+1. Rive ([app.rive.rive-unity](/packages/app.rive.rive-unity/)): 1,234
+2. PurrNet ([dev.purrnet.purrnet](/packages/dev.purrnet.purrnet/)): 326
+3. SaintsField ([today.comes.saintsfield](/packages/today.comes.saintsfield/)): 212
+4. Purrdiction ([dev.purrnet.purrdiction](/packages/dev.purrnet.purrdiction/)): 162
+5. VRCFury ([com.vrcfury.vrcfury](/packages/com.vrcfury.vrcfury/)): 151
 
-<h2>Takeaways</h2>
+## Takeaways
 
-<p>Fewer packages were submitted in 2025, but more of them came directly from package owners. The second half of the year also had a lot more release activity, which usually means maintainers were updating existing packages instead of only adding new ones.</p>
+Fewer packages were submitted in 2025, but more of them came directly from package owners. The second half of the year also had a lot more release activity, which usually means maintainers were updating existing packages instead of only adding new ones.
 
-<p>Notes: Download counts are calculated from the package tarball endpoint. Automated traffic is rate limited but hard to fully exclude, so treat the numbers as directional guidance. This is true for most stats services.</p>
+Notes: Download counts are calculated from the package tarball endpoint. Automated traffic is rate limited but hard to fully exclude, so treat the numbers as directional guidance. This is true for most stats services.
 
 <BlogPostNav />

--- a/apps/docs/docs/blog/openupm-launches-alternative-unitynuget-registry-0b8cc663cc41/index.md
+++ b/apps/docs/docs/blog/openupm-launches-alternative-unitynuget-registry-0b8cc663cc41/index.md
@@ -11,28 +11,30 @@ editLink: false
 
 <BlogPostMeta />
 
-<figure><img alt="" src="./images/openupm-launches-alternative-unitynuget-registry-0b8cc663cc41-01-blog-image.png" /></figure>
+![](./images/openupm-launches-alternative-unitynuget-registry-0b8cc663cc41-01-blog-image.png)
 
-<p>OpenUPM now hosts an alternative endpoint for the UnityNuGet registry. Alexandre Mutel (<a href="http://github.com/xoofx">@xoofx</a>) has resigned from Unity, and the UnityNuGet Azure feed is scheduled to stop on March 10. Thank you to Alexandre for creating UnityNuGet and keeping it useful for so many Unity projects.</p>
+OpenUPM now hosts an alternative endpoint for the UnityNuGet registry. Alexandre Mutel ([@xoofx](http://github.com/xoofx)) has resigned from Unity, and the UnityNuGet Azure feed is scheduled to stop on March 10. Thank you to Alexandre for creating UnityNuGet and keeping it useful for so many Unity projects.
 
-<h2>What changes</h2>
+## What changes
 
-<p>The alternative registry is available at:<br> <a href="https://unitynuget-registry.openupm.com/"><strong>https://unitynuget-registry.openupm.com/</strong></a></p>
+The alternative registry is available at:
+[**https://unitynuget-registry.openupm.com/**](https://unitynuget-registry.openupm.com/)
 
-<p>The service tracks the latest UnityNuGet Docker image and receives regular updates. It currently runs on a small server, so we will watch usage and add capacity if traffic requires it.</p>
+The service tracks the latest UnityNuGet Docker image and receives regular updates. It currently runs on a small server, so we will watch usage and add capacity if traffic requires it.
 
-<p>The main OpenUPM registry now uplinks to this UnityNuGet endpoint, so existing OpenUPM uplink users can keep resolving org.nuget packages through OpenUPM.</p>
+The main OpenUPM registry now uplinks to this UnityNuGet endpoint, so existing OpenUPM uplink users can keep resolving org.nuget packages through OpenUPM.
 
-<h2>UnityNuGet maintenance</h2>
+## UnityNuGet maintenance
 
-<p>Borja Domínguez (<a href="https://github.com/bdovaz">@bdovaz</a>) continues to maintain the UnityNuGet project. Developers can still submit NuGet packages to the curated list at:<br> <a href="https://github.com/xoofx/UnityNuGet/blob/master/registry.json"><strong>https://github.com/xoofx/UnityNuGet/blob/master/registry.json</strong></a></p>
+Borja Domínguez ([@bdovaz](https://github.com/bdovaz)) continues to maintain the UnityNuGet project. Developers can still submit NuGet packages to the curated list at:
+[**https://github.com/xoofx/UnityNuGet/blob/master/registry.json**](https://github.com/xoofx/UnityNuGet/blob/master/registry.json)
 
-<h2>How to support the service</h2>
+## How to support the service
 
-<p>OpenUPM runs on a limited budget. If this registry helps your project, you can support it through <a href="https://www.patreon.com/openupm">Patreon</a>, <a href="https://github.com/sponsors/openupm">GitHub Sponsors</a>, or <a href="https://www.paypal.com/paypalme/favoyang">PayPal</a>.</p>
+OpenUPM runs on a limited budget. If this registry helps your project, you can support it through [Patreon](https://www.patreon.com/openupm), [GitHub Sponsors](https://github.com/sponsors/openupm), or [PayPal](https://www.paypal.com/paypalme/favoyang).
 
-<p><em>References: </em><a href="https://github.com/xoofx/UnityNuGet/issues/480"><em>UnityNuGet Issue #480</em></a><em> | </em><a href="/nuget/"><em>OpenUPM NuGet Registry</em></a></p>
+*References:* [*UnityNuGet Issue #480*](https://github.com/xoofx/UnityNuGet/issues/480) | [*OpenUPM NuGet Registry*](/nuget/)
 
-<p>OpenUPM is hosted on DigitalOcean. Our <a href="https://m.do.co/c/50e7f9860fa9">DigitalOcean referral link</a> includes a $200 onboarding credit valid for 60 days.</p>
+OpenUPM is hosted on DigitalOcean. Our [DigitalOcean referral link](https://m.do.co/c/50e7f9860fa9) includes a $200 onboarding credit valid for 60 days.
 
 <BlogPostNav />

--- a/apps/docs/docs/blog/openupm-trends-page/index.md
+++ b/apps/docs/docs/blog/openupm-trends-page/index.md
@@ -11,12 +11,7 @@ editLink: false
 
 <BlogPostMeta />
 
-<figure>
-  <img
-    alt="OpenUPM Total packages chart"
-    src="/images/blog-covers/openupm-trends-total-packages.png"
-  />
-</figure>
+![OpenUPM Total packages chart](/images/blog-covers/openupm-trends-total-packages.png)
 
 OpenUPM now has a public [Trends](/trends/) page for tracking how the package
 catalog changes over time. The page brings the main ecosystem signals into one

--- a/apps/docs/docs/blog/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c/index.md
+++ b/apps/docs/docs/blog/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c/index.md
@@ -11,37 +11,58 @@ editLink: false
 
 <BlogPostMeta />
 
-<p>Unity had a rough month, and many Unity developers were watching the ecosystem more closely than usual. OpenUPM used Hacktoberfest 2023 to ship several site improvements that had been waiting in the queue.</p>
+Unity had a rough month, and many Unity developers were watching the ecosystem more closely than usual. OpenUPM used Hacktoberfest 2023 to ship several site improvements that had been waiting in the queue.
 
-<p>OpenUPM now has a dark theme for late-night browsing.</p>
-<figure><img alt="OpenUPM Dark Theme" src="./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-01-openupm-dark-theme.jpg" /><figcaption>OpenUPM Dark Theme</figcaption></figure>
+OpenUPM now has a dark theme for late-night browsing.
 
-<p>The package list also received a more consistent layout.</p>
-<figure><img alt="New Designed Package List" src="./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-02-new-designed-package-list.jpg" /><figcaption>New Designed Package List</figcaption></figure>
+![OpenUPM Dark Theme](./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-01-openupm-dark-theme.jpg)
 
-<p>Package list scrolling now uses virtualization. That keeps memory usage stable when browsing long result sets and avoids the crashes some users hit with the old list.</p>
+*OpenUPM Dark Theme*
 
-<p>Topics and categories are easier to scan now.</p>
-<figure><img alt="New Designed Topic List" src="./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-03-new-designed-topic-list.jpg" /><figcaption>New Designed Topic List</figcaption></figure>
+The package list also received a more consistent layout.
 
-<p>OpenUPM can sort packages by monthly downloads, which makes popular packages easier to find.</p>
-<figure><img alt="Sort Packages by Monthly Downloads" src="./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-04-sort-packages-by-monthly-downloads.png" /><figcaption>Sort Packages by Monthly Downloads</figcaption></figure>
+![New Designed Package List](./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-02-new-designed-package-list.jpg)
 
-<p>The package list now supports keyword filtering.</p>
-<figure><img alt="Search by Keywords" src="./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-05-search-by-keywords.jpg" /><figcaption>Search by Keywords</figcaption></figure>
+*New Designed Package List*
 
-<p>The package add form now shows a package card preview, so maintainers can check what they are about to submit.</p>
-<figure><img alt="" src="./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-06-blog-image.jpg" /><figcaption>New Designed Package Add Form</figcaption></figure>
+Package list scrolling now uses virtualization. That keeps memory usage stable when browsing long result sets and avoids the crashes some users hit with the old list.
 
-<p>The site has also moved to <a href="https://github.com/vuepress/vuepress-next">vuepress-next</a>, and parts of the codebase now use TypeScript.</p>
+Topics and categories are easier to scan now.
 
-<p>ComradeVanti migrated openupm-cli to TypeScript in pull request <a href="https://github.com/openupm/openupm-cli/pull/52">#52</a>. That was a useful contribution on its own, and ComradeVanti is also one of our backers.</p>
+![New Designed Topic List](./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-03-new-designed-topic-list.jpg)
 
-<p>Traffic increased after the redesigned site launched.</p>
-<figure><img alt="The Views Bump Up Since the Launch of the Revamped Website" src="./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-07-the-views-bump-up-since-the-launch-of-the-revamped-website.png" /><figcaption>The Views Bump Up Since the Launch of the Revamped Website</figcaption></figure>
+*New Designed Topic List*
 
-<p>OpenUPM remains an independent service. Unity is not involved in sponsorship or development. The project is backed by individual developers who care about game development and open source packages, and that support matters when the wider Unity ecosystem feels uncertain.</p>
+OpenUPM can sort packages by monthly downloads, which makes popular packages easier to find.
 
-<p>If you appreciate the work, you can sponsor OpenUPM on Patreon at <a href="https://www.patreon.com/openupm">patreon.com/openupm</a>.</p>
+![Sort Packages by Monthly Downloads](./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-04-sort-packages-by-monthly-downloads.png)
+
+*Sort Packages by Monthly Downloads*
+
+The package list now supports keyword filtering.
+
+![Search by Keywords](./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-05-search-by-keywords.jpg)
+
+*Search by Keywords*
+
+The package add form now shows a package card preview, so maintainers can check what they are about to submit.
+
+![](./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-06-blog-image.jpg)
+
+*New Designed Package Add Form*
+
+The site has also moved to [vuepress-next](https://github.com/vuepress/vuepress-next), and parts of the codebase now use TypeScript.
+
+ComradeVanti migrated openupm-cli to TypeScript in pull request [#52](https://github.com/openupm/openupm-cli/pull/52). That was a useful contribution on its own, and ComradeVanti is also one of our backers.
+
+Traffic increased after the redesigned site launched.
+
+![The Views Bump Up Since the Launch of the Revamped Website](./images/openupm-x-hacktoberfest-2023-round-ups-a1d968a7894c-07-the-views-bump-up-since-the-launch-of-the-revamped-website.png)
+
+*The Views Bump Up Since the Launch of the Revamped Website*
+
+OpenUPM remains an independent service. Unity is not involved in sponsorship or development. The project is backed by individual developers who care about game development and open source packages, and that support matters when the wider Unity ecosystem feels uncertain.
+
+If you appreciate the work, you can sponsor OpenUPM on Patreon at [patreon.com/openupm](https://www.patreon.com/openupm).
 
 <BlogPostNav />

--- a/apps/docs/docs/blog/unity-66-fast-enter-play-mode-package-readiness/index.md
+++ b/apps/docs/docs/blog/unity-66-fast-enter-play-mode-package-readiness/index.md
@@ -11,12 +11,7 @@ editLink: false
 
 <BlogPostMeta />
 
-<figure>
-  <img
-    alt="Unity package compatibility cleanup illustration"
-    src="/images/blog-covers/unity-66-fast-enter-play-mode-package-readiness.png"
-  />
-</figure>
+![Unity package compatibility cleanup illustration](/images/blog-covers/unity-66-fast-enter-play-mode-package-readiness.png)
 
 Starting with Unity 6.6, Fast Enter Play Mode is enabled by default for new
 projects. For package authors, the main compatibility change is that packages


### PR DESCRIPTION
## Summary
- convert published blog posts that still used raw HTML blocks into normal Markdown
- keep Vue blog components intact while replacing paragraph, heading, list, link, image, caption, and simple emphasis markup
- preserve metadata, links, image paths, and rendered blog content

## Validation
- npm run test -- blog.spec.ts
- npm run lint
- npm run docs:build:limit