### PR TITLE
Fix missing Azure build reconciliation

### DIFF
--- a/apps/queue/README.md
+++ b/apps/queue/README.md
@@ -46,6 +46,13 @@ Common commands:
   remove its deterministic release queue job. This is destructive.
 - `release-requeue <package> <version> [--json]`: reset one release and enqueue
   a fresh release build job.
+- `release-reconcile-published <package> <version> [--json]`: verify that the
+  exact version exists in the OpenUPM registry, mark its release record
+  `Succeeded/None`, clear stale signing and GitHub Release probe metadata, set
+  `publishedVersion` to the requested version, and remove its deterministic
+  release job. This is destructive; an initial repair requires a `Building`
+  release with a failed job and refuses unpublished versions. Cleanup can be
+  retried when the record already has the exact reconciled state.
 - `package-requeue <package> [--json]`: remove the deterministic package queue
   job and enqueue a fresh package scan.
 - `cleanup-missing-packages [--json]`: clean failed package jobs for packages

--- a/apps/queue/__tests__/queueCli.spec.ts
+++ b/apps/queue/__tests__/queueCli.spec.ts
@@ -98,7 +98,12 @@ describe('parseQueueCliArgs', () => {
 
   it('parses top-level help', async () => {
     const { parseQueueCliArgs } = await import('../src/queueCli.js');
-    const parsed = parseQueueCliArgs(['node', 'index.js', 'queue-cli', '--help']);
+    const parsed = parseQueueCliArgs([
+      'node',
+      'index.js',
+      'queue-cli',
+      '--help',
+    ]);
     expect(parsed).toEqual({ command: 'help' });
   });
 
@@ -126,7 +131,9 @@ describe('parseQueueCliArgs', () => {
   it('documents the full releases-failed interface', async () => {
     const { getCommandUsage } = await import('../src/queueCli.js');
     const help = getCommandUsage('releases-failed');
-    expect(help).toContain('queue-cli releases-failed [reason|unknown|timeout]');
+    expect(help).toContain(
+      'queue-cli releases-failed [reason|unknown|timeout]',
+    );
     expect(help).toContain('BuildTimeout/ConnectionTimeout/GatewayTimeout');
     expect(help).toContain('VersionConflict');
   });
@@ -145,14 +152,30 @@ describe('parseQueueCliArgs', () => {
     expect(help).toContain('remove-job <queue> <jobId>');
     expect(help).toContain('This is destructive');
     expect(help).toContain('release-remove <package> <version>');
+    expect(help).toContain('release-reconcile-published <package> <version>');
     expect(help).toContain('cleanup-missing-packages');
+  });
+
+  it('documents safe guards for published release reconciliation', async () => {
+    const { getCommandUsage } = await import('../src/queueCli.js');
+    const help = getCommandUsage('release-reconcile-published');
+    expect(help).toContain(
+      'queue-cli release-reconcile-published <package> <version>',
+    );
+    expect(help).toContain('This is destructive');
+    expect(help).toContain(
+      'Initially the release must be Building; a cleanup retry',
+    );
+    expect(help).toContain('A release-scoped lock prevents package scans');
   });
 
   it('documents cleanup-missing-packages behavior', async () => {
     const { getCommandUsage } = await import('../src/queueCli.js');
     const help = getCommandUsage('cleanup-missing-packages');
     expect(help).toContain('queue-cli cleanup-missing-packages');
-    expect(help).toContain('Successful and non-failed release records are preserved.');
+    expect(help).toContain(
+      'Successful and non-failed release records are preserved.',
+    );
   });
 
   it('queue-jobs includes total and limit metadata', async () => {

--- a/apps/queue/__tests__/queueCliActions.spec.ts
+++ b/apps/queue/__tests__/queueCliActions.spec.ts
@@ -17,6 +17,9 @@ const removeReleaseRecordMock = vi.fn();
 const saveReleaseMock = vi.fn();
 const redisCloseMock = vi.fn();
 const packageMetadataLocalExistsMock = vi.fn();
+const isReleasePublishedMock = vi.fn();
+const markReleasePublishedMock = vi.fn();
+const withReleaseMutationLockMock = vi.fn();
 
 vi.mock('@openupm/local-data', () => ({
   packageMetadataLocalExists: packageMetadataLocalExistsMock,
@@ -46,6 +49,18 @@ vi.mock('@openupm/server-common/build/redis.js', () => ({
   },
 }));
 
+vi.mock('../src/utils/registry.js', () => ({
+  isReleasePublished: isReleasePublishedMock,
+}));
+
+vi.mock('../src/utils/reconcilePublishedRelease.js', () => ({
+  markReleasePublished: markReleasePublishedMock,
+}));
+
+vi.mock('../src/utils/releaseMutationLock.js', () => ({
+  withReleaseMutationLock: withReleaseMutationLockMock,
+}));
+
 describe('queue-cli destructive actions', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -55,10 +70,19 @@ describe('queue-cli destructive actions', () => {
       add: queueAddMock,
       getJobCounts: vi.fn().mockResolvedValue({ failed: 0 }),
       getJobs: vi.fn().mockResolvedValue([]),
+      getJob: vi.fn().mockResolvedValue({
+        getState: vi.fn().mockResolvedValue('failed'),
+      }),
     });
-    hasQueueMock.mockImplementation((name: string) => name === 'pkg' || name === 'rel');
+    hasQueueMock.mockImplementation(
+      (name: string) => name === 'pkg' || name === 'rel',
+    );
     queueRemoveMock.mockResolvedValue(1);
     packageMetadataLocalExistsMock.mockReturnValue(true);
+    isReleasePublishedMock.mockResolvedValue(true);
+    withReleaseMutationLockMock.mockImplementation(
+      async (_packageName, _version, action) => await action(),
+    );
   });
 
   afterEach(() => {
@@ -79,9 +103,12 @@ describe('queue-cli destructive actions', () => {
     ]);
 
     expect(getQueueMock).toHaveBeenCalledWith('rel');
-    expect(queueRemoveMock).toHaveBeenCalledWith('build-rel|com.foo.bar|1.2.3', {
-      removeChildren: true,
-    });
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.foo.bar|1.2.3',
+      {
+        removeChildren: true,
+      },
+    );
     expect(removeReleaseRecordMock).not.toHaveBeenCalled();
     expect(saveReleaseMock).not.toHaveBeenCalled();
     expect(addJobMock).not.toHaveBeenCalled();
@@ -103,10 +130,16 @@ describe('queue-cli destructive actions', () => {
     ]);
 
     expect(getQueueMock).toHaveBeenCalledWith('rel');
-    expect(queueRemoveMock).toHaveBeenCalledWith('build-rel|com.foo.bar|1.2.3', {
-      removeChildren: true,
-    });
-    expect(removeReleaseRecordMock).toHaveBeenCalledWith('com.foo.bar', '1.2.3');
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.foo.bar|1.2.3',
+      {
+        removeChildren: true,
+      },
+    );
+    expect(removeReleaseRecordMock).toHaveBeenCalledWith(
+      'com.foo.bar',
+      '1.2.3',
+    );
     expect(addJobMock).not.toHaveBeenCalled();
   });
 
@@ -145,9 +178,12 @@ describe('queue-cli destructive actions', () => {
     ]);
 
     expect(fetchOneMock).toHaveBeenCalledWith('com.foo.bar', '1.2.3');
-    expect(queueRemoveMock).toHaveBeenCalledWith('build-rel|com.foo.bar|1.2.3', {
-      removeChildren: true,
-    });
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.foo.bar|1.2.3',
+      {
+        removeChildren: true,
+      },
+    );
     expect(saveReleaseMock).toHaveBeenCalledWith({
       ...release,
       state: ReleaseState.Pending,
@@ -166,6 +202,285 @@ describe('queue-cli destructive actions', () => {
     expect(removeReleaseRecordMock).not.toHaveBeenCalled();
   });
 
+  it('release-reconcile-published verifies and repairs a published release', async () => {
+    const release = {
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Building,
+      reason: ReleaseErrorCode.None,
+      buildId: 'expired-build',
+      tag: 'upm/1.2.3',
+      commit: 'abc123',
+      createdAt: 100,
+      updatedAt: 200,
+    };
+    const reconciled = {
+      ...release,
+      state: ReleaseState.Succeeded,
+      buildId: '',
+      publishedVersion: '1.2.3',
+      updatedAt: 300,
+    };
+    fetchOneMock.mockResolvedValue(release);
+    markReleasePublishedMock.mockResolvedValue(reconciled);
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await runQueueCli([
+      'node',
+      'index.js',
+      'queue-cli',
+      'release-reconcile-published',
+      'com.foo.bar',
+      '1.2.3',
+      '--json',
+    ]);
+
+    expect(isReleasePublishedMock).toHaveBeenCalledWith('com.foo.bar', '1.2.3');
+    expect(markReleasePublishedMock).toHaveBeenCalledWith(release);
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.foo.bar|1.2.3',
+      { removeChildren: true },
+    );
+    expect(addJobMock).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"state": "Succeeded"'),
+    );
+  });
+
+  it('release-reconcile-published leaves an unpublished release unchanged', async () => {
+    const release = {
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Building,
+      reason: ReleaseErrorCode.None,
+      buildId: 'expired-build',
+    };
+    fetchOneMock.mockResolvedValue(release);
+    isReleasePublishedMock.mockResolvedValue(false);
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await expect(
+      runQueueCli([
+        'node',
+        'index.js',
+        'queue-cli',
+        'release-reconcile-published',
+        'com.foo.bar',
+        '1.2.3',
+        '--json',
+      ]),
+    ).rejects.toThrow(
+      'Release is not published in the registry: com.foo.bar@1.2.3',
+    );
+
+    expect(queueRemoveMock).not.toHaveBeenCalled();
+    expect(markReleasePublishedMock).not.toHaveBeenCalled();
+  });
+
+  it('release-reconcile-published refuses a release outside Building state', async () => {
+    fetchOneMock.mockResolvedValue({
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Pending,
+      reason: ReleaseErrorCode.None,
+      buildId: '',
+    });
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await expect(
+      runQueueCli([
+        'node',
+        'index.js',
+        'queue-cli',
+        'release-reconcile-published',
+        'com.foo.bar',
+        '1.2.3',
+        '--json',
+      ]),
+    ).rejects.toThrow(
+      'Release must be Building or already reconciled to retry cleanup: com.foo.bar@1.2.3',
+    );
+
+    expect(isReleasePublishedMock).not.toHaveBeenCalled();
+    expect(queueRemoveMock).not.toHaveBeenCalled();
+    expect(markReleasePublishedMock).not.toHaveBeenCalled();
+  });
+
+  it('release-reconcile-published refuses a non-failed release job', async () => {
+    fetchOneMock.mockResolvedValue({
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Building,
+      reason: ReleaseErrorCode.None,
+      buildId: '12345',
+    });
+    getQueueMock.mockReturnValue({
+      remove: queueRemoveMock,
+      add: queueAddMock,
+      getJob: vi.fn().mockResolvedValue({
+        getState: vi.fn().mockResolvedValue('active'),
+      }),
+    });
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await expect(
+      runQueueCli([
+        'node',
+        'index.js',
+        'queue-cli',
+        'release-reconcile-published',
+        'com.foo.bar',
+        '1.2.3',
+        '--json',
+      ]),
+    ).rejects.toThrow(
+      'Release job must be failed to reconcile: com.foo.bar@1.2.3',
+    );
+
+    expect(isReleasePublishedMock).not.toHaveBeenCalled();
+    expect(queueRemoveMock).not.toHaveBeenCalled();
+    expect(markReleasePublishedMock).not.toHaveBeenCalled();
+  });
+
+  it('release-reconcile-published leaves verified success when job removal races', async () => {
+    fetchOneMock.mockResolvedValue({
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Building,
+      reason: ReleaseErrorCode.None,
+      buildId: '12345',
+    });
+    queueRemoveMock.mockResolvedValue(0);
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await expect(
+      runQueueCli([
+        'node',
+        'index.js',
+        'queue-cli',
+        'release-reconcile-published',
+        'com.foo.bar',
+        '1.2.3',
+        '--json',
+      ]),
+    ).rejects.toThrow(
+      'Release job could not be removed safely: com.foo.bar@1.2.3',
+    );
+
+    expect(isReleasePublishedMock).toHaveBeenCalledWith('com.foo.bar', '1.2.3');
+    expect(markReleasePublishedMock).toHaveBeenCalledOnce();
+  });
+
+  it('release-reconcile-published retries cleanup for an already reconciled release', async () => {
+    const release = {
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Succeeded,
+      reason: ReleaseErrorCode.None,
+      buildId: '',
+      signed: false,
+      publishedVersion: '1.2.3',
+      githubReleaseAssetMissingFirstSeenAt: undefined,
+      githubReleaseAssetMissingLastProbeAt: undefined,
+      githubReleaseAssetMissingProbeCount: undefined,
+    };
+    fetchOneMock.mockResolvedValue(release);
+    markReleasePublishedMock.mockResolvedValue(release);
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await runQueueCli([
+      'node',
+      'index.js',
+      'queue-cli',
+      'release-reconcile-published',
+      'com.foo.bar',
+      '1.2.3',
+      '--json',
+    ]);
+
+    expect(isReleasePublishedMock).toHaveBeenCalledWith('com.foo.bar', '1.2.3');
+    expect(markReleasePublishedMock).toHaveBeenCalledOnce();
+    expect(queueRemoveMock).toHaveBeenCalledWith(
+      'build-rel|com.foo.bar|1.2.3',
+      { removeChildren: true },
+    );
+  });
+
+  it('release-reconcile-published accepts an already completed cleanup', async () => {
+    const release = {
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Succeeded,
+      reason: ReleaseErrorCode.None,
+      buildId: '',
+      signed: false,
+      publishedVersion: '1.2.3',
+      githubReleaseAssetMissingFirstSeenAt: undefined,
+      githubReleaseAssetMissingLastProbeAt: undefined,
+      githubReleaseAssetMissingProbeCount: undefined,
+    };
+    fetchOneMock.mockResolvedValue(release);
+    markReleasePublishedMock.mockResolvedValue(release);
+    getQueueMock.mockReturnValue({
+      remove: queueRemoveMock,
+      add: queueAddMock,
+      getJob: vi.fn().mockResolvedValue(null),
+    });
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await runQueueCli([
+      'node',
+      'index.js',
+      'queue-cli',
+      'release-reconcile-published',
+      'com.foo.bar',
+      '1.2.3',
+      '--json',
+    ]);
+
+    expect(markReleasePublishedMock).toHaveBeenCalledWith(release);
+    expect(queueRemoveMock).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"alreadyComplete": true'),
+    );
+  });
+
+  it('release-reconcile-published keeps the failed job when saving success fails', async () => {
+    const release = {
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Building,
+      reason: ReleaseErrorCode.None,
+      buildId: '12345',
+    };
+    fetchOneMock.mockResolvedValue(release);
+    markReleasePublishedMock.mockRejectedValue(new Error('redis write failed'));
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await expect(
+      runQueueCli([
+        'node',
+        'index.js',
+        'queue-cli',
+        'release-reconcile-published',
+        'com.foo.bar',
+        '1.2.3',
+        '--json',
+      ]),
+    ).rejects.toThrow('redis write failed');
+
+    expect(markReleasePublishedMock).toHaveBeenCalledWith(release);
+    expect(queueRemoveMock).not.toHaveBeenCalled();
+  });
+
   it('release-show includes release metadata fields in json output', async () => {
     fetchOneMock.mockResolvedValue({
       packageName: 'com.foo.bar',
@@ -179,6 +494,10 @@ describe('queue-cli destructive actions', () => {
       updatedAt: 200,
       source: 'githubRelease',
       signed: true,
+      publishedVersion: '1.2.3-signed',
+      githubReleaseAssetMissingFirstSeenAt: 150,
+      githubReleaseAssetMissingLastProbeAt: 190,
+      githubReleaseAssetMissingProbeCount: 2,
     });
 
     const { runQueueCli } = await import('../src/queueCli.js');
@@ -198,6 +517,50 @@ describe('queue-cli destructive actions', () => {
     );
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining('"signed": true'),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"publishedVersion": "1.2.3-signed"'),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"githubReleaseAssetMissingProbeCount": 2'),
+    );
+  });
+
+  it('release-show includes release metadata fields in text output', async () => {
+    fetchOneMock.mockResolvedValue({
+      packageName: 'com.foo.bar',
+      version: '1.2.3',
+      state: ReleaseState.Succeeded,
+      reason: ReleaseErrorCode.None,
+      buildId: '',
+      tag: '1.2.3',
+      commit: 'abc123',
+      createdAt: 100,
+      updatedAt: 200,
+      source: 'githubRelease',
+      signed: false,
+      publishedVersion: '1.2.3',
+      githubReleaseAssetMissingFirstSeenAt: 150,
+      githubReleaseAssetMissingLastProbeAt: 190,
+      githubReleaseAssetMissingProbeCount: 2,
+    });
+
+    const { runQueueCli } = await import('../src/queueCli.js');
+
+    await runQueueCli([
+      'node',
+      'index.js',
+      'queue-cli',
+      'release-show',
+      'com.foo.bar',
+      '1.2.3',
+    ]);
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('publishedVersion: 1.2.3'),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('githubReleaseAssetMissingProbeCount: 2'),
     );
   });
 

--- a/apps/queue/__tests__/utils/azure.spec.ts
+++ b/apps/queue/__tests__/utils/azure.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AzureBuildNotFoundError, waitBuild } from '../../src/utils/azure.js';
+
+describe('waitBuild', () => {
+  it('classifies a null Azure response as a missing build', async () => {
+    const buildApi = {
+      getBuild: vi.fn().mockResolvedValue(null),
+    };
+
+    await expect(waitBuild(buildApi, 'missing-build')).rejects.toEqual(
+      new AzureBuildNotFoundError('missing-build'),
+    );
+  });
+
+  it('classifies an Azure 404 error as a missing build', async () => {
+    const buildApi = {
+      getBuild: vi.fn().mockRejectedValue({ statusCode: 404 }),
+    };
+
+    await expect(waitBuild(buildApi, 'deleted-build')).rejects.toEqual(
+      new AzureBuildNotFoundError('deleted-build'),
+    );
+  });
+
+  it('preserves non-404 Azure errors', async () => {
+    const error = Object.assign(new Error('unavailable'), { statusCode: 503 });
+    const buildApi = {
+      getBuild: vi.fn().mockRejectedValue(error),
+    };
+
+    await expect(waitBuild(buildApi, '123')).rejects.toBe(error);
+  });
+});

--- a/apps/queue/__tests__/utils/githubReleaseAsset.spec.ts
+++ b/apps/queue/__tests__/utils/githubReleaseAsset.spec.ts
@@ -14,7 +14,9 @@ describe('githubReleaseAsset utils', () => {
   });
 
   it('parses GitHub repo URLs', () => {
-    expect(parseGitHubRepoUrl('https://github.com/openupm/openupm.git')).toEqual({
+    expect(
+      parseGitHubRepoUrl('https://github.com/openupm/openupm.git'),
+    ).toEqual({
       owner: 'openupm',
       repo: 'openupm',
     });
@@ -22,11 +24,17 @@ describe('githubReleaseAsset utils', () => {
       owner: 'openupm',
       repo: 'openupm',
     });
-    expect(parseGitHubRepoUrl('https://example.com/openupm/openupm')).toBeNull();
-    expect(parseGitHubRepoUrl('https://notgithub.com/openupm/openupm')).toBeNull();
+    expect(
+      parseGitHubRepoUrl('https://example.com/openupm/openupm'),
+    ).toBeNull();
+    expect(
+      parseGitHubRepoUrl('https://notgithub.com/openupm/openupm'),
+    ).toBeNull();
     expect(parseGitHubRepoUrl('https://github.com/')).toBeNull();
     expect(parseGitHubRepoUrl('git@github.com:')).toBeNull();
-    expect(parseGitHubRepoUrl('git@github.com:openupm/openupm/path')).toBeNull();
+    expect(
+      parseGitHubRepoUrl('git@github.com:openupm/openupm/path'),
+    ).toBeNull();
   });
 
   it('selects configured publishable asset by exact name', () => {
@@ -114,8 +122,10 @@ describe('githubReleaseAsset utils', () => {
         new Response(
           JSON.stringify({
             tag_name: 'v1.0.0',
-            zipball_url: 'https://api.github.com/repos/openupm/openupm/zipball/v1.0.0',
-            tarball_url: 'https://api.github.com/repos/openupm/openupm/tarball/v1.0.0',
+            zipball_url:
+              'https://api.github.com/repos/openupm/openupm/zipball/v1.0.0',
+            tarball_url:
+              'https://api.github.com/repos/openupm/openupm/tarball/v1.0.0',
             assets: [
               {
                 name: 'package.tgz',
@@ -180,6 +190,7 @@ describe('githubReleaseAsset utils', () => {
       'https://api.github.com/repos/openupm/openupm/releases/tags/v1.0.0',
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: 'Bearer token-a' }),
+        signal: expect.any(AbortSignal),
       }),
     );
   });

--- a/apps/queue/__tests__/utils/reconcilePublishedRelease.spec.ts
+++ b/apps/queue/__tests__/utils/reconcilePublishedRelease.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ReleaseErrorCode, ReleaseState } from '@openupm/types';
+import {
+  markReleasePublished,
+  reconcilePublishedRelease,
+} from '../../src/utils/reconcilePublishedRelease.js';
+
+const release = {
+  packageName: 'com.foo.bar',
+  version: '1.2.3',
+  state: ReleaseState.Building,
+  reason: ReleaseErrorCode.None,
+  buildId: 'expired-build',
+  tag: 'upm/1.2.3',
+  commit: 'abc123',
+  createdAt: 100,
+  updatedAt: 200,
+  source: 'git' as const,
+  signed: false,
+};
+
+describe('reconcilePublishedRelease', () => {
+  it('marks a registry-confirmed release as succeeded', async () => {
+    const isReleasePublished = vi.fn().mockResolvedValue(true);
+    const save = vi.fn(async (value) => value);
+
+    const result = await reconcilePublishedRelease(release, {
+      isReleasePublished,
+      save: save as never,
+    });
+
+    expect(isReleasePublished).toHaveBeenCalledWith('com.foo.bar', '1.2.3');
+    expect(save).toHaveBeenCalledWith({
+      ...release,
+      state: ReleaseState.Succeeded,
+      reason: ReleaseErrorCode.None,
+      buildId: '',
+      signed: false,
+      publishedVersion: '1.2.3',
+      githubReleaseAssetMissingFirstSeenAt: undefined,
+      githubReleaseAssetMissingLastProbeAt: undefined,
+      githubReleaseAssetMissingProbeCount: undefined,
+    });
+    expect(result).toMatchObject({
+      state: ReleaseState.Succeeded,
+      publishedVersion: '1.2.3',
+    });
+  });
+
+  it('does not save when the version is absent from the registry', async () => {
+    const save = vi.fn();
+
+    await expect(
+      reconcilePublishedRelease(release, {
+        isReleasePublished: vi.fn().mockResolvedValue(false),
+        save: save as never,
+      }),
+    ).resolves.toBeNull();
+
+    expect(save).not.toHaveBeenCalled();
+  });
+});
+
+describe('markReleasePublished', () => {
+  it('discards unverified signing metadata while clearing the stale build', async () => {
+    const save = vi.fn(async (value) => value);
+
+    await markReleasePublished(
+      {
+        ...release,
+        signed: true,
+        publishedVersion: '1.2.3-signed',
+      },
+      save as never,
+    );
+
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: ReleaseState.Succeeded,
+        reason: ReleaseErrorCode.None,
+        buildId: '',
+        signed: false,
+        publishedVersion: '1.2.3',
+      }),
+    );
+  });
+});

--- a/apps/queue/__tests__/utils/registry.spec.ts
+++ b/apps/queue/__tests__/utils/registry.spec.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  accept: vi.fn(),
+  get: vi.fn(),
+  timeout: vi.fn(),
+}));
+
+vi.mock('superagent', () => ({
+  default: {
+    get: mocks.get,
+  },
+}));
+
+describe('isReleasePublished', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.get.mockReturnValue({ accept: mocks.accept });
+    mocks.accept.mockReturnValue({ timeout: mocks.timeout });
+  });
+
+  it('finds the exact version in the registry packument', async () => {
+    mocks.timeout.mockResolvedValue({
+      body: {
+        name: 'com.foo.bar',
+        versions: {
+          '1.2.3': {
+            name: 'com.foo.bar',
+            version: '1.2.3',
+          },
+          '1.2.4': {
+            name: 'com.foo.bar',
+            version: '1.2.4',
+          },
+        },
+      },
+    });
+    const { isReleasePublished } = await import('../../src/utils/registry.js');
+
+    await expect(isReleasePublished('com.foo.bar', '1.2.3')).resolves.toBe(
+      true,
+    );
+    await expect(isReleasePublished('com.foo.bar', '2.0.0')).resolves.toBe(
+      false,
+    );
+
+    expect(mocks.get).toHaveBeenCalledWith(
+      'https://package.openupm.com/com.foo.bar',
+    );
+    expect(mocks.timeout).toHaveBeenCalledWith(10000);
+  });
+
+  it('treats a missing packument as unpublished', async () => {
+    mocks.timeout.mockRejectedValue({ status: 404 });
+    const { isReleasePublished } = await import('../../src/utils/registry.js');
+
+    await expect(
+      isReleasePublished('com.missing.package', '1.0.0'),
+    ).resolves.toBe(false);
+  });
+
+  it('preserves transient registry errors', async () => {
+    const error = Object.assign(new Error('unavailable'), { status: 503 });
+    mocks.timeout.mockRejectedValue(error);
+    const { isReleasePublished } = await import('../../src/utils/registry.js');
+
+    await expect(isReleasePublished('com.foo.bar', '1.2.3')).rejects.toBe(
+      error,
+    );
+  });
+
+  it('rejects a malformed successful registry response', async () => {
+    mocks.timeout.mockResolvedValue({
+      body: {
+        name: 'com.foo.bar',
+      },
+    });
+    const { isReleasePublished } = await import('../../src/utils/registry.js');
+
+    await expect(isReleasePublished('com.foo.bar', '1.2.3')).rejects.toThrow(
+      'Registry returned an invalid packument for com.foo.bar',
+    );
+  });
+
+  it('rejects a packument for the wrong package', async () => {
+    mocks.timeout.mockResolvedValue({
+      body: {
+        name: 'com.other.package',
+        versions: {
+          '1.2.3': {
+            name: 'com.other.package',
+            version: '1.2.3',
+          },
+        },
+      },
+    });
+    const { isReleasePublished } = await import('../../src/utils/registry.js');
+
+    await expect(isReleasePublished('com.foo.bar', '1.2.3')).rejects.toThrow(
+      'Registry returned an invalid packument for com.foo.bar',
+    );
+  });
+
+  it('rejects a malformed exact-version manifest', async () => {
+    mocks.timeout.mockResolvedValue({
+      body: {
+        name: 'com.foo.bar',
+        versions: {
+          '1.2.3': null,
+        },
+      },
+    });
+    const { isReleasePublished } = await import('../../src/utils/registry.js');
+
+    await expect(isReleasePublished('com.foo.bar', '1.2.3')).rejects.toThrow(
+      'Registry returned an invalid manifest for com.foo.bar@1.2.3',
+    );
+  });
+
+  it('rejects a mismatched exact-version manifest', async () => {
+    mocks.timeout.mockResolvedValue({
+      body: {
+        name: 'com.foo.bar',
+        versions: {
+          '1.2.3': {
+            name: 'com.foo.bar',
+            version: '9.9.9',
+          },
+        },
+      },
+    });
+    const { isReleasePublished } = await import('../../src/utils/registry.js');
+
+    await expect(isReleasePublished('com.foo.bar', '1.2.3')).rejects.toThrow(
+      'Registry returned an invalid manifest for com.foo.bar@1.2.3',
+    );
+  });
+});

--- a/apps/queue/__tests__/utils/releaseMutationLock.spec.ts
+++ b/apps/queue/__tests__/utils/releaseMutationLock.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  eval: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock('@openupm/server-common/build/redis.js', () => ({
+  default: {
+    client: {
+      eval: mocks.eval,
+      set: mocks.set,
+    },
+  },
+}));
+
+import {
+  ReleaseMutationLockedError,
+  withReleaseMutationLock,
+} from '../../src/utils/releaseMutationLock.js';
+
+describe('withReleaseMutationLock', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.set.mockResolvedValue('OK');
+    mocks.eval.mockResolvedValue(1);
+  });
+
+  it('holds the release lock while running the mutation', async () => {
+    const action = vi.fn().mockResolvedValue('done');
+
+    await expect(
+      withReleaseMutationLock('com.foo.bar', '1.2.3', action),
+    ).resolves.toBe('done');
+
+    expect(mocks.set).toHaveBeenCalledWith(
+      'lock:release-mutation:com.foo.bar:1.2.3',
+      expect.any(String),
+      'PX',
+      300000,
+      'NX',
+    );
+    expect(action).toHaveBeenCalledOnce();
+    expect(mocks.eval).toHaveBeenCalledOnce();
+  });
+
+  it('refuses a concurrent mutation', async () => {
+    mocks.set.mockResolvedValue(null);
+    const action = vi.fn();
+
+    await expect(
+      withReleaseMutationLock('com.foo.bar', '1.2.3', action),
+    ).rejects.toEqual(new ReleaseMutationLockedError('com.foo.bar', '1.2.3'));
+
+    expect(action).not.toHaveBeenCalled();
+    expect(mocks.eval).not.toHaveBeenCalled();
+  });
+
+  it('releases the lock when the mutation fails', async () => {
+    const error = new Error('mutation failed');
+
+    await expect(
+      withReleaseMutationLock('com.foo.bar', '1.2.3', async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+
+    expect(mocks.eval).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
+++ b/apps/queue/__tests__/workers/buildPackageGithubReleaseAssetProbe.spec.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ReleaseErrorCode, ReleaseState, type ReleaseModel } from '@openupm/types';
+import {
+  ReleaseErrorCode,
+  ReleaseState,
+  type ReleaseModel,
+} from '@openupm/types';
 
 const loadPackageMetadataLocalMock = vi.fn();
 const packageMetadataLocalExistsMock = vi.fn();
@@ -15,6 +19,7 @@ const queueRemoveMock = vi.fn();
 const resolveGitHubReleaseAssetMock = vi.fn();
 const setInvalidTagsMock = vi.fn();
 const setRepoUnavailableMock = vi.fn();
+const withReleaseMutationLockMock = vi.fn();
 
 vi.mock('@openupm/local-data', () => ({
   loadPackageMetadataLocal: loadPackageMetadataLocalMock,
@@ -52,9 +57,12 @@ vi.mock('../../src/utils/githubReleaseAsset.js', async () => {
   };
 });
 
-function createRelease(
-  overrides: Partial<ReleaseModel> = {},
-): ReleaseModel {
+vi.mock('../../src/utils/releaseMutationLock.js', () => ({
+  ReleaseMutationLockedError: class ReleaseMutationLockedError extends Error {},
+  withReleaseMutationLock: withReleaseMutationLockMock,
+}));
+
+function createRelease(overrides: Partial<ReleaseModel> = {}): ReleaseModel {
   return {
     packageName: 'com.example.asset',
     version: '1.0.0',
@@ -84,6 +92,9 @@ async function runBuildPackage(release: ReleaseModel): Promise<void> {
 describe('buildPackage GitHub Release pending probes', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    withReleaseMutationLockMock.mockImplementation(
+      async (_packageName, _version, action) => await action(),
+    );
     vi.spyOn(Date, 'now').mockReturnValue(
       Date.parse('2026-05-10T07:00:00.000Z'),
     );
@@ -126,8 +137,12 @@ describe('buildPackage GitHub Release pending probes', () => {
     expect(getGitHubReleasePendingProbeIntervalMs(0)).toEqual(10 * 60 * 1000);
     expect(getGitHubReleasePendingProbeIntervalMs(1)).toEqual(20 * 60 * 1000);
     expect(getGitHubReleasePendingProbeIntervalMs(2)).toEqual(40 * 60 * 1000);
-    expect(getGitHubReleasePendingProbeIntervalMs(6)).toEqual(6 * 60 * 60 * 1000);
-    expect(getGitHubReleasePendingProbeIntervalMs(20)).toEqual(6 * 60 * 60 * 1000);
+    expect(getGitHubReleasePendingProbeIntervalMs(6)).toEqual(
+      6 * 60 * 60 * 1000,
+    );
+    expect(getGitHubReleasePendingProbeIntervalMs(20)).toEqual(
+      6 * 60 * 60 * 1000,
+    );
   });
 
   it('skips the first probe before the ten minute interval elapses', async () => {
@@ -212,7 +227,9 @@ describe('buildPackage GitHub Release pending probes', () => {
       { tag: 'upm/1.0.1', commit: 'def456' },
     ]);
     fetchAllMock.mockResolvedValue([deletedRelease]);
-    fetchOneMock.mockResolvedValue(null);
+    fetchOneMock.mockImplementation(async (_packageName, version) =>
+      version === '1.0.0' ? deletedRelease : null,
+    );
     saveReleaseMock.mockImplementation(async (value) => ({
       packageName: 'com.example.asset',
       version: '1.0.1',
@@ -250,6 +267,7 @@ describe('buildPackage GitHub Release pending probes', () => {
     });
     gitListRemoteTagsMock.mockResolvedValue([]);
     fetchAllMock.mockResolvedValue([deletedRelease]);
+    fetchOneMock.mockResolvedValue(deletedRelease);
 
     const { buildPackage } = await import('../../src/workers/buildPackage.js');
     await buildPackage('com.example.asset');
@@ -262,7 +280,29 @@ describe('buildPackage GitHub Release pending probes', () => {
       'com.example.asset',
       '1.0.0',
     );
-    expect(fetchOneMock).not.toHaveBeenCalled();
+    expect(fetchOneMock).toHaveBeenCalledWith('com.example.asset', '1.0.0');
+    expect(addJobMock).not.toHaveBeenCalled();
+  });
+
+  it('refetches under the lock and skips a stale job mutation after reconciliation', async () => {
+    const stale = createRelease({
+      state: ReleaseState.Building,
+      reason: ReleaseErrorCode.None,
+    });
+    fetchOneMock.mockResolvedValue({
+      ...stale,
+      state: ReleaseState.Succeeded,
+      buildId: '',
+      publishedVersion: stale.version,
+    });
+
+    const { addReleaseJobs } = await import(
+      '../../src/workers/buildPackage.js'
+    );
+    await addReleaseJobs([stale]);
+
+    expect(fetchOneMock).toHaveBeenCalledWith('com.example.asset', '1.0.0');
+    expect(queueRemoveMock).not.toHaveBeenCalled();
     expect(addJobMock).not.toHaveBeenCalled();
   });
 
@@ -486,5 +526,26 @@ describe('buildPackage GitHub Release pending probes', () => {
         }),
       }),
     );
+  });
+
+  it('skips release job mutation while an operator repair holds the lock', async () => {
+    const { ReleaseMutationLockedError } = await import(
+      '../../src/utils/releaseMutationLock.js'
+    );
+    withReleaseMutationLockMock.mockRejectedValueOnce(
+      new ReleaseMutationLockedError(),
+    );
+
+    await expect(
+      runBuildPackage(
+        createRelease({
+          state: ReleaseState.Building,
+          reason: ReleaseErrorCode.None,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(addJobMock).not.toHaveBeenCalled();
+    expect(queueRemoveMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/queue/__tests__/workers/buildRelease.spec.ts
+++ b/apps/queue/__tests__/workers/buildRelease.spec.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { ReleaseErrorCode, RetryableReleaseErrorCodes } from "@openupm/types";
+import {
+  ReleaseErrorCode,
+  ReleaseState,
+  RetryableReleaseErrorCodes,
+} from "@openupm/types";
 import {
   getPackageResultFromBuildLogText,
   getQueueBuildParameters,
   getReasonFromBuildLogText,
   getReleaseSource,
+  recoverMissingAzureBuild,
 } from "../../src/workers/buildRelease.js";
+import { ReleaseMutationLockedError } from "../../src/utils/releaseMutationLock.js";
 
 describe("buildRelease.getReasonFromBuildLogText", () => {
   it("None", () => {
@@ -164,6 +170,111 @@ describe("buildRelease.getReleaseSource", () => {
     expect(
       getReleaseSource({ trackingMode: "git" }, { source: "githubRelease" }),
     ).toEqual("githubRelease");
+  });
+});
+
+describe("buildRelease.recoverMissingAzureBuild", () => {
+  const release = {
+    packageName: "com.foo.bar",
+    version: "1.2.3",
+    state: ReleaseState.Building,
+    reason: ReleaseErrorCode.None,
+    buildId: "expired-build",
+    tag: "upm/1.2.3",
+    commit: "abc123",
+    createdAt: 100,
+    updatedAt: 200,
+    source: "git" as const,
+    signed: false,
+  };
+
+  it("accepts a release already reconciled from the registry", async () => {
+    const save = vi.fn();
+
+    await expect(
+      recoverMissingAzureBuild(release, "expired-build", {
+        fetchOne: vi.fn().mockResolvedValue(release) as never,
+        reconcilePublishedRelease: vi.fn().mockResolvedValue({
+          ...release,
+          state: ReleaseState.Succeeded,
+          buildId: "",
+        }),
+        save: save as never,
+        withReleaseMutationLock: vi.fn(
+          async (_packageName, _version, action) => await action(),
+        ) as never,
+      }),
+    ).resolves.toBe("reconciled");
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("resets an unpublished release for a fresh build retry", async () => {
+    const save = vi.fn(async (value) => value);
+
+    await expect(
+      recoverMissingAzureBuild(release, "expired-build", {
+        fetchOne: vi.fn().mockResolvedValue(release) as never,
+        reconcilePublishedRelease: vi.fn().mockResolvedValue(null),
+        save: save as never,
+        withReleaseMutationLock: vi.fn(
+          async (_packageName, _version, action) => await action(),
+        ) as never,
+      }),
+    ).resolves.toBe("reset");
+
+    expect(save).toHaveBeenCalledWith({
+      ...release,
+      state: ReleaseState.Pending,
+      reason: ReleaseErrorCode.None,
+      buildId: "",
+      signed: false,
+      publishedVersion: undefined,
+    });
+  });
+
+  it("does not overwrite a release changed while the Azure build was polled", async () => {
+    const save = vi.fn();
+    const reconcile = vi.fn();
+
+    await expect(
+      recoverMissingAzureBuild(release, "expired-build", {
+        fetchOne: vi.fn().mockResolvedValue({
+          ...release,
+          state: ReleaseState.Succeeded,
+          buildId: "",
+        }) as never,
+        reconcilePublishedRelease: reconcile,
+        save: save as never,
+        withReleaseMutationLock: vi.fn(
+          async (_packageName, _version, action) => await action(),
+        ) as never,
+      }),
+    ).resolves.toBe("stale");
+
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("retries instead of completing while another mutation holds the lock", async () => {
+    const save = vi.fn();
+    const reconcile = vi.fn();
+    const lockError = new ReleaseMutationLockedError(
+      release.packageName,
+      release.version,
+    );
+
+    await expect(
+      recoverMissingAzureBuild(release, "expired-build", {
+        fetchOne: vi.fn() as never,
+        reconcilePublishedRelease: reconcile,
+        save: save as never,
+        withReleaseMutationLock: vi.fn().mockRejectedValue(lockError) as never,
+      }),
+    ).rejects.toBe(lockError);
+
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/queue/config/default.json5
+++ b/apps/queue/config/default.json5
@@ -62,10 +62,17 @@
     },
   },
 
+  // OpenUPM package registry.
+  registry: {
+    url: 'https://package.openupm.com',
+    requestTimeoutMs: 10000,
+  },
+
   // GitHub.
   github: {
     // Round-robin tokens for GitHub access.
     tokens: [],
+    requestTimeoutMs: 10000,
   },
 
   // Azure devops.

--- a/apps/queue/src/queueCli.ts
+++ b/apps/queue/src/queueCli.ts
@@ -14,6 +14,9 @@ import {
 import { addJob, closeQueues, getQueue, hasQueue } from './queues/core.js';
 import { createJobId } from './queues/jobId.js';
 import { cleanupMissingPackageJobs } from './jobs/cleanupMissingPackage.js';
+import { isReleasePublished } from './utils/registry.js';
+import { markReleasePublished } from './utils/reconcilePublishedRelease.js';
+import { withReleaseMutationLock } from './utils/releaseMutationLock.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
@@ -67,6 +70,10 @@ interface ReleaseSummary {
   updatedAt: number;
   source?: 'git' | 'githubRelease';
   signed?: boolean;
+  publishedVersion?: string;
+  githubReleaseAssetMissingFirstSeenAt?: number;
+  githubReleaseAssetMissingLastProbeAt?: number;
+  githubReleaseAssetMissingProbeCount?: number;
 }
 
 const knownJobTypes: JobType[] = [
@@ -156,6 +163,11 @@ function getUsage(): string {
     '  release-requeue <package> <version> [--json]',
     '    Reset one release to Pending/None with an empty buildId, remove its',
     '    deterministic rel queue job, then enqueue a fresh rel build job.',
+    '',
+    '  release-reconcile-published <package> <version> [--json]',
+    '    Verify that a release exists in the OpenUPM registry, mark its Redis',
+    '    record Succeeded/None, and remove its deterministic rel queue job.',
+    '    This is destructive.',
     '',
     '  package-requeue <package> [--json]',
     '    Remove the deterministic pkg queue job and enqueue a fresh package scan.',
@@ -292,6 +304,26 @@ function getCommandUsage(topic: string | undefined): string {
         'Examples:',
         '  queue-cli release-requeue com.foo.bar 1.2.3 --json',
       ].join('\n');
+    case 'release-reconcile-published':
+      return [
+        'Usage: queue-cli release-reconcile-published <package> <version> [--json]',
+        '',
+        'Verify that the exact version exists in the OpenUPM registry, mark its',
+        'release record state=Succeeded and reason=None, clear a stale buildId,',
+        'and remove its deterministic rel queue job.',
+        '',
+        'This is destructive. It repairs stale state only after registry',
+        'verification. Initially the release must be Building; a cleanup retry',
+        'also accepts the exact already-reconciled Succeeded state. The job must',
+        'be failed unless cleanup already completed, and the exact version must',
+        'be published.',
+        '',
+        'A release-scoped lock prevents package scans and other model-level CLI',
+        'operations from replacing the job while verification is in progress.',
+        '',
+        'Examples:',
+        '  queue-cli release-reconcile-published com.foo.bar 1.2.3 --json',
+      ].join('\n');
     case 'package-requeue':
       return [
         'Usage: queue-cli package-requeue <package> [--json]',
@@ -360,6 +392,10 @@ function summarizeRelease(rel: {
   updatedAt: number;
   source?: 'git' | 'githubRelease';
   signed?: boolean;
+  publishedVersion?: string;
+  githubReleaseAssetMissingFirstSeenAt?: number;
+  githubReleaseAssetMissingLastProbeAt?: number;
+  githubReleaseAssetMissingProbeCount?: number;
 }): ReleaseSummary {
   return {
     packageName: rel.packageName,
@@ -374,6 +410,13 @@ function summarizeRelease(rel: {
     updatedAt: rel.updatedAt,
     source: rel.source,
     signed: rel.signed,
+    publishedVersion: rel.publishedVersion,
+    githubReleaseAssetMissingFirstSeenAt:
+      rel.githubReleaseAssetMissingFirstSeenAt,
+    githubReleaseAssetMissingLastProbeAt:
+      rel.githubReleaseAssetMissingLastProbeAt,
+    githubReleaseAssetMissingProbeCount:
+      rel.githubReleaseAssetMissingProbeCount,
   };
 }
 
@@ -390,7 +433,8 @@ function formatValue(value: unknown): string {
   if (typeof value !== 'object' || value === null) return `${value}`;
 
   if (Array.isArray(value)) return value.map(formatValue).join('\n\n');
-  if (isQueueStatusList(value)) return value.map(formatQueueStatus).join('\n\n');
+  if (isQueueStatusList(value))
+    return value.map(formatQueueStatus).join('\n\n');
   if (isQueueStatus(value)) return formatQueueStatus(value);
   if (isQueueJobsResult(value)) return formatQueueJobsResult(value);
   if (isQueueJobSummary(value)) return formatQueueJob(value);
@@ -413,12 +457,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function isQueueStatusList(value: unknown): value is Array<Record<string, unknown>> {
+function isQueueStatusList(
+  value: unknown,
+): value is Array<Record<string, unknown>> {
   return Array.isArray(value) && value.every(isQueueStatus);
 }
 
 function isQueueStatus(value: unknown): value is Record<string, unknown> {
-  return isRecord(value) && typeof value.queue === 'string' && isRecord(value.counts);
+  return (
+    isRecord(value) && typeof value.queue === 'string' && isRecord(value.counts)
+  );
 }
 
 function isQueueJobsResult(value: unknown): value is QueueJobsResult {
@@ -505,9 +553,12 @@ function formatQueueJob(job: QueueJobSummary, indent = ''): string {
     `${indent}  timestamp: ${formatTimestamp(job.timestamp)}`,
     `${indent}  data: ${JSON.stringify(job.data)}`,
   ];
-  if (job.processedOn) lines.push(`${indent}  processedOn: ${formatTimestamp(job.processedOn)}`);
-  if (job.finishedOn) lines.push(`${indent}  finishedOn: ${formatTimestamp(job.finishedOn)}`);
-  if (job.failedReason) lines.push(`${indent}  failedReason: ${job.failedReason}`);
+  if (job.processedOn)
+    lines.push(`${indent}  processedOn: ${formatTimestamp(job.processedOn)}`);
+  if (job.finishedOn)
+    lines.push(`${indent}  finishedOn: ${formatTimestamp(job.finishedOn)}`);
+  if (job.failedReason)
+    lines.push(`${indent}  failedReason: ${job.failedReason}`);
   return lines.join('\n');
 }
 
@@ -521,6 +572,20 @@ function formatRelease(release: ReleaseSummary): string {
     `  commit: ${release.commit}`,
     `  source: ${release.source || 'git'}`,
     `  signed: ${release.signed === true ? 'true' : 'false'}`,
+    `  publishedVersion: ${release.publishedVersion || ''}`,
+    `  githubReleaseAssetMissingFirstSeenAt: ${
+      release.githubReleaseAssetMissingFirstSeenAt
+        ? formatTimestamp(release.githubReleaseAssetMissingFirstSeenAt)
+        : ''
+    }`,
+    `  githubReleaseAssetMissingLastProbeAt: ${
+      release.githubReleaseAssetMissingLastProbeAt
+        ? formatTimestamp(release.githubReleaseAssetMissingLastProbeAt)
+        : ''
+    }`,
+    `  githubReleaseAssetMissingProbeCount: ${
+      release.githubReleaseAssetMissingProbeCount ?? ''
+    }`,
     `  updatedAt: ${formatTimestamp(release.updatedAt)}`,
   ].join('\n');
 }
@@ -563,9 +628,9 @@ async function queueJobs(
 ): Promise<QueueJobsResult> {
   assertQueue(queueName);
   const queue = getQueue(queueName);
-  const jobTypes = (states.length
-    ? states
-    : ['failed', 'active', 'waiting']) as JobType[];
+  const jobTypes = (
+    states.length ? states : ['failed', 'active', 'waiting']
+  ) as JobType[];
   const counts = await queue.getJobCounts(...jobTypes);
   const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
   const effectiveLimit = limit ?? total;
@@ -623,7 +688,8 @@ function matchesReason(
   reasonFilter: string | undefined,
 ): boolean {
   if (!reasonFilter) return true;
-  if (reasonFilter === 'unknown') return rel.reasonCode === ReleaseErrorCode.None;
+  if (reasonFilter === 'unknown')
+    return rel.reasonCode === ReleaseErrorCode.None;
   if (reasonFilter === 'timeout') {
     return (
       rel.reasonCode === ReleaseErrorCode.BuildTimeout ||
@@ -668,50 +734,126 @@ async function releaseRemove(
   packageName: string,
   version: string,
 ): Promise<Record<string, unknown>> {
-  const jobId = getBuildReleaseJobId(packageName, version);
-  const queueName = config.jobs.buildRelease.queue;
-  const removedJob = await getQueue(queueName).remove(jobId, {
-    removeChildren: true,
+  return await withReleaseMutationLock(packageName, version, async () => {
+    const jobId = getBuildReleaseJobId(packageName, version);
+    const queueName = config.jobs.buildRelease.queue;
+    const removedJob = await getQueue(queueName).remove(jobId, {
+      removeChildren: true,
+    });
+    await removeReleaseRecord(packageName, version);
+    return {
+      packageName,
+      version,
+      releaseRemoved: true,
+      relatedJob: { queue: queueName, jobId, removed: removedJob === 1 },
+    };
   });
-  await removeReleaseRecord(packageName, version);
-  return {
-    packageName,
-    version,
-    releaseRemoved: true,
-    relatedJob: { queue: queueName, jobId, removed: removedJob === 1 },
-  };
 }
 
 async function releaseRequeue(
   packageName: string,
   version: string,
 ): Promise<Record<string, unknown>> {
-  const release = await fetchOne(packageName, version);
-  if (!release) throw new Error(`Release not found: ${packageName}@${version}`);
+  return await withReleaseMutationLock(packageName, version, async () => {
+    const release = await fetchOne(packageName, version);
+    if (!release)
+      throw new Error(`Release not found: ${packageName}@${version}`);
 
-  const jobConfig = config.jobs.buildRelease;
-  const queue = getQueue(jobConfig.queue);
-  const jobId = getBuildReleaseJobId(packageName, version);
-  await queue.remove(jobId, { removeChildren: true });
-  const saved = await saveRelease({
-    ...release,
-    state: ReleaseState.Pending,
-    reason: ReleaseErrorCode.None,
-    buildId: '',
-    githubReleaseAssetMissingFirstSeenAt: undefined,
-    githubReleaseAssetMissingLastProbeAt: undefined,
-    githubReleaseAssetMissingProbeCount: undefined,
+    const jobConfig = config.jobs.buildRelease;
+    const queue = getQueue(jobConfig.queue);
+    const jobId = getBuildReleaseJobId(packageName, version);
+    await queue.remove(jobId, { removeChildren: true });
+    const saved = await saveRelease({
+      ...release,
+      state: ReleaseState.Pending,
+      reason: ReleaseErrorCode.None,
+      buildId: '',
+      githubReleaseAssetMissingFirstSeenAt: undefined,
+      githubReleaseAssetMissingLastProbeAt: undefined,
+      githubReleaseAssetMissingProbeCount: undefined,
+    });
+    const job = await addJob({
+      queue,
+      name: jobConfig.name,
+      data: { name: packageName, version },
+      opts: { jobId },
+    });
+    return {
+      release: summarizeRelease(saved),
+      job: { queue: jobConfig.queue, jobId, added: job !== null },
+    };
   });
-  const job = await addJob({
-    queue,
-    name: jobConfig.name,
-    data: { name: packageName, version },
-    opts: { jobId },
+}
+
+async function releaseReconcilePublished(
+  packageName: string,
+  version: string,
+): Promise<Record<string, unknown>> {
+  return await withReleaseMutationLock(packageName, version, async () => {
+    const release = await fetchOne(packageName, version);
+    if (!release)
+      throw new Error(`Release not found: ${packageName}@${version}`);
+    const alreadyReconciled =
+      release.state === ReleaseState.Succeeded &&
+      release.reason === ReleaseErrorCode.None &&
+      release.buildId === '' &&
+      release.signed === false &&
+      release.publishedVersion === version &&
+      release.githubReleaseAssetMissingFirstSeenAt === undefined &&
+      release.githubReleaseAssetMissingLastProbeAt === undefined &&
+      release.githubReleaseAssetMissingProbeCount === undefined;
+    if (release.state !== ReleaseState.Building && !alreadyReconciled) {
+      throw new Error(
+        `Release must be Building or already reconciled to retry cleanup: ${packageName}@${version}`,
+      );
+    }
+
+    const jobConfig = config.jobs.buildRelease;
+    const queue = getQueue(jobConfig.queue);
+    const jobId = getBuildReleaseJobId(packageName, version);
+    const job = await queue.getJob(jobId);
+    const jobState = job ? await job.getState() : null;
+    if (jobState !== 'failed' && !(alreadyReconciled && jobState === null)) {
+      throw new Error(
+        `Release job must be failed to reconcile: ${packageName}@${version}`,
+      );
+    }
+
+    if (!(await isReleasePublished(packageName, version))) {
+      throw new Error(
+        `Release is not published in the registry: ${packageName}@${version}`,
+      );
+    }
+
+    const reconciled = await markReleasePublished(release);
+    if (jobState === null) {
+      return {
+        release: summarizeRelease(reconciled),
+        relatedJob: {
+          queue: jobConfig.queue,
+          jobId,
+          previousState: null,
+          removed: false,
+          alreadyComplete: true,
+        },
+      };
+    }
+    const removedJob = await queue.remove(jobId, { removeChildren: true });
+    if (removedJob !== 1) {
+      throw new Error(
+        `Release job could not be removed safely: ${packageName}@${version}`,
+      );
+    }
+    return {
+      release: summarizeRelease(reconciled),
+      relatedJob: {
+        queue: jobConfig.queue,
+        jobId,
+        previousState: jobState,
+        removed: true,
+      },
+    };
   });
-  return {
-    release: summarizeRelease(saved),
-    job: { queue: jobConfig.queue, jobId, added: job !== null },
-  };
 }
 
 async function packageRequeue(
@@ -737,7 +879,9 @@ function requireArgs(args: string[], count: number): void {
   if (args.length < count) throw new Error(getUsage());
 }
 
-export async function runQueueCli(argv: string[] = process.argv): Promise<void> {
+export async function runQueueCli(
+  argv: string[] = process.argv,
+): Promise<void> {
   const args = parseQueueCliArgs(argv);
   if (args.command === 'help') {
     const helpArgs = args as QueueCliHelpArgs;
@@ -777,6 +921,10 @@ export async function runQueueCli(argv: string[] = process.argv): Promise<void> 
       case 'release-requeue':
         requireArgs(args.rest, 2);
         result = await releaseRequeue(args.rest[0], args.rest[1]);
+        break;
+      case 'release-reconcile-published':
+        requireArgs(args.rest, 2);
+        result = await releaseReconcilePublished(args.rest[0], args.rest[1]);
         break;
       case 'package-requeue':
         requireArgs(args.rest, 1);

--- a/apps/queue/src/utils/azure.ts
+++ b/apps/queue/src/utils/azure.ts
@@ -13,6 +13,21 @@ const logger = createLogger('@openupm/queue/azure');
 export const BuildStatus = buildInterfaces.BuildStatus;
 export const BuildResult = buildInterfaces.BuildResult;
 
+export class AzureBuildNotFoundError extends Error {
+  constructor(public readonly buildId: string) {
+    super(`Azure build not found: ${buildId}`);
+    this.name = 'AzureBuildNotFoundError';
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  return (
+    ('statusCode' in error && error.statusCode === 404) ||
+    ('status' in error && error.status === 404)
+  );
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function getBuildApi(): Promise<any> {
   const authHandler = azureDevops.getPersonalAccessTokenHandler(
@@ -45,7 +60,20 @@ export async function waitBuild(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any | null> {
   for (let i = 0; i < config.azureDevops.check.retries; i++) {
-    const build = await buildApi.getBuild(config.azureDevops.project, buildId);
+    let build:
+      | {
+          status?: number;
+          result?: number;
+        }
+      | null
+      | undefined;
+    try {
+      build = await buildApi.getBuild(config.azureDevops.project, buildId);
+    } catch (error) {
+      if (isNotFoundError(error)) throw new AzureBuildNotFoundError(buildId);
+      throw error;
+    }
+    if (!build) throw new AzureBuildNotFoundError(buildId);
     const status = build.status;
     const result = build.result;
     logger.debug({ buildId, status, result }, 'wait build');
@@ -65,7 +93,12 @@ function joinUrl(...parts: Array<string | number>): string {
 }
 
 export function getBuildLogsUrl(buildId: string): string {
-  return joinUrl(config.azureDevops.buildUrlBase, '_apis/build/builds', buildId, 'logs');
+  return joinUrl(
+    config.azureDevops.buildUrlBase,
+    '_apis/build/builds',
+    buildId,
+    'logs',
+  );
 }
 
 export function getBuildSectionLogUrl(buildId: string, stepId: number): string {

--- a/apps/queue/src/utils/githubReleaseAsset.ts
+++ b/apps/queue/src/utils/githubReleaseAsset.ts
@@ -116,9 +116,9 @@ export async function resolveGitHubReleaseAsset(options: {
     );
   }
 
-  const releaseUrl = `https://api.github.com/repos/${repo.owner}/${repo.repo}/releases/tags/${encodeURIComponent(
-    options.releaseTag,
-  )}`;
+  const releaseUrl = `https://api.github.com/repos/${repo.owner}/${
+    repo.repo
+  }/releases/tags/${encodeURIComponent(options.releaseTag)}`;
   const headers = withGitHubAuthorizationHeader(options.config, {
     Accept: 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28',
@@ -126,10 +126,17 @@ export async function resolveGitHubReleaseAsset(options: {
 
   let response: Response;
   try {
-    response = await fetch(releaseUrl, { headers });
+    const requestTimeoutMs =
+      Number(options.config.github?.requestTimeoutMs) || 10_000;
+    response = await fetch(releaseUrl, {
+      headers,
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    });
   } catch (error) {
     throw new GitHubReleaseAssetError(
-      `GitHub Release API request failed: ${error instanceof Error ? error.message : String(error)}`,
+      `GitHub Release API request failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
       ReleaseErrorCode.GitHubReleaseApiError,
     );
   }
@@ -140,7 +147,11 @@ export async function resolveGitHubReleaseAsset(options: {
       ReleaseErrorCode.GitHubReleaseNotFound,
     );
   }
-  if (response.status === 403 || response.status === 429 || response.status >= 500) {
+  if (
+    response.status === 403 ||
+    response.status === 429 ||
+    response.status >= 500
+  ) {
     throw new GitHubReleaseAssetError(
       `GitHub Release API failed with status ${response.status}`,
       ReleaseErrorCode.GitHubReleaseApiError,
@@ -158,13 +169,17 @@ export async function resolveGitHubReleaseAsset(options: {
     release = (await response.json()) as GitHubReleaseResponse;
   } catch (error) {
     throw new GitHubReleaseAssetError(
-      `GitHub Release API response was not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      `GitHub Release API response was not valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
       ReleaseErrorCode.GitHubReleaseApiError,
     );
   }
   if (release.tag_name !== options.releaseTag) {
     throw new GitHubReleaseAssetError(
-      `GitHub Release tag mismatch: actual=${release.tag_name || ''}, expected=${options.releaseTag}`,
+      `GitHub Release tag mismatch: actual=${
+        release.tag_name || ''
+      }, expected=${options.releaseTag}`,
       ReleaseErrorCode.GitHubReleaseNotFound,
     );
   }

--- a/apps/queue/src/utils/reconcilePublishedRelease.ts
+++ b/apps/queue/src/utils/reconcilePublishedRelease.ts
@@ -1,0 +1,51 @@
+import {
+  ReleaseErrorCode,
+  type ReleaseModel,
+  ReleaseState,
+} from '@openupm/types';
+import { save } from '@openupm/server-common/build/models/release.js';
+
+import { isReleasePublished } from './registry.js';
+
+interface ReconcilePublishedReleaseDependencies {
+  isReleasePublished: typeof isReleasePublished;
+  save: typeof save;
+}
+
+const defaultDependencies: ReconcilePublishedReleaseDependencies = {
+  isReleasePublished,
+  save,
+};
+
+export async function markReleasePublished(
+  release: ReleaseModel,
+  saveRelease: typeof save = save,
+): Promise<ReleaseModel> {
+  return await saveRelease({
+    ...release,
+    state: ReleaseState.Succeeded,
+    reason: ReleaseErrorCode.None,
+    buildId: '',
+    signed: false,
+    publishedVersion: release.version,
+    githubReleaseAssetMissingFirstSeenAt: undefined,
+    githubReleaseAssetMissingLastProbeAt: undefined,
+    githubReleaseAssetMissingProbeCount: undefined,
+  });
+}
+
+export async function reconcilePublishedRelease(
+  release: ReleaseModel,
+  dependencies: ReconcilePublishedReleaseDependencies = defaultDependencies,
+): Promise<ReleaseModel | null> {
+  if (
+    !(await dependencies.isReleasePublished(
+      release.packageName,
+      release.version,
+    ))
+  ) {
+    return null;
+  }
+
+  return await markReleasePublished(release, dependencies.save);
+}

--- a/apps/queue/src/utils/registry.ts
+++ b/apps/queue/src/utils/registry.ts
@@ -1,0 +1,68 @@
+import configRaw from 'config';
+import superagent from 'superagent';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config = configRaw as any;
+
+function getPackumentUrl(packageName: string): string {
+  const baseUrl = String(config.registry.url).replace(/\/+$/, '');
+  return `${baseUrl}/${encodeURIComponent(packageName)}`;
+}
+
+export async function isReleasePublished(
+  packageName: string,
+  version: string,
+): Promise<boolean> {
+  try {
+    const response = await superagent
+      .get(getPackumentUrl(packageName))
+      .accept('json')
+      .timeout(config.registry.requestTimeoutMs);
+    const body = response.body as unknown;
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      throw new Error(
+        `Registry returned an invalid packument for ${packageName}`,
+      );
+    }
+    const versions = (body as { versions?: unknown }).versions;
+    if (
+      typeof versions !== 'object' ||
+      versions === null ||
+      Array.isArray(versions)
+    ) {
+      throw new Error(
+        `Registry returned an invalid packument for ${packageName}`,
+      );
+    }
+    if ((body as { name?: unknown }).name !== packageName) {
+      throw new Error(
+        `Registry returned an invalid packument for ${packageName}`,
+      );
+    }
+    if (!Object.prototype.hasOwnProperty.call(versions, version)) return false;
+
+    const manifest = (versions as Record<string, unknown>)[version];
+    if (
+      typeof manifest !== 'object' ||
+      manifest === null ||
+      Array.isArray(manifest) ||
+      (manifest as { name?: unknown }).name !== packageName ||
+      (manifest as { version?: unknown }).version !== version
+    ) {
+      throw new Error(
+        `Registry returned an invalid manifest for ${packageName}@${version}`,
+      );
+    }
+    return true;
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'status' in error &&
+      error.status === 404
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/apps/queue/src/utils/releaseMutationLock.ts
+++ b/apps/queue/src/utils/releaseMutationLock.ts
@@ -1,0 +1,53 @@
+import { randomUUID } from 'node:crypto';
+
+import redis from '@openupm/server-common/build/redis.js';
+
+const releaseMutationLockTtlMs = 5 * 60_000;
+
+export class ReleaseMutationLockedError extends Error {
+  constructor(packageName: string, version: string) {
+    super(`Release mutation is already in progress: ${packageName}@${version}`);
+    this.name = 'ReleaseMutationLockedError';
+  }
+}
+
+function getReleaseMutationLockKey(
+  packageName: string,
+  version: string,
+): string {
+  return `lock:release-mutation:${packageName}:${version}`;
+}
+
+export async function withReleaseMutationLock<T>(
+  packageName: string,
+  version: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  const client = redis.client!;
+  const key = getReleaseMutationLockKey(packageName, version);
+  const token = randomUUID();
+  const acquired = await client.set(
+    key,
+    token,
+    'PX',
+    releaseMutationLockTtlMs,
+    'NX',
+  );
+  if (acquired !== 'OK') {
+    throw new ReleaseMutationLockedError(packageName, version);
+  }
+
+  try {
+    return await action();
+  } finally {
+    await client.eval(
+      `if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("del", KEYS[1])
+      end
+      return 0`,
+      1,
+      key,
+      token,
+    );
+  }
+}

--- a/apps/queue/src/workers/buildPackage.ts
+++ b/apps/queue/src/workers/buildPackage.ts
@@ -33,6 +33,10 @@ import {
   GitHubReleaseAssetError,
   resolveGitHubReleaseAsset,
 } from '../utils/githubReleaseAsset.js';
+import {
+  ReleaseMutationLockedError,
+  withReleaseMutationLock,
+} from '../utils/releaseMutationLock.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
@@ -41,9 +45,7 @@ const githubReleasePendingProbeInitialIntervalMs = 10 * 60 * 1000;
 const githubReleasePendingProbeMaxIntervalMs = 6 * 60 * 60 * 1000;
 const githubReleasePendingProbeWindowMs = 3 * 24 * 60 * 60 * 1000;
 
-function parseGitHubRepo(
-  url: string,
-): { owner: string; repo: string } | null {
+function parseGitHubRepo(url: string): { owner: string; repo: string } | null {
   if (url.startsWith('git@github.com:')) {
     const path = url.split(':')[1] || '';
     const [owner, rawRepo] = path.split('/').filter(Boolean);
@@ -226,16 +228,28 @@ async function updateReleaseRecords(
         (x) => x.tag === rel.tag && x.commit === rel.commit,
       );
       if (!found) {
-        logger.warn(
-          {
-            pkg: packageName,
-            rel: `${packageName}@${rel.version}`,
-            tag: rel.tag,
-            commit: rel.commit,
-          },
-          'remove failed release that not listed in remoteTags',
-        );
-        await removeStaleFailedRelease(packageName, rel);
+        await withPackageScanReleaseLock(packageName, rel.version, async () => {
+          const current = await fetchOne(packageName, rel.version);
+          if (
+            !current ||
+            current.state !== ReleaseState.Failed ||
+            remoteTags.some(
+              (x) => x.tag === current.tag && x.commit === current.commit,
+            )
+          ) {
+            return;
+          }
+          logger.warn(
+            {
+              pkg: packageName,
+              rel: `${packageName}@${current.version}`,
+              tag: current.tag,
+              commit: current.commit,
+            },
+            'remove failed release that not listed in remoteTags',
+          );
+          await removeStaleFailedRelease(packageName, current);
+        });
       }
     }
   }
@@ -244,19 +258,41 @@ async function updateReleaseRecords(
   for (const remoteTag of remoteTags) {
     const version = getVersionFromTag(remoteTag.tag);
     if (!version) continue;
-    let release = await fetchOne(packageName, version);
-    if (!release) {
-      release = await save({
-        packageName,
-        version,
-        commit: remoteTag.commit,
-        tag: remoteTag.tag,
-        source,
-      });
-    }
-    releases.push(release);
+    const release = await withPackageScanReleaseLock(
+      packageName,
+      version,
+      async () => {
+        const current = await fetchOne(packageName, version);
+        if (current) return current;
+        return await save({
+          packageName,
+          version,
+          commit: remoteTag.commit,
+          tag: remoteTag.tag,
+          source,
+        });
+      },
+    );
+    if (release) releases.push(release);
   }
   return releases;
+}
+
+async function withPackageScanReleaseLock<T>(
+  packageName: string,
+  version: string,
+  action: () => Promise<T>,
+): Promise<T | undefined> {
+  try {
+    return await withReleaseMutationLock(packageName, version, action);
+  } catch (error) {
+    if (!(error instanceof ReleaseMutationLockedError)) throw error;
+    logger.info(
+      { rel: `${packageName}@${version}` },
+      'skip release mutation while another repair is in progress',
+    );
+    return undefined;
+  }
 }
 
 async function removeStaleFailedRelease(
@@ -270,35 +306,48 @@ async function removeStaleFailedRelease(
   await remove(packageName, release.version);
 }
 
-async function addReleaseJobs(releases: ReleaseModel[]): Promise<void> {
+export async function addReleaseJobs(releases: ReleaseModel[]): Promise<void> {
   const jobConfig = config.jobs.buildRelease;
   const queue = getQueue(jobConfig.queue);
   let i = 0;
 
   for (const rel of releases) {
-    if (
-      rel.state === ReleaseState.Succeeded ||
-      (rel.state === ReleaseState.Failed &&
-        !RetryableReleaseErrorCodes.includes(rel.reason as ReleaseErrorCode))
-    ) {
-      continue;
-    }
+    await withPackageScanReleaseLock(rel.packageName, rel.version, async () => {
+      const current = await fetchOne(rel.packageName, rel.version);
+      if (
+        !current ||
+        current.state === ReleaseState.Succeeded ||
+        (current.state === ReleaseState.Failed &&
+          !RetryableReleaseErrorCodes.includes(
+            current.reason as ReleaseErrorCode,
+          ))
+      ) {
+        return;
+      }
 
-    const jobId = createJobId(jobConfig.name, rel.packageName, rel.version);
-    if (isExpiredGitHubReleasePendingFailure(rel)) {
-      await removeExhaustedFailedJob(queue, jobId);
-      continue;
-    }
-    if (rel.state === ReleaseState.Pending) {
-      await removeExhaustedFailedJob(queue, jobId);
-    }
-    await addJob({
-      queue,
-      name: jobConfig.name,
-      data: { name: rel.packageName, version: rel.version },
-      opts: { jobId, delay: jobConfig.interval * i },
+      const jobId = createJobId(
+        jobConfig.name,
+        current.packageName,
+        current.version,
+      );
+      if (isExpiredGitHubReleasePendingFailure(current)) {
+        await removeExhaustedFailedJob(queue, jobId);
+        return;
+      }
+      if (current.state === ReleaseState.Pending) {
+        await removeExhaustedFailedJob(queue, jobId);
+      }
+      await addJob({
+        queue,
+        name: jobConfig.name,
+        data: {
+          name: current.packageName,
+          version: current.version,
+        },
+        opts: { jobId, delay: jobConfig.interval * i },
+      });
+      i++;
     });
-    i++;
   }
 }
 
@@ -354,67 +403,82 @@ async function probePendingGitHubReleaseAssets(
 ): Promise<void> {
   if (!pkg || (pkg.trackingMode || 'git') !== 'githubRelease') return;
 
-  for (const release of releases) {
-    if (!(await shouldProbePendingGitHubReleaseAsset(release))) continue;
+  for (const snapshot of releases) {
+    await withPackageScanReleaseLock(
+      snapshot.packageName,
+      snapshot.version,
+      async () => {
+        const release = await fetchOne(snapshot.packageName, snapshot.version);
+        if (
+          !release ||
+          !(await shouldProbePendingGitHubReleaseAsset(release))
+        ) {
+          return;
+        }
 
-    const now = Date.now();
-    release.githubReleaseAssetMissingFirstSeenAt ??= release.updatedAt;
-    release.githubReleaseAssetMissingLastProbeAt = now;
-    release.githubReleaseAssetMissingProbeCount =
-      (release.githubReleaseAssetMissingProbeCount || 0) + 1;
+        const now = Date.now();
+        release.githubReleaseAssetMissingFirstSeenAt ??= release.updatedAt;
+        release.githubReleaseAssetMissingLastProbeAt = now;
+        release.githubReleaseAssetMissingProbeCount =
+          (release.githubReleaseAssetMissingProbeCount || 0) + 1;
 
-    try {
-      await resolveGitHubReleaseAsset({
-        config,
-        repoUrl: pkg.repoUrl,
-        releaseTag: release.tag,
-        githubReleaseAssetName: pkg.githubReleaseAssetName,
-      });
-    } catch (error) {
-      if (error instanceof GitHubReleaseAssetError) {
-        const saved =
-          error.reason === ReleaseErrorCode.GitHubReleaseNotFound ||
-          error.reason === ReleaseErrorCode.GitHubReleaseAssetNotFound ||
-          error.reason === ReleaseErrorCode.GitHubReleaseApiError
-            ? await save({
-                ...release,
-                reason:
-                  error.reason === ReleaseErrorCode.GitHubReleaseApiError
-                    ? release.reason
-                    : error.reason,
-              })
-            : await save({
-                ...release,
-                reason: error.reason,
-                githubReleaseAssetMissingFirstSeenAt: undefined,
-                githubReleaseAssetMissingLastProbeAt: undefined,
-                githubReleaseAssetMissingProbeCount: undefined,
-              });
-        Object.assign(release, saved);
-        continue;
-      }
-      throw error;
-    }
+        try {
+          await resolveGitHubReleaseAsset({
+            config,
+            repoUrl: pkg.repoUrl,
+            releaseTag: release.tag,
+            githubReleaseAssetName: pkg.githubReleaseAssetName,
+          });
+        } catch (error) {
+          if (error instanceof GitHubReleaseAssetError) {
+            await save(
+              error.reason === ReleaseErrorCode.GitHubReleaseNotFound ||
+                error.reason === ReleaseErrorCode.GitHubReleaseAssetNotFound ||
+                error.reason === ReleaseErrorCode.GitHubReleaseApiError
+                ? {
+                    ...release,
+                    reason:
+                      error.reason === ReleaseErrorCode.GitHubReleaseApiError
+                        ? release.reason
+                        : error.reason,
+                  }
+                : {
+                    ...release,
+                    reason: error.reason,
+                    githubReleaseAssetMissingFirstSeenAt: undefined,
+                    githubReleaseAssetMissingLastProbeAt: undefined,
+                    githubReleaseAssetMissingProbeCount: undefined,
+                  },
+            );
+            return;
+          }
+          throw error;
+        }
 
-    const jobConfig = config.jobs.buildRelease;
-    const queue = getQueue(jobConfig.queue);
-    const jobId = createJobId(jobConfig.name, release.packageName, release.version);
-    await queue.remove(jobId, { removeChildren: true });
-    const resetRelease = await save({
-      ...release,
-      state: ReleaseState.Pending,
-      reason: ReleaseErrorCode.None,
-      buildId: '',
-      signed: false,
-      publishedVersion: undefined,
-      githubReleaseAssetMissingFirstSeenAt: undefined,
-      githubReleaseAssetMissingLastProbeAt: undefined,
-      githubReleaseAssetMissingProbeCount: undefined,
-    });
-    Object.assign(release, resetRelease);
-    logger.info(
-      { rel: `${release.packageName}@${release.version}` },
-      'GitHub Release asset is available; release requeued',
+        const jobConfig = config.jobs.buildRelease;
+        const queue = getQueue(jobConfig.queue);
+        const jobId = createJobId(
+          jobConfig.name,
+          release.packageName,
+          release.version,
+        );
+        await queue.remove(jobId, { removeChildren: true });
+        await save({
+          ...release,
+          state: ReleaseState.Pending,
+          reason: ReleaseErrorCode.None,
+          buildId: '',
+          signed: false,
+          publishedVersion: undefined,
+          githubReleaseAssetMissingFirstSeenAt: undefined,
+          githubReleaseAssetMissingLastProbeAt: undefined,
+          githubReleaseAssetMissingProbeCount: undefined,
+        });
+        logger.info(
+          { rel: `${release.packageName}@${release.version}` },
+          'GitHub Release asset is available; release requeued',
+        );
+      },
     );
   }
 }

--- a/apps/queue/src/workers/buildRelease.ts
+++ b/apps/queue/src/workers/buildRelease.ts
@@ -11,6 +11,7 @@ import {
 } from "@openupm/types";
 import { loadPackageMetadataLocal } from "@openupm/local-data";
 import {
+  fetchOne,
   fetchOneOrThrow,
   save,
 } from "@openupm/server-common/build/models/release.js";
@@ -19,22 +20,77 @@ import { createLogger } from "@openupm/server-common/build/log.js";
 import {
   BuildResult,
   BuildStatus,
+  AzureBuildNotFoundError,
   getBuildApi,
   getBuildLogsUrl,
   getBuildSectionLogUrl,
   queueBuild,
   waitBuild,
 } from "../utils/azure.js";
+import { reconcilePublishedRelease } from "../utils/reconcilePublishedRelease.js";
 import {
   GitHubReleaseAssetError,
   resolveGitHubReleaseAsset,
 } from "../utils/githubReleaseAsset.js";
+import { withReleaseMutationLock } from "../utils/releaseMutationLock.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const config = configRaw as any;
 const sleep = util.promisify(setTimeout);
 const logger = createLogger("@openupm/queue/buildRelease");
 const packageResultMarker = "OPENUPM_PACKAGE_RESULT";
+
+interface RecoverMissingAzureBuildDependencies {
+  fetchOne: typeof fetchOne;
+  reconcilePublishedRelease: typeof reconcilePublishedRelease;
+  save: typeof save;
+  withReleaseMutationLock: typeof withReleaseMutationLock;
+}
+
+const recoverMissingAzureBuildDependencies: RecoverMissingAzureBuildDependencies =
+  {
+    fetchOne,
+    reconcilePublishedRelease,
+    save,
+    withReleaseMutationLock,
+  };
+
+export async function recoverMissingAzureBuild(
+  release: ReleaseModel,
+  missingBuildId: string,
+  dependencies: RecoverMissingAzureBuildDependencies = recoverMissingAzureBuildDependencies,
+): Promise<"reconciled" | "reset" | "stale"> {
+  return await dependencies.withReleaseMutationLock(
+    release.packageName,
+    release.version,
+    async () => {
+      const current = await dependencies.fetchOne(
+        release.packageName,
+        release.version,
+      );
+      if (
+        !current ||
+        current.state !== ReleaseState.Building ||
+        current.buildId !== missingBuildId
+      ) {
+        return "stale";
+      }
+
+      const reconciled = await dependencies.reconcilePublishedRelease(current);
+      if (reconciled) return "reconciled";
+
+      await dependencies.save({
+        ...current,
+        state: ReleaseState.Pending,
+        reason: ReleaseErrorCode.None,
+        buildId: "",
+        signed: false,
+        publishedVersion: undefined,
+      });
+      return "reset";
+    },
+  );
+}
 
 export async function buildRelease(
   packageName: string,
@@ -53,7 +109,36 @@ export async function buildRelease(
     const build = await waitReleaseBuild(buildApi, release);
     await handleReleaseBuild(build, release);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ETIMEDOUT") {
+    if (err instanceof AzureBuildNotFoundError) {
+      const recovery = await recoverMissingAzureBuild(release, err.buildId);
+      if (recovery === "reconciled") {
+        logger.warn(
+          {
+            rel: `${release.packageName}@${release.version}`,
+            missingBuild: err.buildId,
+          },
+          "missing Azure build reconciled from published registry version",
+        );
+        return;
+      }
+      if (recovery === "stale") {
+        logger.warn(
+          {
+            rel: `${release.packageName}@${release.version}`,
+            missingBuild: err.buildId,
+          },
+          "skip missing Azure build recovery because release state changed",
+        );
+        return;
+      }
+      logger.warn(
+        {
+          rel: `${release.packageName}@${release.version}`,
+          missingBuild: err.buildId,
+        },
+        "missing Azure build reset for a fresh retry",
+      );
+    } else if ((err as NodeJS.ErrnoException).code === "ETIMEDOUT") {
       release.state = ReleaseState.Failed;
       release.reason = ReleaseErrorCode.ConnectionTimeout;
       release.signed = false;


### PR DESCRIPTION
## Summary
- detect expired or missing Azure build records without null dereferences
- reconcile exact versions already present in the registry, or reset unpublished releases for a fresh retry
- add a guarded, release-locked operator command with idempotent cleanup and complete metadata reporting
- bound registry and GitHub verification requests and cover concurrency and failure-order cases

## Validation
- npm -w @openupm/queue run lint
- npm run build -- --filter=@openupm/queue
- npm -w @openupm/queue test (19 files, 138 tests)
- npm -w @openupm/queue run queue-cli -- release-reconcile-published --help
- git diff --check
- branch review gate: clean