### PR TITLE
fix(docs): prevent package list double scrolling

### DIFF
--- a/apps/docs/__tests__/vue/breadcrumb.spec.ts
+++ b/apps/docs/__tests__/vue/breadcrumb.spec.ts
@@ -65,6 +65,17 @@ describe("site breadcrumbs", () => {
     expect(source).toContain('<SiteBreadcrumb :items="breadcrumbItems" />');
   });
 
+  it("lets the breadcrumb size itself above the package results scroller", () => {
+    const source = readFileSync(packageListLayoutPath, "utf8");
+
+    expect(source).toContain("display: flex");
+    expect(source).toContain("height: 100vh");
+    expect(source).toContain("min-height: 0");
+    expect(source).toContain(">.column {\n          height: 100%");
+    expect(source).toContain(".grid-wrapper {\n    height: 100%");
+    expect(source).not.toContain("height: calc(100vh");
+  });
+
   it("passes exact OpenUPM package detail breadcrumb items", () => {
     const source = readFileSync(packageDetailLayoutPath, "utf8");
 

--- a/apps/docs/__tests__/vue/search.spec.ts
+++ b/apps/docs/__tests__/vue/search.spec.ts
@@ -290,4 +290,24 @@ describe("PackageListLayout search result counts", () => {
     );
     expect(source).toContain("{{ resultCount }}");
   });
+
+  it("keeps every result type inside the shared results scroller", () => {
+    const source = readFileSync(packageListLayoutPath, "utf8");
+    const gridWrapperIndex = source.indexOf('class="grid-wrapper"');
+    const packagePageResultsIndex = source.indexOf(
+      'class="package-page-results"',
+    );
+
+    expect(source).toContain(
+      "metadataEntries.length || packagePageSearchSuggestions.length",
+    );
+    expect(gridWrapperIndex).toBeGreaterThan(-1);
+    expect(packagePageResultsIndex).toBeGreaterThan(gridWrapperIndex);
+    expect(source).toContain(
+      'v-if="searchTerm && metadataEntries.length"',
+    );
+    expect(source).toContain(
+      '<Grid v-if="metadataEntries.length"',
+    );
+  });
 });

--- a/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
+++ b/apps/docs/docs/.vuepress/layouts/PackageListLayout.vue
@@ -410,31 +410,35 @@ watch(() => topicSlug.value, () => {
               </div>
               <div v-else>
                 <client-only>
-                  <section
-                    v-if="packagePageSearchSuggestions.length"
-                    class="package-page-results"
-                  >
-                    <h2>{{ $t("unitynuget-packages") }}</h2>
-                    <ul>
-                      <li
-                        v-for="suggestion in packagePageSearchSuggestions"
-                        :key="suggestion.name"
-                      >
-                        <RouterLink :to="suggestion.link">
-                          <strong>{{ suggestion.displayName }}</strong>
-                          <small>{{ suggestion.name }}</small>
-                        </RouterLink>
-                      </li>
-                    </ul>
-                  </section>
                   <div v-if="!metadataEntries.length && !packagePageSearchSuggestions.length" class="no-data">
                     {{ noDataAvailableText }}
                   </div>
-                  <div v-if="metadataEntries.length" ref="gridWrapperElement" class="grid-wrapper">
-                    <h2 v-if="searchTerm" class="package-results-heading">
+                  <div
+                    v-if="metadataEntries.length || packagePageSearchSuggestions.length"
+                    ref="gridWrapperElement"
+                    class="grid-wrapper"
+                  >
+                    <section
+                      v-if="packagePageSearchSuggestions.length"
+                      class="package-page-results"
+                    >
+                      <h2>{{ $t("unitynuget-packages") }}</h2>
+                      <ul>
+                        <li
+                          v-for="suggestion in packagePageSearchSuggestions"
+                          :key="suggestion.name"
+                        >
+                          <RouterLink :to="suggestion.link">
+                            <strong>{{ suggestion.displayName }}</strong>
+                            <small>{{ suggestion.name }}</small>
+                          </RouterLink>
+                        </li>
+                      </ul>
+                    </section>
+                    <h2 v-if="searchTerm && metadataEntries.length" class="package-results-heading">
                       {{ $t("openupm-packages") }}
                     </h2>
-                    <Grid class="grid" :length="listItems.length" :page-size="gridPageSize"
+                    <Grid v-if="metadataEntries.length" class="grid" :length="listItems.length" :page-size="gridPageSize"
                       :page-provider="gridPageProvider" :get-key="getGridKey">
                       <template #probe>
                         <!-- The virtual grid is designed to be used with a network provider.
@@ -507,12 +511,26 @@ watch(() => topicSlug.value, () => {
     }
 
     >:is(.theme-default-content, [vp-content]):not(.custom) {
-      padding: 0;
-      margin-top: $navbar-height;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      margin-top: 0;
+      padding: $navbar-height 0 0;
+
+      >.columns {
+        flex: 1;
+        min-height: 0;
+
+        >.column {
+          height: 100%;
+          min-height: 0;
+        }
+      }
 
       @media (max-width: $MQMobileNarrow) {
-        padding: 0 0.5rem;
-        margin-top: $navbar-height-mobile;
+        margin-top: 0;
+        padding: $navbar-height-mobile 0.5rem 0;
       }
     }
   }
@@ -544,6 +562,12 @@ watch(() => topicSlug.value, () => {
 @use '@/styles/palette' as *;
 
 .package-section {
+  height: 100%;
+
+  >div {
+    height: 100%;
+  }
+
   .package-results-heading,
   .package-page-results h2 {
     font-size: 1rem;
@@ -602,11 +626,10 @@ watch(() => topicSlug.value, () => {
   }
 
   .grid-wrapper {
-    height: calc(100vh - $navbar-height);
+    height: 100%;
     overflow: auto;
 
     @media (max-width: $MQMobileNarrow) {
-      height: calc(100vh - $navbar-height-mobile);
       // Hide scrollbar
       --scrollbar-width: 0;
     }


### PR DESCRIPTION
## Summary

- constrain the package-list content to the viewport and let the breadcrumb size itself naturally
- keep package cards and UnityNuGet search suggestions inside one results scroller
- prevent the navbar offset from collapsing into the document and creating an outer scrollbar
- preserve correct headings for mixed and UnityNuGet-only searches
- add regression coverage for the constrained layout and shared search-results scroller

## Root cause

The virtual package grid used a fixed viewport-derived height while the breadcrumb and a collapsing navbar margin added height outside it. Search suggestions could also render above the grid. Together these paths allowed the document and the results grid to become independently scrollable.

## Validation

- `npm test -- breadcrumb.spec.ts search.spec.ts` — 25 tests passed
- `npm run lint`
- `npm run docs:build:limit` — 629 pages rendered
- browser checks at desktop and mobile widths confirmed the document remains viewport-height while the package results area is the sole vertical scroller
- reviewed package and topic listings, a wrapping topic breadcrumb, and suggestion-only search results
- independent branch review: clean

Fixes openupm/openupm#6751