### PR TITLE
fix(data): reject plain GitHub blob image URLs

### DIFF
--- a/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
+++ b/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
@@ -249,7 +249,7 @@ describe('validateDataDirectory', () => {
   });
 
   it('covers package semantic checks from openupm data tests', async () => {
-    expect.assertions(10);
+    expect.assertions(16);
     await expectIssue(
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {
@@ -304,6 +304,35 @@ describe('validateDataDirectory', () => {
         }),
       'package-image-url-invalid',
     );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          image: 'https://github.com/example/package/blob/main/image.png',
+        }),
+      'package-image-github-blob-url-invalid',
+    );
+    for (const image of [
+      'https://github.com/example/package/blob/main/image.png?raw=true',
+      'https://github.com/example/package/raw/main/image.png',
+      'https://raw.githubusercontent.com/example/package/main/image.png',
+      'https://github.com/example/package/assets/123/image.png',
+      'https://github.com/example/package/wiki/image.png',
+    ]) {
+      const dataDir = await createDataDir();
+      try {
+        await writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          image,
+        });
+        expect(await validateDataDirectory(dataDir)).toEqual({
+          valid: true,
+          issues: [],
+        });
+      } finally {
+        await afs.rm(dataDir, { recursive: true, force: true });
+      }
+    }
     await expectIssue(
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {

--- a/packages/@openupm/local-data/src/validation/data-validator.ts
+++ b/packages/@openupm/local-data/src/validation/data-validator.ts
@@ -69,6 +69,19 @@ function isGitHubRepoUrl(value: string): boolean {
   }
 }
 
+function isPlainGitHubBlobImageUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.hostname.toLowerCase() === 'github.com' &&
+      /^\/[^/]+\/[^/]+\/blob\//.test(parsed.pathname) &&
+      parsed.searchParams.get('raw') !== 'true'
+    );
+  } catch {
+    return false;
+  }
+}
+
 function messageFromError(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
@@ -326,10 +339,19 @@ export async function validateDataDirectory(
           });
         }
       }
-      if (pkg.image && !/https?:\/\//i.test(pkg.image)) {
+      const imageIsPlainGitHubBlobUrl =
+        pkg.image && isPlainGitHubBlobImageUrl(pkg.image);
+      if (
+        pkg.image &&
+        (!/https?:\/\//i.test(pkg.image) || imageIsPlainGitHubBlobUrl)
+      ) {
         addIssue(issues, {
-          code: 'package-image-url-invalid',
-          message: 'image field should be a valid URL',
+          code: imageIsPlainGitHubBlobUrl
+            ? 'package-image-github-blob-url-invalid'
+            : 'package-image-url-invalid',
+          message: imageIsPlainGitHubBlobUrl
+            ? 'image field must not use a plain github.com blob URL'
+            : 'image field should be a valid URL',
           path: relPath,
           packageName,
         });


### PR DESCRIPTION
## Summary\n- reject plain GitHub blob-page URLs in package image metadata\n- continue accepting raw GitHub, raw-content, asset, and wiki URL forms\n- add focused validation coverage\n\n## Validation\n- npm run lint -- --filter=@openupm/local-data\n- npm test -- --filter=@openupm/local-data