### PR TITLE
Promote PlayMaker 2 in package listings

### DIFF
--- a/apps/docs/__tests__/vue/featuredListingAd.spec.ts
+++ b/apps/docs/__tests__/vue/featuredListingAd.spec.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createTimedCampaignState } from "../../docs/.vuepress/featuredListingAd";
+
+const packageListSource = readFileSync(
+  fileURLToPath(
+    new URL(
+      "../../docs/.vuepress/layouts/PackageListLayout.vue",
+      import.meta.url,
+    ),
+  ),
+  "utf8",
+);
+
+describe("featured listing ad", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the PlayMaker 2 affiliate promotion first through July 31, 2026", () => {
+    expect(packageListSource).toContain(
+      'const featuredListingAdCampaignEnd = new Date("2026-07-31T00:00:00Z");',
+    );
+    expect(packageListSource).toContain('title: "PlayMaker 2"');
+    expect(packageListSource).toContain('originalPrice: "$65"');
+    expect(packageListSource).toContain('price: "$32.50"');
+    expect(packageListSource).toContain("ratingCount: 2908");
+    expect(packageListSource).toContain(
+      "https://af.unity.com/sr/camref:1011lJJH/destination:https://assetstore.unity.com/packages/tools/visual-scripting/playmaker2-391026",
+    );
+    expect(packageListSource).toContain(
+      'publisher: "Hutong Games LLC · Affiliate"',
+    );
+    const featuredAdInsertion = packageListSource.indexOf(
+      'items.push({ type: "ad", value: featuredListingAdPlacementData });',
+    );
+    const packageInsertionLoop = packageListSource.indexOf(
+      "for (let i = 0; i < metadataEntries.value.length; i++)",
+    );
+    expect(featuredAdInsertion).toBeGreaterThan(-1);
+    expect(featuredAdInsertion).toBeLessThan(packageInsertionLoop);
+    expect(packageListSource).toContain(
+      "onUnmounted(featuredListingAdCampaign.stop);",
+    );
+  });
+
+  it("expires an open listing at the campaign boundary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-30T23:59:59.999Z"));
+    const campaign = createTimedCampaignState(
+      new Date("2026-07-31T00:00:00Z"),
+    );
+
+    campaign.start();
+    expect(campaign.isActive.value).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(campaign.isActive.value).toBe(false);
+  });
+
+  it("stays inactive at expiry and cancels pending expiry work on stop", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-30T23:59:59.999Z"));
+    const activeCampaign = createTimedCampaignState(
+      new Date("2026-07-31T00:00:00Z"),
+    );
+    activeCampaign.start();
+    expect(vi.getTimerCount()).toBe(1);
+    activeCampaign.stop();
+    expect(vi.getTimerCount()).toBe(0);
+
+    vi.setSystemTime(new Date("2026-07-31T00:00:00Z"));
+    const expiredCampaign = createTimedCampaignState(
+      new Date("2026-07-31T00:00:00Z"),
+    );
+    expiredCampaign.start();
+    expect(expiredCampaign.isActive.value).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/apps/docs/__tests__/vue/unityAiTrialAd.spec.ts
+++ b/apps/docs/__tests__/vue/unityAiTrialAd.spec.ts
@@ -24,22 +24,7 @@ describe("UnityAiTrialAd", () => {
     expect(source).toContain("new Date() < campaignEnd");
     expect(source).toContain("Try Unity AI FREE ✨");
     expect(source).toContain("border: 1px solid rgba($primary-color, 0.25);");
-    expect(packageListSource).toContain(
-      'const unityAiTrialCampaignEnd = new Date("2026-07-01T00:00:00");',
-    );
-    expect(packageListSource).toContain('title: "Unity AI FREE"');
-    expect(packageListSource).toContain(
-      'image: "/images/ads/unity-ai-trial-600.jpg"',
-    );
-    expect(packageListSource).toContain(
-      'publisher: "Project-aware Assistant, AI Gateway, and MCP Server"',
-    );
-    expect(packageListSource).toContain(
-      "const isUnityAiTrialAdActive = computed(() => new Date() < unityAiTrialCampaignEnd);",
-    );
-    expect(packageListSource).toContain(
-      'items.push({ type: "ad", value: unityAiTrialAdPlacementData });',
-    );
+    expect(packageListSource).not.toContain("unityAiTrialAdPlacementData");
   });
 
   it("is shown next to the navbar brand only", () => {

--- a/apps/docs/docs/.vuepress/featuredListingAd.ts
+++ b/apps/docs/docs/.vuepress/featuredListingAd.ts
@@ -1,0 +1,35 @@
+import { ref, type Ref } from "vue";
+
+export type TimedCampaignState = {
+  isActive: Ref<boolean>;
+  start: () => void;
+  stop: () => void;
+};
+
+export const createTimedCampaignState = (
+  campaignEnd: Date,
+): TimedCampaignState => {
+  const campaignEndTime = campaignEnd.getTime();
+  const isActive = ref(Date.now() < campaignEndTime);
+  let expiryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const stop = (): void => {
+    if (expiryTimer === undefined) return;
+    clearTimeout(expiryTimer);
+    expiryTimer = undefined;
+  };
+
+  const start = (): void => {
+    stop();
+    const remainingTime = campaignEndTime - Date.now();
+    isActive.value = remainingTime > 0;
+    if (!isActive.value) return;
+
+    expiryTimer = setTimeout(() => {
+      isActive.value = false;
+      expiryTimer = undefined;
+    }, remainingTime);
+  };
+
+  return { isActive, start, stop };
+};

--- a/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import axios from "axios";
 import { orderBy, capitalize, groupBy } from "lodash-es";
-import { computed, watch, onMounted, reactive, ref } from "vue";
+import { computed, watch, onMounted, onUnmounted, reactive, ref } from "vue";
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n'
 import { usePageFrontmatter } from "@vuepress/client";
@@ -21,6 +21,7 @@ import { isUnityNuGetPackageName, usePackageSearchSuggestions } from "@/search";
 import UnityAssetAdPlacement from '@/components/UnityAssetAdPlacementForPackageList.vue';
 import DonationSidebarAd from '@/components/DonationSidebarAd.vue';
 import UnityAssetStoreSale from '@/components/UnityAssetStoreSale.vue';
+import { createTimedCampaignState } from "@/featuredListingAd";
 
 const route = useRoute();
 const router = useRouter();
@@ -138,20 +139,22 @@ type ListItem = {
   value: PackageMetadata | AdPlacementData;
 };
 
-const unityAiTrialCampaignEnd = new Date("2026-07-01T00:00:00");
+const featuredListingAdCampaignEnd = new Date("2026-07-31T00:00:00Z");
 
-const unityAiTrialAdPlacementData: AdPlacementData = {
-  title: "Unity AI FREE",
-  image: "/images/ads/unity-ai-trial-600.jpg",
-  originalPrice: "FREE",
-  price: "FREE",
-  url: "https://unity.com/features/ai?aid=1011lJJH",
-  ratingCount: null,
-  ratingAverage: 0,
-  publisher: "Project-aware Assistant, AI Gateway, and MCP Server",
+const featuredListingAdPlacementData: AdPlacementData = {
+  title: "PlayMaker 2",
+  image: "https://assetstorev1-prd-cdn.unity3d.com/key-image/4641c0f4-1ec6-46ed-80cf-908e45bccd6c.jpg",
+  originalPrice: "$65",
+  price: "$32.50",
+  url: "https://af.unity.com/sr/camref:1011lJJH/destination:https://assetstore.unity.com/packages/tools/visual-scripting/playmaker2-391026",
+  ratingCount: 2908,
+  ratingAverage: 5,
+  publisher: "Hutong Games LLC · Affiliate",
 };
 
-const isUnityAiTrialAdActive = computed(() => new Date() < unityAiTrialCampaignEnd);
+const featuredListingAdCampaign = createTimedCampaignState(
+  featuredListingAdCampaignEnd,
+);
 
 /* The ListItems to be displayed in the grid.
  * It includes both package metadata and ad placement data.
@@ -161,8 +164,8 @@ const listItems = computed(() => {
   const items = [] as ListItem[];
   const adInterval = 6;
   let adIndex = 0;
-  if (isUnityAiTrialAdActive.value) {
-    items.push({ type: "ad", value: unityAiTrialAdPlacementData });
+  if (featuredListingAdCampaign.isActive.value) {
+    items.push({ type: "ad", value: featuredListingAdPlacementData });
   }
   for (let i = 0; i < metadataEntries.value.length; i++) {
     items.push({ type: "package", value: metadataEntries.value[i] });
@@ -299,10 +302,13 @@ const fetchAdPlacementData = async (): Promise<void> => {
 
 // Hooks
 onMounted(() => {
+  featuredListingAdCampaign.start();
   parseQuery();
   store.fetchCachedPackageListData();
   fetchAdPlacementData();
 });
+
+onUnmounted(featuredListingAdCampaign.stop);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 watch(() => route.path, (newPath, oldPath) => {


### PR DESCRIPTION
## Summary

- replace the expired featured listing promotion with PlayMaker 2
- keep the affiliate promotion pinned as the first package-list card until July 31, 2026 at 00:00 UTC
- show Unity’s five-star review count (2,908), affiliate disclosure, campaign pricing, and official artwork
- expire already-open listing pages at the campaign boundary and clean up the timer on unmount

## Validation

- `npm run test -- unityAiTrialAd.spec.ts featuredListingAd.spec.ts`
- `npm run lint`
- `OPENUPM_DATA_PATH=<openupm-data> npm run docs:build:limit`
- staged locally and reviewed on desktop and mobile, in dark and light themes
- verified the AF.Unity link redirects to the canonical PlayMaker 2 Asset Store page

## Review

This docs client change was visually reviewed on local staging before publication.