### PR TITLE
fix(data): reject missing package hunters

### DIFF
--- a/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
+++ b/packages/@openupm/local-data/__tests__/validation/data-validator.spec.ts
@@ -100,6 +100,20 @@ describe('validateDataDirectory', () => {
     }
   });
 
+  it('accepts an explicitly empty hunter for legacy data', async () => {
+    const dataDir = await createDataDir();
+    try {
+      await writePackage(dataDir, validPackage.name, {
+        ...validPackage,
+        hunter: '',
+      });
+      const result = await validateDataDirectory(dataDir);
+      expect(result).toEqual({ valid: true, issues: [] });
+    } finally {
+      await afs.rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('accepts GitHub Release tracking metadata with optional asset name', async () => {
     const dataDir = await createDataDir();
     try {
@@ -180,7 +194,7 @@ describe('validateDataDirectory', () => {
   });
 
   it('covers required package field checks from openupm data tests', async () => {
-    expect.assertions(8);
+    expect.assertions(11);
     await expectIssue(
       (dataDir) =>
         writePackage(dataDir, validPackage.name, {
@@ -237,6 +251,30 @@ describe('validateDataDirectory', () => {
           hunter: ' ',
         }),
       'package-hunter-empty',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          hunter: undefined,
+        }),
+      'package-metadata-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          hunter: false,
+        }),
+      'package-metadata-invalid',
+    );
+    await expectIssue(
+      (dataDir) =>
+        writePackage(dataDir, validPackage.name, {
+          ...validPackage,
+          hunter: 0,
+        }),
+      'package-metadata-invalid',
     );
     await expectIssue(
       (dataDir) =>

--- a/packages/@openupm/local-data/src/validation/data-validator.ts
+++ b/packages/@openupm/local-data/src/validation/data-validator.ts
@@ -90,7 +90,7 @@ function messageFromError(error: unknown): string {
 function normalizePackageForLegacyData(raw: unknown): unknown {
   if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
     const record = raw as Record<string, unknown>;
-    if (!record.hunter) record.hunter = '-';
+    if (record.hunter === '') record.hunter = '-';
   }
   return raw;
 }


### PR DESCRIPTION
## Summary

- stop synthesizing `hunter` when the key is omitted so schema validation fails during package-data CI
- retain compatibility for the actual legacy representation, `hunter: ''`
- reject other non-string falsy values such as `false` and `0`
- add regression coverage for omitted, legacy-empty, boolean, and numeric hunter values

This prevents invalid package submissions from passing data validation and later breaking the website build.

## Validation

- `npm test -- data-validator.spec.ts` in `packages/@openupm/local-data` (12 tests)
- `npm run lint` in `packages/@openupm/local-data`
- `npm run build -- --filter=@openupm/local-data`
- OpenUPM's exact `npm test` wrapper against the updated validator (20 tests)
- full VuePress website build against repaired package data (6,193 pages)
- independent branch review loop: clean